### PR TITLE
Hardcode throw arc parameters

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -16,10 +16,3 @@ AimLineEnabled=true
 AimLineThickness=0.3
 AimLineFrameDurationMultiplier=1.5
 AimLineColor=255,0,0,180
-// 投掷轨迹落点高度偏移（单位：Hammer 单位；负数让落点更贴地，正数抬高落点）
-ThrowArcBaseDistance=600
-ThrowArcMinDistance=150
-ThrowArcMaxDistance=1200
-ThrowArcHeightRatio=0.25
-ThrowArcPitchScale=1.0
-ThrowArcLandingOffset=0.0

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1729,12 +1729,6 @@ void VR::ParseConfigFile()
     m_AimLineFrameDurationMultiplier = std::max(0.0f, getFloat("AimLineFrameDurationMultiplier", m_AimLineFrameDurationMultiplier));
     m_ForceNonVRServerMovement = getBool("ForceNonVRServerMovement", m_ForceNonVRServerMovement);
     m_RequireSecondaryAttackForItemSwitch = getBool("RequireSecondaryAttackForItemSwitch", m_RequireSecondaryAttackForItemSwitch);
-    m_ThrowArcBaseDistance = std::max(0.0f, getFloat("ThrowArcBaseDistance", m_ThrowArcBaseDistance));
-    m_ThrowArcMinDistance = std::max(0.0f, getFloat("ThrowArcMinDistance", m_ThrowArcMinDistance));
-    m_ThrowArcMaxDistance = std::max(m_ThrowArcMinDistance, getFloat("ThrowArcMaxDistance", m_ThrowArcMaxDistance));
-    m_ThrowArcHeightRatio = std::max(0.0f, getFloat("ThrowArcHeightRatio", m_ThrowArcHeightRatio));
-    m_ThrowArcPitchScale = std::max(0.0f, getFloat("ThrowArcPitchScale", m_ThrowArcPitchScale));
-    m_ThrowArcLandingOffset = getFloat("ThrowArcLandingOffset", m_ThrowArcLandingOffset);
 }
 
 void VR::WaitForConfigUpdate()

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -128,12 +128,12 @@ public:
         std::array<Vector, THROW_ARC_SEGMENTS + 1> m_LastThrowArcPoints{};
         bool m_HasThrowArc = false;
         bool m_LastAimWasThrowable = false;
-        float m_ThrowArcBaseDistance = 600.0f;
-        float m_ThrowArcMinDistance = 150.0f;
-        float m_ThrowArcMaxDistance = 1200.0f;
+        float m_ThrowArcBaseDistance = 500.0f;
+        float m_ThrowArcMinDistance = 20.0f;
+        float m_ThrowArcMaxDistance = 2200.0f;
         float m_ThrowArcHeightRatio = 0.25f;
-        float m_ThrowArcPitchScale = 1.0f;
-        float m_ThrowArcLandingOffset = 0.0f;
+        float m_ThrowArcPitchScale = 6.0f;
+        float m_ThrowArcLandingOffset = -90.0f;
         // Tracks the duration of the previous frame so the aim line can persist when the framerate dips.
         float m_LastFrameDuration = 1.0f / 90.0f;
 


### PR DESCRIPTION
## Summary
- hardcode the tuned throw arc parameters directly in VR defaults
- stop reading throw arc settings from the config file and drop the sample entries

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c5fb64754832189ed8f5a7bbbae49)