### PR TITLE
Fix quick turn combo input handling

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -820,7 +820,10 @@ void VR::ProcessInput()
         m_Game->ClientCmd_Unrestricted("-reload");
     }
 
-    bool secondaryAttackActive = PressedDigitalAction(m_ActionSecondaryAttack);
+    vr::InputDigitalActionData_t secondaryAttackActionData{};
+    bool secondaryAttackDataValid = GetDigitalActionData(m_ActionSecondaryAttack, secondaryAttackActionData);
+    bool secondaryAttackActive = secondaryAttackDataValid && secondaryAttackActionData.bState;
+
     if (secondaryAttackActive)
     {
         m_Game->ClientCmd_Unrestricted("+attack2");
@@ -828,6 +831,18 @@ void VR::ProcessInput()
     else
     {
         m_Game->ClientCmd_Unrestricted("-attack2");
+    }
+
+    bool quickTurnComboPressed = secondaryAttackActive && crouchButtonDown;
+    if (quickTurnComboPressed && !m_QuickTurnTriggered)
+    {
+        m_RotationOffset += 180.0f;
+        m_RotationOffset -= 360 * std::floor(m_RotationOffset / 360);
+        m_QuickTurnTriggered = true;
+    }
+    else if (!quickTurnComboPressed)
+    {
+        m_QuickTurnTriggered = false;
     }
 
     if (secondaryAttackActive || !m_RequireSecondaryAttackForItemSwitch)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -165,10 +165,11 @@ public:
 	bool m_CompositorNeedsHandoff = false;
 	TextureID m_CreatingTextureID = Texture_None;
 
-	bool m_PressedTurn = false;
-	bool m_PushingThumbstick = false;
-	bool m_CrouchToggleActive = false;
-	bool m_VoiceRecordActive = false;
+        bool m_PressedTurn = false;
+        bool m_PushingThumbstick = false;
+        bool m_CrouchToggleActive = false;
+        bool m_VoiceRecordActive = false;
+        bool m_QuickTurnTriggered = false;
 
 	// action set
 	vr::VRActionSetHandle_t m_ActionSet;


### PR DESCRIPTION
## Summary
- read secondary attack digital action data explicitly before issuing attack2 commands
- reuse the fetched state for the crouch + secondary combo quick turn to avoid undefined identifiers

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfce0c18483219219030712927871)