### PR TITLE
Make special infected warning omnidirectional

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1958,11 +1958,6 @@ void VR::RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin)
 
 bool VR::IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const
 {
-    Vector forward = m_HmdForward;
-    forward.z = 0.0f;
-    if (forward.IsZero())
-        return false;
-
     Vector toInfected = infectedOrigin - m_HmdPosAbs;
     toInfected.z = 0.0f;
     if (toInfected.IsZero())
@@ -1973,14 +1968,7 @@ bool VR::IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const
         return false;
 
     const float maxDistanceSq = maxDistance * maxDistance;
-    if (toInfected.LengthSqr() > maxDistanceSq)
-        return false;
-
-    VectorNormalize(forward);
-    VectorNormalize(toInfected);
-
-    const float dot = DotProduct(forward, toInfected);
-    return dot < 0.0f;
+    return toInfected.LengthSqr() <= maxDistanceSq;
 }
 
 void VR::UpdateSpecialInfectedWarningState()


### PR DESCRIPTION
## Summary
- trigger the special infected warning based solely on distance instead of only when behind the player

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933c5e6c86483218e01a691426382ad)