### PR TITLE
Adjust motion gesture directions

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -281,6 +281,7 @@ public:
         float m_MotionGestureSwingThreshold = 1.1f;
         float m_MotionGestureDownSwingThreshold = 1.0f;
         float m_MotionGestureJumpThreshold = 1.0f;
+        float m_MotionGestureCrouchThreshold = 1.0f;
         float m_MotionGestureCooldown = 0.8f;
         float m_MotionGestureHoldDuration = 0.2f;
         bool m_MotionGestureInitialized = false;
@@ -291,9 +292,11 @@ public:
         std::chrono::steady_clock::time_point m_SecondaryAttackGestureHoldUntil{};
         std::chrono::steady_clock::time_point m_ReloadGestureHoldUntil{};
         std::chrono::steady_clock::time_point m_JumpGestureHoldUntil{};
+        std::chrono::steady_clock::time_point m_CrouchGestureHoldUntil{};
         std::chrono::steady_clock::time_point m_SecondaryGestureCooldownEnd{};
         std::chrono::steady_clock::time_point m_ReloadGestureCooldownEnd{};
         std::chrono::steady_clock::time_point m_JumpGestureCooldownEnd{};
+        std::chrono::steady_clock::time_point m_CrouchGestureCooldownEnd{};
 
 	bool m_ForceNonVRServerMovement = false;
 	bool m_RequireSecondaryAttackForItemSwitch = true;


### PR DESCRIPTION
## Summary
- require left controller outward motion for the secondary attack gesture
- keep reload on a downward right-hand swing and move jump to an upward right-hand swing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a9a5dcc188321a70274bc322b2e2a)