### PR TITLE
Align viewmodel translation with adjustment rotation

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -137,6 +137,9 @@ public:
         QAngle m_AdjustStartLeftAng = { 0,0,0 };
         Vector m_AdjustStartViewmodelPos = { 0,0,0 };
         QAngle m_AdjustStartViewmodelAng = { 0,0,0 };
+        Vector m_AdjustStartViewmodelForward = { 0,0,0 };
+        Vector m_AdjustStartViewmodelRight = { 0,0,0 };
+        Vector m_AdjustStartViewmodelUp = { 0,0,0 };
 
         Vector m_AimLineStart = { 0,0,0 };
         Vector m_AimLineEnd = { 0,0,0 };


### PR DESCRIPTION
## Summary
- rotate the viewmodel adjustment projection basis with ongoing angular changes so translations follow the adjusted axes
- continue projecting controller movement into viewmodel space when updating position offsets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693174022f748321ac71cec720adbc7f)