### PR TITLE
Add debug logging for special infected warnings

### DIFF
--- a/L4D2VR/game.h
+++ b/L4D2VR/game.h
@@ -19,7 +19,7 @@ class IModelRender;
 class IMaterial;
 class IInput;
 class ISurface;
-class CBaseEntity;
+class C_BaseEntity;
 class C_BasePlayer;
 struct model_t;
 class IVDebugOverlay;
@@ -97,8 +97,9 @@ public:
 
     // === Interface Utilities ===
     void* GetInterface(const char* dllname, const char* interfacename);
-    CBaseEntity* GetClientEntity(int entityIndex);
+    C_BaseEntity* GetClientEntity(int entityIndex);
     char* getNetworkName(uintptr_t* entity);
+    const char* GetNetworkClassName(void* entity) const;
 
     // === Command Execution ===
     void ClientCmd(const char* szCmdString);

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -678,13 +678,15 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 	{
 		modelName = m_Game->m_ModelInfo->GetModelName(info.pModel);
 
-                const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
-                if (infectedType != VR::SpecialInfectedType::None)
-                {
-                        m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
-                        m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
-                }
-        }
+		const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
+		if (infectedType != VR::SpecialInfectedType::None)
+		{
+			float distanceSqr = -1.0f;
+			const bool isInBlindSpot = m_VR->IsSpecialInfectedInBlindSpot(info.origin, &distanceSqr);
+			m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin, isInBlindSpot, distanceSqr);
+			m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
+		}
+	}
 
 	if (info.pModel && hideArms && !m_Game->m_CachedArmsModel)
 	{

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -228,6 +228,7 @@ void VR::Update()
     }
 
     UpdateTracking();
+    ScanSpecialInfectedEntities();
 
 
     if (m_Game->m_VguiSurface->IsCursorVisible())
@@ -1944,31 +1945,146 @@ void VR::DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type
     drawArrowLine(base + Vector(0.0f, -wingLength, 0.0f), tip);
 }
 
-void VR::RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin)
+void VR::ScanSpecialInfectedEntities()
+{
+    struct ScanDebug
+    {
+        bool enabled = false;
+        int highestIndex = -1;
+        int totalEntities = 0;
+        int nullEntities = 0;
+        int missingClassName = 0;
+        int specialInfected = 0;
+        int blindSpotCandidates = 0;
+        int warningsActivated = 0;
+        int arrowsDrawn = 0;
+        float lastDistance = -1.0f;
+    } debug;
+
+    debug.enabled = m_SpecialInfectedWarningDebugLog;
+
+    if (!m_Game || !m_Game->m_ClientEntityList || !m_Game->m_ModelInfo || !m_Game->m_EngineClient)
+    {
+        if (debug.enabled)
+            Game::logMsg("[S.I.Warn] Scan skipped: missing interfaces (game=%p, list=%p, modelInfo=%p, engine=%p)", m_Game, m_Game ? m_Game->m_ClientEntityList : nullptr, m_Game ? m_Game->m_ModelInfo : nullptr, m_Game ? m_Game->m_EngineClient : nullptr);
+        return;
+    }
+
+    if (!m_Game->m_EngineClient->IsInGame())
+    {
+        if (debug.enabled)
+            Game::logMsg("[S.I.Warn] Scan skipped: not in game");
+        return;
+    }
+
+    const int highestIndex = m_Game->m_ClientEntityList->GetHighestEntityIndex();
+    debug.highestIndex = highestIndex;
+    for (int entityIndex = 0; entityIndex <= highestIndex; ++entityIndex)
+    {
+        ++debug.totalEntities;
+
+        C_BaseEntity* entity = m_Game->GetClientEntity(entityIndex);
+        if (!entity)
+        {
+            ++debug.nullEntities;
+            continue;
+        }
+
+        const char* className = m_Game->GetNetworkClassName(entity);
+        if (!className)
+        {
+            ++debug.missingClassName;
+            continue;
+        }
+
+        const auto infectedType = GetSpecialInfectedType(className);
+        if (infectedType == SpecialInfectedType::None)
+            continue;
+
+        ++debug.specialInfected;
+
+        const Vector& origin = entity->GetAbsOrigin();
+        float distanceSqr = -1.0f;
+        const bool isInBlindSpot = IsSpecialInfectedInBlindSpot(origin, &distanceSqr);
+        if (isInBlindSpot)
+            ++debug.blindSpotCandidates;
+        if (distanceSqr >= 0.0f)
+            debug.lastDistance = std::sqrt(distanceSqr);
+
+        if (RefreshSpecialInfectedBlindSpotWarning(origin, isInBlindSpot, distanceSqr))
+            ++debug.warningsActivated;
+
+        const bool arrowWouldDraw = m_SpecialInfectedArrowEnabled && m_SpecialInfectedArrowSize > 0.0f && infectedType != SpecialInfectedType::None && m_Game && m_Game->m_DebugOverlay;
+        if (arrowWouldDraw)
+            ++debug.arrowsDrawn;
+        DrawSpecialInfectedArrow(origin, infectedType);
+    }
+
+    if (debug.enabled)
+    {
+        Game::logMsg("[S.I.Warn] Scan frame: highest=%d total=%d null=%d noClass=%d special=%d blindSpot=%d activated=%d arrows=%d lastDist=%.1f", debug.highestIndex, debug.totalEntities, debug.nullEntities, debug.missingClassName, debug.specialInfected, debug.blindSpotCandidates, debug.warningsActivated, debug.arrowsDrawn, debug.lastDistance);
+    }
+}
+
+bool VR::RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin, bool isInBlindSpot, float distanceSqr)
 {
     if (m_SpecialInfectedBlindSpotDistance <= 0.0f)
-        return;
+    {
+        if (m_SpecialInfectedWarningDebugLog)
+            Game::logMsg("[S.I.Warn] Blind-spot disabled (distance=%.2f)", m_SpecialInfectedBlindSpotDistance);
+        return false;
+    }
 
-    if (!IsSpecialInfectedInBlindSpot(infectedOrigin))
-        return;
+    float computedDistanceSqr = distanceSqr;
+    if (computedDistanceSqr < 0.0f)
+    {
+        isInBlindSpot = IsSpecialInfectedInBlindSpot(infectedOrigin, &computedDistanceSqr);
+    }
+
+    if (!isInBlindSpot)
+    {
+        if (m_SpecialInfectedWarningDebugLog && computedDistanceSqr >= 0.0f)
+            Game::logMsg("[S.I.Warn] Outside blind-spot (dist=%.1f, max=%.1f)", std::sqrt(computedDistanceSqr), m_SpecialInfectedBlindSpotDistance);
+        return false;
+    }
 
     m_SpecialInfectedBlindSpotWarningActive = true;
     m_LastSpecialInfectedWarningTime = std::chrono::steady_clock::now();
+
+    if (m_SpecialInfectedWarningDebugLog)
+    {
+        const float distance = computedDistanceSqr >= 0.0f ? std::sqrt(computedDistanceSqr) : -1.0f;
+        Game::logMsg("[S.I.Warn] Warning activated (dist=%.1f, threshold=%.1f)", distance, m_SpecialInfectedBlindSpotDistance);
+    }
+
+    return true;
 }
 
