### PR TITLE
Include Windows.h for VR header

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <Windows.h>
+
 #include "openvr.h"
 #include "vector.h"
 #include <array>


### PR DESCRIPTION
## Summary
- add Windows header inclusion to vr.h so WORD is defined for SendFunctionKey declaration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d69c6563c8321b4630d195c69e1c1)