### PR TITLE
Add lateral controller HUD offset and five-way bottom overlay

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -12,6 +12,11 @@ HudSize=1.8
 ControllerHudSize=0.5
 ControllerHudYOffset=0.12
 ControllerHudZOffset=0.0
+# ControllerHudRotation 单位是“度”，可以填任意正负角度（例如 15、45、90）。
+# 值越大 HUD 越朝你抬头；也可以填入大于 360 的值来绕圈调试。
+ControllerHudRotation=0.0
+# ControllerHudXOffset 控制左右分离/靠拢的距离；正值让左右 HUD 向外分开，负值让它们更靠近中线。
+ControllerHudXOffset=0.0
 ControllerSmoothing=0
 ForceNonVRServerMovement=false
 RequireSecondaryAttackForItemSwitch=true

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -87,8 +87,8 @@ VR::VR(Game* game)
     m_Overlay->CreateOverlay("MenuOverlayKey", "MenuOverlay", &m_MainMenuHandle);
     m_Overlay->CreateOverlay("HUDOverlayTopKey", "HUDOverlayTop", &m_HUDTopHandle);
 
-    const char* bottomOverlayKeys[4] = { "HUDOverlayBottom1", "HUDOverlayBottom2", "HUDOverlayBottom3", "HUDOverlayBottom4" };
-    for (int i = 0; i < 4; ++i)
+    const char* bottomOverlayKeys[5] = { "HUDOverlayBottom1", "HUDOverlayBottom2", "HUDOverlayBottom3", "HUDOverlayBottom4", "HUDOverlayBottom5" };
+    for (int i = 0; i < 5; ++i)
     {
         m_Overlay->CreateOverlay(bottomOverlayKeys[i], bottomOverlayKeys[i], &m_HUDBottomHandles[i]);
     }
@@ -315,11 +315,12 @@ void VR::SubmitVRTextures()
         };
 
     const vr::VRTextureBounds_t topBounds{ 0.0f, 0.0f, 1.0f, 0.5f };
-    const std::array<vr::VRTextureBounds_t, 4> bottomBounds{
-        vr::VRTextureBounds_t{ 0.0f, 0.5f, 0.25f, 1.0f },
-        vr::VRTextureBounds_t{ 0.25f, 0.5f, 0.5f, 1.0f },
-        vr::VRTextureBounds_t{ 0.5f, 0.5f, 0.75f, 1.0f },
-        vr::VRTextureBounds_t{ 0.75f, 0.5f, 1.0f, 1.0f }
+    const std::array<vr::VRTextureBounds_t, 5> bottomBounds{
+        vr::VRTextureBounds_t{ 0.0f, 0.5f, 0.2f, 1.0f },
+        vr::VRTextureBounds_t{ 0.2f, 0.5f, 0.4f, 1.0f },
+        vr::VRTextureBounds_t{ 0.4f, 0.5f, 0.6f, 1.0f },
+        vr::VRTextureBounds_t{ 0.6f, 0.5f, 0.8f, 1.0f },
+        vr::VRTextureBounds_t{ 0.8f, 0.5f, 1.0f, 1.0f }
     };
 
     auto applyHudTexture = [&](vr::VROverlayHandle_t overlay, const vr::VRTextureBounds_t& bounds)
@@ -359,7 +360,7 @@ void VR::SubmitVRTextures()
 
     vr::VROverlay()->HideOverlay(m_MainMenuHandle);
     applyHudTexture(m_HUDTopHandle, topBounds);
-    for (int i = 0; i < 4; ++i)
+    for (int i = 0; i < 5; ++i)
     {
         applyHudTexture(m_HUDBottomHandles[i], bottomBounds[i]);
     }
@@ -370,7 +371,7 @@ void VR::SubmitVRTextures()
         {
             if (i == 0 && m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_LeftHand) == vr::k_unTrackedDeviceIndexInvalid)
                 continue;
-            if (i == 3 && m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_RightHand) == vr::k_unTrackedDeviceIndexInvalid)
+            if (i == 4 && m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_RightHand) == vr::k_unTrackedDeviceIndexInvalid)
                 continue;
 
             vr::VROverlay()->ShowOverlay(m_HUDBottomHandles[i]);
@@ -520,25 +521,32 @@ void VR::RepositionOverlays(bool attachToControllers)
     vr::VROverlay()->SetOverlayWidthInMeters(m_HUDTopHandle, m_HudSize);
 
     Vector hudRight = { cos(hmdRotationDegrees), 0.0f, -sin(hmdRotationDegrees) };
