### PR TITLE
Limit movement speed during viewmodel adjustment

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -277,7 +277,7 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 			const float ny = norm(ay);
 
 			// 最大移动速度：给一个安全常数；服务器会按自身规则再夹紧
-			const float maxSpeed = 250.f;
+                        const float maxSpeed = m_VR->m_AdjustingViewmodel ? 25.f : 250.f;
 
 			// 直接写 CUserCmd（服务器端对这两个字段天然支持）
 			cmd->forwardmove += ny * maxSpeed;

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1452,6 +1452,7 @@ void VR::UpdateTracking()
     wrapAngles(m_RightControllerAngSmoothed);
 
     Vector rightControllerPosSmoothed = m_RightControllerPosSmoothed;
+    Vector leftControllerPosSmoothed = m_LeftControllerPosSmoothed;
     QAngle leftControllerAngSmoothed = m_LeftControllerAngSmoothed;
     QAngle rightControllerAngSmoothed = m_RightControllerAngSmoothed;
 


### PR DESCRIPTION
## Summary
- reduce movement speed to 25 when viewmodel adjustment mode is active to keep movement constrained

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69318a4cd9ec8321b8d9f97061ade3dd)