### PR TITLE
Improve blind spot warning detection

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -24,6 +24,7 @@ SpecialInfectedArrowEnabled=false
 SpecialInfectedArrowSize=24.0
 SpecialInfectedArrowHeight=72.0
 SpecialInfectedArrowThickness=0.0
+SpecialInfectedBlindSpotDistance=300.0
 SpecialInfectedArrowColor=255,64,0,255
 SpecialInfectedArrowColorBoomer=120,220,80,255
 SpecialInfectedArrowColorSmoker=180,80,255,255

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -678,10 +678,13 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 	{
 		modelName = m_Game->m_ModelInfo->GetModelName(info.pModel);
 
-		const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
-		if (infectedType != VR::SpecialInfectedType::None)
-			m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
-	}
+                const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
+                if (infectedType != VR::SpecialInfectedType::None)
+                {
+                        m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
+                        m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
+                }
+        }
 
 	if (info.pModel && hideArms && !m_Game->m_CachedArmsModel)
 	{

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -263,9 +263,9 @@ public:
 	float m_ControllerHudZOffset = 0.0f;
 	float m_ControllerHudRotation = 0.0f;
 	float m_ControllerHudXOffset = 0.0f;
-	bool m_HudAlwaysVisible = false;
-	float m_ControllerSmoothing = 0.0f;
-	bool m_ControllerSmoothingInitialized = false;
+        bool m_HudAlwaysVisible = false;
+        float m_ControllerSmoothing = 0.0f;
+        bool m_ControllerSmoothingInitialized = false;
 
 	bool m_ForceNonVRServerMovement = false;
 	bool m_RequireSecondaryAttackForItemSwitch = true;
@@ -295,16 +295,23 @@ public:
 	float m_SpecialInfectedArrowHeight = 36.0f;
 	float m_SpecialInfectedArrowThickness = 0.0f;
 	RgbColor m_SpecialInfectedArrowDefaultColor{ 255, 64, 0 };
-	std::array<RgbColor, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedArrowColors{
-		RgbColor{ 120, 220, 80 },   // Boomer
-		RgbColor{ 180, 80, 255 },   // Smoker
-		RgbColor{ 0, 170, 255 },    // Hunter
-		RgbColor{ 60, 220, 120 },   // Spitter
-		RgbColor{ 255, 140, 20 },   // Jockey
-		RgbColor{ 0, 200, 200 },    // Charger
-		RgbColor{ 240, 40, 40 },    // Tank
-		RgbColor{ 255, 255, 255 }   // Witch
-	};
+        std::array<RgbColor, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedArrowColors{
+                RgbColor{ 120, 220, 80 },   // Boomer
+                RgbColor{ 180, 80, 255 },   // Smoker
+                RgbColor{ 0, 170, 255 },    // Hunter
+                RgbColor{ 60, 220, 120 },   // Spitter
+                RgbColor{ 255, 140, 20 },   // Jockey
+                RgbColor{ 0, 200, 200 },    // Charger
+                RgbColor{ 240, 40, 40 },    // Tank
+                RgbColor{ 255, 255, 255 }   // Witch
+        };
+        float m_SpecialInfectedBlindSpotDistance = 300.0f;
+        float m_SpecialInfectedBlindSpotWarningDuration = 0.5f;
+        bool m_SpecialInfectedBlindSpotWarningActive = false;
+        std::chrono::steady_clock::time_point m_LastSpecialInfectedWarningTime{};
+        int m_AimLineWarningColorR = 255;
+        int m_AimLineWarningColorG = 255;
+        int m_AimLineWarningColorB = 0;
 
 	VR() {};
 	VR(Game* game);
@@ -362,8 +369,12 @@ public:
 	void DrawThrowArc(const Vector& origin, const Vector& forward);
 	void DrawThrowArcFromCache(float duration);
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
-	SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
-	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
+        SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
+        void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
+        void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
+        bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;
+        void UpdateSpecialInfectedWarningState();
+        void GetAimLineColor(int& r, int& g, int& b, int& a) const;
 	void FinishFrame();
 	void ConfigureExplicitTiming();
 };


### PR DESCRIPTION
## Summary
- trigger blind-spot warnings for arrow-marked special infected even when the arrow overlay is disabled
- evaluate blind-spot checks on a horizontal plane to better respect the configured distance

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933bb2d41648321990ee8576fff113c)