-    float segmentWidth = m_HudSize / 4.0f;
+    float segmentWidth = m_HudSize / 5.0f;
 
     for (size_t i = 0; i < m_HUDBottomHandles.size(); ++i)
     {
         vr::VROverlayHandle_t overlay = m_HUDBottomHandles[i];
 
-        // Bottom 1 & 4 attach to controllers, 2 & 3 stay fixed in front
-        if (attachToControllers && (i == 0 || i == 3))
+        // Bottom 1 & 5 attach to controllers, 2-4 stay fixed in front
+        if (attachToControllers && (i == 0 || i == 4))
         {
             vr::ETrackedControllerRole controllerRole = (i == 0) ? vr::TrackedControllerRole_LeftHand : vr::TrackedControllerRole_RightHand;
             vr::TrackedDeviceIndex_t controllerIndex = m_System->GetTrackedDeviceIndexForControllerRole(controllerRole);
 
             if (controllerIndex != vr::k_unTrackedDeviceIndexInvalid)
             {
+                // m_ControllerHudRotation is in degrees; allow any magnitude (e.g., 15, 90, 360+) for easier tuning.
+                const float controllerHudRotationRad = m_ControllerHudRotation * (3.14159265358979323846f / 180.0f);
+                const float cosRotation = cosf(controllerHudRotationRad);
+                const float sinRotation = sinf(controllerHudRotationRad);
+
+                const float controllerHudXOffset = (i == 0) ? -m_ControllerHudXOffset : m_ControllerHudXOffset;
+
                 vr::HmdMatrix34_t relativeTransform =
                 {
-                    1.0f, 0.0f, 0.0f, 0.0f,
-                    0.0f, 1.0f, 0.0f, m_ControllerHudYOffset - hudHalfStackOffset,
-                    0.0f, 0.0f, 1.0f, m_ControllerHudZOffset
+                    1.0f, 0.0f, 0.0f, controllerHudXOffset,
+                    0.0f, cosRotation, -sinRotation, m_ControllerHudYOffset - hudHalfStackOffset,
+                    0.0f, sinRotation,  cosRotation, m_ControllerHudZOffset
                 };
 
                 vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(overlay, controllerIndex, &relativeTransform);
@@ -551,7 +559,7 @@ void VR::RepositionOverlays(bool attachToControllers)
         }
         else
         {
-            Vector offset = hudRight * ((static_cast<float>(i) - 1.5f) * segmentWidth);
+            Vector offset = hudRight * ((static_cast<float>(i) - 2.0f) * segmentWidth);
             Vector segmentPos = hudCenterPos + offset;
             segmentPos.y -= hudHalfStackOffset;
             vr::HmdMatrix34_t segmentTransform = buildFacingTransform(segmentPos);
@@ -1899,6 +1907,8 @@ void VR::ParseConfigFile()
     m_ControllerHudSize = getFloat("ControllerHudSize", m_ControllerHudSize);
     m_ControllerHudYOffset = getFloat("ControllerHudYOffset", m_ControllerHudYOffset);
     m_ControllerHudZOffset = getFloat("ControllerHudZOffset", m_ControllerHudZOffset);
+    m_ControllerHudRotation = getFloat("ControllerHudRotation", m_ControllerHudRotation);
+    m_ControllerHudXOffset = getFloat("ControllerHudXOffset", m_ControllerHudXOffset);
     m_HudAlwaysVisible = getBool("HudAlwaysVisible", m_HudAlwaysVisible);
     float controllerSmoothingValue = m_ControllerSmoothing;
     if (userConfig.find("ControllerSmoothing") != userConfig.end())

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -44,7 +44,7 @@ public:
 
         vr::VROverlayHandle_t m_MainMenuHandle;
         vr::VROverlayHandle_t m_HUDTopHandle;
-        std::array<vr::VROverlayHandle_t, 4> m_HUDBottomHandles{};
+        std::array<vr::VROverlayHandle_t, 5> m_HUDBottomHandles{};
 
 	float m_HorizontalOffsetLeft;
 	float m_VerticalOffsetLeft;
@@ -234,6 +234,8 @@ public:
         float m_ControllerHudSize = 0.5f;
         float m_ControllerHudYOffset = 0.12f;
         float m_ControllerHudZOffset = 0.0f;
+        float m_ControllerHudRotation = 0.0f;
+        float m_ControllerHudXOffset = 0.0f;
         bool m_HudAlwaysVisible = false;
         float m_ControllerSmoothing = 0.0f;
         bool m_ControllerSmoothingInitialized = false;


### PR DESCRIPTION
## Summary
- add a ControllerHudXOffset setting to let left/right controller HUD pieces move outward or inward independently
- split the bottom HUD into five segments and attach the first and last to the left and right controllers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693028b15c1883218eedee8178e4f4a1)