-bool VR::IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const
+bool VR::IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin, float* distanceSqrOut) const
 {
     Vector toInfected = infectedOrigin - m_HmdPosAbs;
     toInfected.z = 0.0f;
     if (toInfected.IsZero())
+    {
+        if (distanceSqrOut)
+            *distanceSqrOut = 0.0f;
         return false;
+    }
 
     const float maxDistance = m_SpecialInfectedBlindSpotDistance;
     if (maxDistance <= 0.0f)
+    {
+        if (distanceSqrOut)
+            *distanceSqrOut = 0.0f;
         return false;
+    }
+
+    const float distanceSqr = toInfected.LengthSqr();
+    if (distanceSqrOut)
+        *distanceSqrOut = distanceSqr;
 
     const float maxDistanceSq = maxDistance * maxDistance;
-    return toInfected.LengthSqr() <= maxDistanceSq;
+    return distanceSqr <= maxDistanceSq;
 }
 
 void VR::UpdateSpecialInfectedWarningState()
@@ -2379,13 +2495,14 @@ void VR::ParseConfigFile()
     m_AimLineColorA = aimColor[3];
     m_AimLinePersistence = std::max(0.0f, getFloat("AimLinePersistence", m_AimLinePersistence));
     m_AimLineFrameDurationMultiplier = std::max(0.0f, getFloat("AimLineFrameDurationMultiplier", m_AimLineFrameDurationMultiplier));
