### PR TITLE
Add option to disable first-person arm sway

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -5,6 +5,7 @@ SnapTurning=false
 SnapTurnAngle=45.0
 LeftHanded=false
 HideArms=false
+DisableFirstPersonArmSway=false
 IPDScale=1.0
 HudAlwaysVisible=false
 HudSize=1.8

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -176,6 +176,8 @@ void VR::Update()
     if (!m_IsInitialized || !m_Game->m_Initialized)
         return;
 
+    ApplyFirstPersonArmSwayState();
+
     if (m_IsVREnabled && g_D3DVR9)
     {
         // Prevents crashing at menu
@@ -209,6 +211,40 @@ void VR::Update()
         ProcessMenuInput();
     else
         ProcessInput();
+}
+
+void VR::ApplyFirstPersonArmSwayState()
+{
+    if (!m_Game || !m_Game->m_EngineClient)
+        return;
+
+    if (m_DisableFirstPersonArmSway == m_CurrentArmSwayDisabled)
+        return;
+
+    struct ArmSwayCvar
+    {
+        const char* name;
+        const char* disabledValue;
+        const char* defaultValue;
+    };
+
+    static constexpr ArmSwayCvar kArmSwayCVars[] = {
+        { "cl_bobcycle", "0", "0.98" },
+        { "cl_bobamt_lat", "0", "0.33" },
+        { "cl_bobamt_vert", "0", "0.14" },
+        { "cl_bob_lower_amt", "0", "21" },
+        { "cl_viewmodel_shift_left_amt", "0", "1.5" },
+        { "cl_viewmodel_shift_right_amt", "0", "0.75" }
+    };
+
+    const bool disableSway = m_DisableFirstPersonArmSway;
+    for (const ArmSwayCvar& cvar : kArmSwayCVars)
+    {
+        std::string command = std::string(cvar.name) + " " + (disableSway ? cvar.disabledValue : cvar.defaultValue);
+        m_Game->ClientCmd_Unrestricted(command.c_str());
+    }
+
+    m_CurrentArmSwayDisabled = disableSway;
 }
 
 bool VR::GetWalkAxis(float& x, float& y) {
@@ -1553,6 +1589,7 @@ void VR::ParseConfigFile()
     m_VRScale = getFloat("VRScale", m_VRScale);
     m_IpdScale = getFloat("IPDScale", m_IpdScale);
     m_HideArms = getBool("HideArms", m_HideArms);
+    m_DisableFirstPersonArmSway = getBool("DisableFirstPersonArmSway", m_DisableFirstPersonArmSway);
     m_HudDistance = getFloat("HudDistance", m_HudDistance);
     m_HudSize = getFloat("HudSize", m_HudSize);
     m_HudAlwaysVisible = getBool("HudAlwaysVisible", m_HudAlwaysVisible);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -214,6 +214,7 @@ public:
 	float m_VRScale = 43.2;
 	float m_IpdScale = 1.0;
 	bool m_HideArms = false;
+	bool m_DisableFirstPersonArmSway = false;
 	float m_HudDistance = 1.3;
 	float m_HudSize = 1.1;
 	bool m_HudAlwaysVisible = false;
@@ -222,12 +223,14 @@ public:
 
 	bool m_ForceNonVRServerMovement = false;
 	bool m_RequireSecondaryAttackForItemSwitch = true;
+	bool m_CurrentArmSwayDisabled = false;
 
 	VR() {};
 	VR(Game* game);
 	int SetActionManifest(const char* fileName);
 	void InstallApplicationManifest(const char* fileName);
 	void Update();
+	void ApplyFirstPersonArmSwayState();
 	void CreateVRTextures();
 	void HandleMissingRenderContext(const char* location);
         void SubmitVRTextures();


### PR DESCRIPTION
## Summary
- add a `DisableFirstPersonArmSway` option that can be toggled via `VR/config.txt`
- update the VR runtime to push the appropriate console variables and keep their state in sync so arm sway can be enabled/disabled dynamically

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a6d7ab4948321937ae4dc5a13e9a4)