### PR TITLE
Expose throw arc landing offset configuration

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -16,6 +16,7 @@ AimLineEnabled=true
 AimLineThickness=0.3
 AimLineFrameDurationMultiplier=1.5
 AimLineColor=255,0,0,180
+// 投掷轨迹落点高度偏移（单位：Hammer 单位；负数让落点更贴地，正数抬高落点）
 ThrowArcBaseDistance=600
 ThrowArcMinDistance=150
 ThrowArcMaxDistance=1200

--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -21,3 +21,4 @@ ThrowArcMinDistance=150
 ThrowArcMaxDistance=1200
 ThrowArcHeightRatio=0.25
 ThrowArcPitchScale=1.0
+ThrowArcLandingOffset=0.0

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1459,6 +1459,7 @@ void VR::DrawThrowArc(const Vector& origin, const Vector& forward)
     const float arcHeight = std::max(distance * m_ThrowArcHeightRatio, m_ThrowArcMinDistance * 0.5f);
 
     Vector landingPoint = origin + planarForward * distance;
+    landingPoint.z += m_ThrowArcLandingOffset;
     Vector apex = origin + planarForward * distance * 0.5f;
     apex.z += arcHeight;
 
@@ -1722,6 +1723,7 @@ void VR::ParseConfigFile()
     m_ThrowArcMaxDistance = std::max(m_ThrowArcMinDistance, getFloat("ThrowArcMaxDistance", m_ThrowArcMaxDistance));
     m_ThrowArcHeightRatio = std::max(0.0f, getFloat("ThrowArcHeightRatio", m_ThrowArcHeightRatio));
     m_ThrowArcPitchScale = std::max(0.0f, getFloat("ThrowArcPitchScale", m_ThrowArcPitchScale));
+    m_ThrowArcLandingOffset = getFloat("ThrowArcLandingOffset", m_ThrowArcLandingOffset);
 }
 
 void VR::WaitForConfigUpdate()

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -133,6 +133,7 @@ public:
         float m_ThrowArcMaxDistance = 1200.0f;
         float m_ThrowArcHeightRatio = 0.25f;
         float m_ThrowArcPitchScale = 1.0f;
+        float m_ThrowArcLandingOffset = 0.0f;
         // Tracks the duration of the previous frame so the aim line can persist when the framerate dips.
         float m_LastFrameDuration = 1.0f / 90.0f;
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -279,7 +279,7 @@ public:
         void UpdateAimingLaser(C_BasePlayer* localPlayer);
         bool ShouldShowAimLine(C_WeaponCSBase* weapon) const;
         bool IsThrowableWeapon(C_WeaponCSBase* weapon) const;
-        float CalculateThrowArcDistance(const Vector& forward) const;
+        float CalculateThrowArcDistance(const Vector& forward, bool* clampedToMax = nullptr) const;
         void DrawAimLine(const Vector& start, const Vector& end);
         void DrawThrowArc(const Vector& origin, const Vector& forward);
         void DrawThrowArcFromCache(float duration);

--- a/README.md
+++ b/README.md
@@ -22,8 +22,15 @@
    ``` -insecure -window -novid +mat_motion_blur_percent_of_screen_max 0 +crosshair 0 -w 1280 -h 720 +mat_queue_mode 0 +mat_vsync 0 +mat_antialias 0 +mat_grain_scale_override 0 ```
 
 3. At the menu, feel free to change [these video settings](https://i.imgur.com/yYQMXs6.jpg).
-4. Load into a campaign. 
+4. Load into a campaign.
 5. To recenter the camera height, press down on the left stick. To see the HUD, aim the controller up or down.
+
+### 投掷轨迹校准（ThrowArcLandingOffset）
+* 配置文件路径：`VR\\config.txt`。
+* 参数含义：`ThrowArcLandingOffset` 用来微调抛物线落点的高度，单位是 Hammer 游戏单位。
+  * 取 **负值**（如 `-10` 或 `-20`）可以让落点更贴近地面，用于修正落点悬空的问题。
+  * 取 **正值** 会抬高落点，用于避免地形抬升导致的穿地显示。
+* 修改后保存文件即可，游戏会在检测到配置更新时自动重新读取。
 
 ## How to play multiplayer
 * The host must have the mod installed and the server must be set to local. Other players can play in VR too (if they also installed the mod).


### PR DESCRIPTION
## Summary
- allow configuring a landing height offset for the throw arc so the end point can be adjusted
- document the new ThrowArcLandingOffset option in the sample config

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c518e67e08321bb0ce49879c83aae)