### PR TITLE
Fix client entity type usage

### DIFF
--- a/L4D2VR/game.cpp
+++ b/L4D2VR/game.cpp
@@ -182,12 +182,12 @@ void Game::ResetAllPlayerVRInfo()
 }
 
 // === Entity Access ===
-CBaseEntity* Game::GetClientEntity(int entityIndex)
+C_BaseEntity* Game::GetClientEntity(int entityIndex)
 {
     if (!m_ClientEntityList)
         return nullptr;
 
-    return static_cast<CBaseEntity*>(m_ClientEntityList->GetClientEntity(entityIndex));
+    return static_cast<C_BaseEntity*>(m_ClientEntityList->GetClientEntity(entityIndex));
 }
 
 // === Network Name Utility ===
@@ -215,7 +215,7 @@ char* Game::getNetworkName(uintptr_t* entity)
     return name;
 }
 
-std::string Game::GetClientClassName(CBaseEntity* entity) const
+std::string Game::GetClientClassName(C_BaseEntity* entity) const
 {
     if (!entity)
         return {};

--- a/L4D2VR/game.h
+++ b/L4D2VR/game.h
@@ -19,7 +19,7 @@ class IModelRender;
 class IMaterial;
 class IInput;
 class ISurface;
-class CBaseEntity;
+class C_BaseEntity;
 class C_BasePlayer;
 struct model_t;
 class IVDebugOverlay;
@@ -97,9 +97,9 @@ public:
 
     // === Interface Utilities ===
     void* GetInterface(const char* dllname, const char* interfacename);
-    CBaseEntity* GetClientEntity(int entityIndex);
+    C_BaseEntity* GetClientEntity(int entityIndex);
     char* getNetworkName(uintptr_t* entity);
-    std::string GetClientClassName(CBaseEntity* entity) const;
+    std::string GetClientClassName(C_BaseEntity* entity) const;
 
     // === Command Execution ===
     void ClientCmd(const char* szCmdString);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1900,7 +1900,7 @@ bool VR::HasBehindInfectedThreat(C_BasePlayer* localPlayer)
     const int highestIndex = m_Game->m_ClientEntityList->GetHighestEntityIndex();
     for (int i = 0; i <= highestIndex; ++i)
     {
-        auto* entity = static_cast<C_BaseEntity*>(m_Game->GetClientEntity(i));
+        auto* entity = m_Game->GetClientEntity(i);
         if (!entity || entity == localPlayer)
             continue;
 


### PR DESCRIPTION
## Summary
- align client entity accessors to use C_BaseEntity pointers
- update client class name helper to accept the corrected entity type
- simplify VR behind-threat detection to use the new helper return type

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933ad427d788321bb39632ab7181831)