### PR TITLE
Enable aim line for special infected

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1350,6 +1350,20 @@ bool VR::ShouldShowAimLine(C_WeaponCSBase* weapon) const
     case C_WeaponCSBase::SCOUT:
     case C_WeaponCSBase::GRENADE_LAUNCHER:
     case C_WeaponCSBase::M60:
+    case C_WeaponCSBase::TANK_CLAW:
+    case C_WeaponCSBase::HUNTER_CLAW:
+    case C_WeaponCSBase::CHARGER_CLAW:
+    case C_WeaponCSBase::BOOMER_CLAW:
+    case C_WeaponCSBase::SMOKER_CLAW:
+    case C_WeaponCSBase::SPITTER_CLAW:
+    case C_WeaponCSBase::JOCKEY_CLAW:
+    case C_WeaponCSBase::VOMIT:
+    case C_WeaponCSBase::SPLAT:
+    case C_WeaponCSBase::POUNCE:
+    case C_WeaponCSBase::LOUNGE:
+    case C_WeaponCSBase::PULL:
+    case C_WeaponCSBase::CHOKE:
+    case C_WeaponCSBase::ROCK:
         return true;
     default:
         return false;


### PR DESCRIPTION
## Summary
- allow the VR aim line overlay to render for special infected by including their weapon and ability IDs

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c31f788bc8321b8ab9041ee9d8d4c)