### PR TITLE
Improve viewmodel position adjustment alignment

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -131,12 +131,15 @@ public:
 	bool m_ViewmodelAdjustmentsDirty = false;
 	std::string m_ViewmodelAdjustmentSavePath;
 
-	bool m_AdjustingViewmodel = false;
-	std::string m_AdjustingKey;
-	Vector m_AdjustStartLeftPos = { 0,0,0 };
-	QAngle m_AdjustStartLeftAng = { 0,0,0 };
-	Vector m_AdjustStartViewmodelPos = { 0,0,0 };
-	QAngle m_AdjustStartViewmodelAng = { 0,0,0 };
+        bool m_AdjustingViewmodel = false;
+        std::string m_AdjustingKey;
+        Vector m_AdjustStartLeftPos = { 0,0,0 };
+        QAngle m_AdjustStartLeftAng = { 0,0,0 };
+        Vector m_AdjustStartViewmodelPos = { 0,0,0 };
+        QAngle m_AdjustStartViewmodelAng = { 0,0,0 };
+        Vector m_AdjustStartViewmodelForward = { 0,0,0 };
+        Vector m_AdjustStartViewmodelRight = { 0,0,0 };
+        Vector m_AdjustStartViewmodelUp = { 0,0,0 };
 
 	Vector m_AimLineStart = { 0,0,0 };
 	Vector m_AimLineEnd = { 0,0,0 };


### PR DESCRIPTION
## Summary
- record viewmodel basis vectors when entering adjustment to keep changes aligned
- project left-controller movement into viewmodel space before applying position offsets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693187dc35f88321afaf6036c3067b03)