### PR TITLE
Split bottom HUD overlays into four segments

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -87,8 +87,8 @@ VR::VR(Game* game)
     m_Overlay->CreateOverlay("MenuOverlayKey", "MenuOverlay", &m_MainMenuHandle);
     m_Overlay->CreateOverlay("HUDOverlayTopKey", "HUDOverlayTop", &m_HUDTopHandle);
 
-    const char* bottomOverlayKeys[5] = { "HUDOverlayBottom1", "HUDOverlayBottom2", "HUDOverlayBottom3", "HUDOverlayBottom4", "HUDOverlayBottom5" };
-    for (int i = 0; i < 5; ++i)
+    const char* bottomOverlayKeys[4] = { "HUDOverlayBottom1", "HUDOverlayBottom2", "HUDOverlayBottom3", "HUDOverlayBottom4" };
+    for (int i = 0; i < 4; ++i)
     {
         m_Overlay->CreateOverlay(bottomOverlayKeys[i], bottomOverlayKeys[i], &m_HUDBottomHandles[i]);
     }
@@ -315,12 +315,11 @@ void VR::SubmitVRTextures()
         };
 
     const vr::VRTextureBounds_t topBounds{ 0.0f, 0.0f, 1.0f, 0.5f };
-    const std::array<vr::VRTextureBounds_t, 5> bottomBounds{
-        vr::VRTextureBounds_t{ 0.0f, 0.5f, 0.2f, 1.0f },
-        vr::VRTextureBounds_t{ 0.2f, 0.5f, 0.4f, 1.0f },
-        vr::VRTextureBounds_t{ 0.4f, 0.5f, 0.6f, 1.0f },
-        vr::VRTextureBounds_t{ 0.6f, 0.5f, 0.8f, 1.0f },
-        vr::VRTextureBounds_t{ 0.8f, 0.5f, 1.0f, 1.0f }
+    const std::array<vr::VRTextureBounds_t, 4> bottomBounds{
+        vr::VRTextureBounds_t{ 0.0f, 0.5f, 0.25f, 1.0f },
+        vr::VRTextureBounds_t{ 0.25f, 0.5f, 0.5f, 1.0f },
+        vr::VRTextureBounds_t{ 0.5f, 0.5f, 0.75f, 1.0f },
+        vr::VRTextureBounds_t{ 0.75f, 0.5f, 1.0f, 1.0f }
     };
 
     auto applyHudTexture = [&](vr::VROverlayHandle_t overlay, const vr::VRTextureBounds_t& bounds)
@@ -360,7 +359,7 @@ void VR::SubmitVRTextures()
 
     vr::VROverlay()->HideOverlay(m_MainMenuHandle);
     applyHudTexture(m_HUDTopHandle, topBounds);
-    for (int i = 0; i < 5; ++i)
+    for (int i = 0; i < 4; ++i)
     {
         applyHudTexture(m_HUDBottomHandles[i], bottomBounds[i]);
     }
@@ -371,7 +370,7 @@ void VR::SubmitVRTextures()
         {
             if (i == 0 && m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_LeftHand) == vr::k_unTrackedDeviceIndexInvalid)
                 continue;
-            if (i == 4 && m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_RightHand) == vr::k_unTrackedDeviceIndexInvalid)
+            if (i == 3 && m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_RightHand) == vr::k_unTrackedDeviceIndexInvalid)
                 continue;
 
             vr::VROverlay()->ShowOverlay(m_HUDBottomHandles[i]);
@@ -521,14 +520,14 @@ void VR::RepositionOverlays(bool attachToControllers)
     vr::VROverlay()->SetOverlayWidthInMeters(m_HUDTopHandle, m_HudSize);
 
     Vector hudRight = { cos(hmdRotationDegrees), 0.0f, -sin(hmdRotationDegrees) };
-    float segmentWidth = m_HudSize / 5.0f;
+    float segmentWidth = m_HudSize / 4.0f;
 
     for (size_t i = 0; i < m_HUDBottomHandles.size(); ++i)
     {
         vr::VROverlayHandle_t overlay = m_HUDBottomHandles[i];
 
-        // Bottom 1 & 5 attach to controllers, 2-4 stay fixed in front
-        if (attachToControllers && (i == 0 || i == 4))
+        // Bottom 1 & 4 attach to controllers, 2-3 stay fixed in front
+        if (attachToControllers && (i == 0 || i == 3))
         {
             vr::ETrackedControllerRole controllerRole = (i == 0) ? vr::TrackedControllerRole_LeftHand : vr::TrackedControllerRole_RightHand;
             vr::TrackedDeviceIndex_t controllerIndex = m_System->GetTrackedDeviceIndexForControllerRole(controllerRole);
@@ -559,7 +558,8 @@ void VR::RepositionOverlays(bool attachToControllers)
         }
         else
         {
-            Vector offset = hudRight * ((static_cast<float>(i) - 2.0f) * segmentWidth);
+            const float segmentIndexOffset = static_cast<float>(i) - 1.5f;
+            Vector offset = hudRight * (segmentIndexOffset * segmentWidth);
             Vector segmentPos = hudCenterPos + offset;
             segmentPos.y -= hudHalfStackOffset;
             vr::HmdMatrix34_t segmentTransform = buildFacingTransform(segmentPos);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -44,7 +44,7 @@ public:
 
         vr::VROverlayHandle_t m_MainMenuHandle;
         vr::VROverlayHandle_t m_HUDTopHandle;
-        std::array<vr::VROverlayHandle_t, 5> m_HUDBottomHandles{};
+        std::array<vr::VROverlayHandle_t, 4> m_HUDBottomHandles{};
 
 	float m_HorizontalOffsetLeft;
 	float m_VerticalOffsetLeft;


### PR DESCRIPTION
## Summary
- change the bottom HUD overlay set to four segments with updated texture bounds
- keep the first and fourth segments attached to the left/right controllers and reposition the remaining overlays accordingly

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693030eea9bc832187c7489f36437511)