-    m_ForceNonVRServerMovement = getBool("ForceNonVRServerMovement", m_ForceNonVRServerMovement);
-    m_RequireSecondaryAttackForItemSwitch = getBool("RequireSecondaryAttackForItemSwitch", m_RequireSecondaryAttackForItemSwitch);
-    m_SpecialInfectedArrowEnabled = getBool("SpecialInfectedArrowEnabled", m_SpecialInfectedArrowEnabled);
-    m_SpecialInfectedArrowSize = std::max(0.0f, getFloat("SpecialInfectedArrowSize", m_SpecialInfectedArrowSize));
-    m_SpecialInfectedArrowHeight = std::max(0.0f, getFloat("SpecialInfectedArrowHeight", m_SpecialInfectedArrowHeight));
-    m_SpecialInfectedArrowThickness = std::max(0.0f, getFloat("SpecialInfectedArrowThickness", m_SpecialInfectedArrowThickness));
-    m_SpecialInfectedBlindSpotDistance = std::max(0.0f, getFloat("SpecialInfectedBlindSpotDistance", m_SpecialInfectedBlindSpotDistance));
+	m_ForceNonVRServerMovement = getBool("ForceNonVRServerMovement", m_ForceNonVRServerMovement);
+	m_RequireSecondaryAttackForItemSwitch = getBool("RequireSecondaryAttackForItemSwitch", m_RequireSecondaryAttackForItemSwitch);
+	m_SpecialInfectedArrowEnabled = getBool("SpecialInfectedArrowEnabled", m_SpecialInfectedArrowEnabled);
+	m_SpecialInfectedArrowSize = std::max(0.0f, getFloat("SpecialInfectedArrowSize", m_SpecialInfectedArrowSize));
+	m_SpecialInfectedArrowHeight = std::max(0.0f, getFloat("SpecialInfectedArrowHeight", m_SpecialInfectedArrowHeight));
+	m_SpecialInfectedArrowThickness = std::max(0.0f, getFloat("SpecialInfectedArrowThickness", m_SpecialInfectedArrowThickness));
+	m_SpecialInfectedWarningDebugLog = getBool("SpecialInfectedWarningDebugLog", m_SpecialInfectedWarningDebugLog);
+	m_SpecialInfectedBlindSpotDistance = std::max(0.0f, getFloat("SpecialInfectedBlindSpotDistance", m_SpecialInfectedBlindSpotDistance));
     auto specialInfectedArrowColor = getColor("SpecialInfectedArrowColor", m_SpecialInfectedArrowDefaultColor.r, m_SpecialInfectedArrowDefaultColor.g, m_SpecialInfectedArrowDefaultColor.b, 255);
     const bool hasGlobalArrowColor = userConfig.find("SpecialInfectedArrowColor") != userConfig.end();
     m_SpecialInfectedArrowDefaultColor.r = specialInfectedArrowColor[0];

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -295,23 +295,24 @@ public:
 	float m_SpecialInfectedArrowHeight = 36.0f;
 	float m_SpecialInfectedArrowThickness = 0.0f;
 	RgbColor m_SpecialInfectedArrowDefaultColor{ 255, 64, 0 };
-        std::array<RgbColor, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedArrowColors{
-                RgbColor{ 120, 220, 80 },   // Boomer
-                RgbColor{ 180, 80, 255 },   // Smoker
-                RgbColor{ 0, 170, 255 },    // Hunter
-                RgbColor{ 60, 220, 120 },   // Spitter
-                RgbColor{ 255, 140, 20 },   // Jockey
-                RgbColor{ 0, 200, 200 },    // Charger
-                RgbColor{ 240, 40, 40 },    // Tank
-                RgbColor{ 255, 255, 255 }   // Witch
-        };
-        float m_SpecialInfectedBlindSpotDistance = 300.0f;
-        float m_SpecialInfectedBlindSpotWarningDuration = 0.5f;
-        bool m_SpecialInfectedBlindSpotWarningActive = false;
-        std::chrono::steady_clock::time_point m_LastSpecialInfectedWarningTime{};
-        int m_AimLineWarningColorR = 255;
-        int m_AimLineWarningColorG = 255;
-        int m_AimLineWarningColorB = 0;
+	bool m_SpecialInfectedWarningDebugLog = false;
+	std::array<RgbColor, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedArrowColors{
+		RgbColor{ 120, 220, 80 },   // Boomer
+		RgbColor{ 180, 80, 255 },   // Smoker
+		RgbColor{ 0, 170, 255 },    // Hunter
+		RgbColor{ 60, 220, 120 },   // Spitter
+		RgbColor{ 255, 140, 20 },   // Jockey
+		RgbColor{ 0, 200, 200 },    // Charger
+		RgbColor{ 240, 40, 40 },    // Tank
+		RgbColor{ 255, 255, 255 }   // Witch
+	};
+	float m_SpecialInfectedBlindSpotDistance = 300.0f;
+	float m_SpecialInfectedBlindSpotWarningDuration = 0.5f;
+	bool m_SpecialInfectedBlindSpotWarningActive = false;
+	std::chrono::steady_clock::time_point m_LastSpecialInfectedWarningTime{};
+	int m_AimLineWarningColorR = 255;
+	int m_AimLineWarningColorG = 255;
+	int m_AimLineWarningColorB = 0;
 
 	VR() {};
 	VR(Game* game);
@@ -369,12 +370,13 @@ public:
 	void DrawThrowArc(const Vector& origin, const Vector& forward);
 	void DrawThrowArcFromCache(float duration);
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
-        SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
-        void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
-        void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
-        bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;
-        void UpdateSpecialInfectedWarningState();
-        void GetAimLineColor(int& r, int& g, int& b, int& a) const;
+	SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
+	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
+	void ScanSpecialInfectedEntities();
+	bool RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin, bool isInBlindSpot, float distanceSqr);
+	bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin, float* distanceSqrOut = nullptr) const;
+	void UpdateSpecialInfectedWarningState();
+	void GetAimLineColor(int& r, int& g, int& b, int& a) const;
 	void FinishFrame();
 	void ConfigureExplicitTiming();
 };


### PR DESCRIPTION
## Summary
- add a configurable debug log for special infected scans and blind-spot checks
- include distance-aware warning activation logic shared between scans and render hook
- keep configuration aligned with new logging flag

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933f99f59fc832197e463c50f2ebd04)