### PR TITLE
React to special infected warning with evasive move

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -308,6 +308,7 @@ public:
         float m_SpecialInfectedBlindSpotDistance = 300.0f;
         float m_SpecialInfectedBlindSpotWarningDuration = 0.5f;
         bool m_SpecialInfectedBlindSpotWarningActive = false;
+        bool m_SpecialInfectedWarningActionQueued = false;
         std::chrono::steady_clock::time_point m_LastSpecialInfectedWarningTime{};
         int m_AimLineWarningColorR = 255;
         int m_AimLineWarningColorG = 255;
@@ -373,6 +374,7 @@ public:
         void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
         void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
         bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;
+        void PerformSpecialInfectedWarningReaction();
         void UpdateSpecialInfectedWarningState();
         void GetAimLineColor(int& r, int& g, int& b, int& a) const;
 	void FinishFrame();


### PR DESCRIPTION
## Summary
- trigger a one-time secondary attack and backward jump when the special infected blind spot warning activates
- queue the reaction only on new warning activations and clear it once processed or expired

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934d55bb8348321b4ff2e5167c40792)