### PR TITLE
Handle L4D1 special infected arrow colors

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -22,4 +22,15 @@ ControllerHudRotation=-60
 ControllerHudXOffset=0.1
 SpecialInfectedArrowEnabled=true
 SpecialInfectedArrowSize=24.0
+SpecialInfectedArrowHeight=72.0
+SpecialInfectedArrowThickness=0.0
+// L4D1 特感会自动跟随这些颜色设置
 SpecialInfectedArrowColor=255,64,0,255
+SpecialInfectedArrowColorBoomer=120,220,80,255
+SpecialInfectedArrowColorSmoker=180,80,255,255
+SpecialInfectedArrowColorHunter=0,170,255,255
+SpecialInfectedArrowColorSpitter=60,220,120,255
+SpecialInfectedArrowColorJockey=255,140,20,255
+SpecialInfectedArrowColorCharger=0,200,200,255
+SpecialInfectedArrowColorTank=240,40,40,255
+SpecialInfectedArrowColorWitch=255,255,255,255

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -678,9 +678,10 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 	{
 		modelName = m_Game->m_ModelInfo->GetModelName(info.pModel);
 
-		if (m_VR->IsSpecialInfectedModel(modelName))
-			m_VR->DrawSpecialInfectedArrow(info.origin);
-	}
+                const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
+                if (infectedType != VR::SpecialInfectedType::None)
+                        m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
+        }
 
 	if (info.pModel && hideArms && !m_Game->m_CachedArmsModel)
 	{

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -268,12 +268,43 @@ public:
 	bool m_ControllerSmoothingInitialized = false;
 
 	bool m_ForceNonVRServerMovement = false;
-	bool m_RequireSecondaryAttackForItemSwitch = true;
-	bool m_SpecialInfectedArrowEnabled = true;
-	float m_SpecialInfectedArrowSize = 12.0f;
-	int m_SpecialInfectedArrowColorR = 255;
-	int m_SpecialInfectedArrowColorG = 64;
-	int m_SpecialInfectedArrowColorB = 0;
+        bool m_RequireSecondaryAttackForItemSwitch = true;
+        struct RgbColor
+        {
+            int r;
+            int g;
+            int b;
+        };
+
+        enum class SpecialInfectedType
+        {
+            None = -1,
+            Boomer,
+            Smoker,
+            Hunter,
+            Spitter,
+            Jockey,
+            Charger,
+            Tank,
+            Witch,
+            Count
+        };
+
+        bool m_SpecialInfectedArrowEnabled = true;
+        float m_SpecialInfectedArrowSize = 12.0f;
+        float m_SpecialInfectedArrowHeight = 36.0f;
+        float m_SpecialInfectedArrowThickness = 0.0f;
+        RgbColor m_SpecialInfectedArrowDefaultColor{ 255, 64, 0 };
+        std::array<RgbColor, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedArrowColors{
+            RgbColor{ 120, 220, 80 },   // Boomer
+            RgbColor{ 180, 80, 255 },   // Smoker
+            RgbColor{ 0, 170, 255 },    // Hunter
+            RgbColor{ 60, 220, 120 },   // Spitter
+            RgbColor{ 255, 140, 20 },   // Jockey
+            RgbColor{ 0, 200, 200 },    // Charger
+            RgbColor{ 240, 40, 40 },    // Tank
+            RgbColor{ 255, 255, 255 }   // Witch
+        };
 
 	VR() {};
 	VR(Game* game);
@@ -331,8 +362,8 @@ public:
 	void DrawThrowArc(const Vector& origin, const Vector& forward);
 	void DrawThrowArcFromCache(float duration);
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
-	bool IsSpecialInfectedModel(const std::string& modelName) const;
-	void DrawSpecialInfectedArrow(const Vector& origin);
+    SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
+    void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
 	void FinishFrame();
 	void ConfigureExplicitTiming();
 };


### PR DESCRIPTION
## Summary
- detect L4D1 special infected model variants and map them to the existing arrow colors
- cover additional L4D1 tank aliases so Hulk-prefixed models also share the same colors

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931a1c9200c8321aa7a2ee0b958132f)