### PR TITLE
Add manual reload viewmodel hide option

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -33,3 +33,16 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 # Any combo can be disabled by setting it to "false".
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
+
+# Manual reload tuning
+ManualReloadEnabled=true
+# Hide first-person reload animation during manual reload (viewmodel not drawn while active)
+ManualReloadHideAnimation=false
+ManualReloadGunForwardOffset=0.05
+ManualReloadPouchSideOffset=0.18
+ManualReloadPouchVerticalOffset=-0.35
+ManualReloadGrabRadius=0.12
+ManualReloadRemoveDistance=0.25
+ManualReloadPouchRadius=0.18
+ManualReloadInsertRadius=0.14
+ManualReloadBoltDistance=0.16

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -667,10 +667,11 @@ Vector* Hooks::dEyePosition(void* ecx, void* edx, Vector* eyePos)
 
 void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRenderInfo_t& info, void* pCustomBoneToWorld)
 {
-	if (m_Game->m_SwitchedWeapons)
-		m_Game->m_CachedArmsModel = false;
+    if (m_Game->m_SwitchedWeapons)
+        m_Game->m_CachedArmsModel = false;
 
-	bool hideArms = m_Game->m_IsMeleeWeaponActive || m_VR->m_HideArms;
+    const bool hideViewmodel = m_VR->m_ManualReloadHidingViewmodel;
+    bool hideArms = m_Game->m_IsMeleeWeaponActive || m_VR->m_HideArms || hideViewmodel;
 
 	std::string modelName;
 	if (info.pModel)
@@ -685,15 +686,36 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		}
 	}
 
-	if (info.pModel && hideArms && !m_Game->m_CachedArmsModel)
-	{
-		if (modelName.find("/arms/") != std::string::npos)
-		{
-			m_Game->m_ArmsMaterial = m_Game->m_MaterialSystem->FindMaterial(modelName.c_str(), "Model textures");
-			m_Game->m_ArmsModel = info.pModel;
-			m_Game->m_CachedArmsModel = true;
-		}
-	}
+    if (info.pModel && hideArms && !m_Game->m_CachedArmsModel)
+    {
+        if (modelName.find("/arms/") != std::string::npos)
+        {
+            m_Game->m_ArmsMaterial = m_Game->m_MaterialSystem->FindMaterial(modelName.c_str(), "Model textures");
+            m_Game->m_ArmsModel = info.pModel;
+            m_Game->m_CachedArmsModel = true;
+        }
+    }
+
+    if (info.pModel && hideViewmodel)
+    {
+        if (modelName.empty())
+        {
+            modelName = m_Game->m_ModelInfo->GetModelName(info.pModel);
+        }
+
+        if (modelName.find("/v_") != std::string::npos)
+        {
+            IMaterial* viewmodelMaterial = m_Game->m_MaterialSystem->FindMaterial(modelName.c_str(), "Model textures");
+            if (viewmodelMaterial)
+            {
+                viewmodelMaterial->SetMaterialVarFlag(MATERIAL_VAR_NO_DRAW, true);
+                m_Game->m_ModelRender->ForcedMaterialOverride(viewmodelMaterial);
+                hkDrawModelExecute.fOriginal(ecx, state, info, pCustomBoneToWorld);
+                m_Game->m_ModelRender->ForcedMaterialOverride(NULL);
+                return;
+            }
+        }
+    }
 
 	if (info.pModel && info.pModel == m_Game->m_ArmsModel && hideArms)
 	{

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -906,15 +906,6 @@ void VR::ProcessInput()
     // Movement via console commands disabled; handled in Hooks::dCreateMove via CUserCmd.
 #endif
 
-    if (PressedDigitalAction(m_ActionPrimaryAttack))
-    {
-        m_Game->ClientCmd_Unrestricted("+attack");
-    }
-    else
-    {
-        m_Game->ClientCmd_Unrestricted("-attack");
-    }
-
     const bool jumpGestureActive = currentTime < m_JumpGestureHoldUntil;
     if (PressedDigitalAction(m_ActionJump) || jumpGestureActive)
     {
@@ -1076,16 +1067,38 @@ void VR::ProcessInput()
         m_VoiceRecordActive = false;
     }
 
-    reloadButtonDown = reloadButtonDown || gestureReloadActive;
+    const bool gripButtonDown = reloadButtonDown;
+    const bool reloadInputDown = reloadButtonDown || gestureReloadActive;
+
     secondaryAttackActive = secondaryAttackActive || gestureSecondaryAttackActive;
 
-    if (!crouchButtonDown && reloadButtonDown && !adjustViewmodelActive)
+    const bool weaponHandIsRight = !m_LeftHanded;
+    const Vector weaponHandPos = weaponHandIsRight ? m_RightControllerPosAbs : m_LeftControllerPosAbs;
+    const Vector weaponHandForward = weaponHandIsRight ? m_RightControllerForward : m_LeftControllerForward;
+    const Vector offHandPos = weaponHandIsRight ? m_LeftControllerPosAbs : m_RightControllerPosAbs;
+
+    if (m_ManualReloadEnabled)
+    {
+        UpdateManualReload(weaponHandPos, weaponHandForward, offHandPos, gripButtonDown, reloadJustPressed, m_ReloadGestureTriggered, adjustViewmodelActive);
+    }
+    else if (!crouchButtonDown && reloadInputDown && !adjustViewmodelActive)
     {
         m_Game->ClientCmd_Unrestricted("+reload");
     }
     else
     {
         m_Game->ClientCmd_Unrestricted("-reload");
+    }
+
+    const bool manualReloadActive = m_ManualReloadPhase != ManualReloadPhase::None;
+
+    if (PressedDigitalAction(m_ActionPrimaryAttack) && !manualReloadActive)
+    {
+        m_Game->ClientCmd_Unrestricted("+attack");
+    }
+    else
+    {
+        m_Game->ClientCmd_Unrestricted("-attack");
     }
 
     if (secondaryAttackActive && !adjustViewmodelActive)
@@ -1142,6 +1155,8 @@ void VR::ProcessInput()
     {
         m_Game->ClientCmd_Unrestricted("impulse 201");
     }
+
+    DrawManualReloadDebug();
 
     auto showHudOverlays = [&](bool attachToControllers)
         {
@@ -1658,6 +1673,8 @@ void VR::UpdateMotionGestures(C_BasePlayer* localPlayer)
         return;
     }
 
+    m_ReloadGestureTriggered = false;
+
     const Vector leftDelta = m_LeftControllerPose.TrackedDevicePos - m_PrevLeftControllerLocalPos;
     const Vector rightDelta = m_RightControllerPose.TrackedDevicePos - m_PrevRightControllerLocalPos;
     const Vector hmdDelta = m_HmdPose.TrackedDevicePos - m_PrevHmdLocalPos;
@@ -1694,6 +1711,7 @@ void VR::UpdateMotionGestures(C_BasePlayer* localPlayer)
     {
         startHold(m_ReloadGestureHoldUntil);
         startCooldown(m_ReloadGestureCooldownEnd);
+        m_ReloadGestureTriggered = true;
     }
 
     const bool onGround = localPlayer && localPlayer->m_hGroundEntity != -1;
@@ -2009,6 +2027,201 @@ void VR::DrawLineWithThickness(const Vector& start, const Vector& end, float dur
         m_Game->m_DebugOverlay->AddTriangleOverlay(start0, start1, end1, colorR, colorG, colorB, colorA, false, duration);
         m_Game->m_DebugOverlay->AddTriangleOverlay(start0, end1, end0, colorR, colorG, colorB, colorA, false, duration);
     }
+}
+
+void VR::BeginManualReload(const Vector& weaponHandPos, const Vector& weaponForward)
+{
+    m_ManualReloadPhase = ManualReloadPhase::AwaitMagRelease;
+    m_ManualReloadCommandIssued = false;
+    m_ManualReloadOldMagGrabbed = false;
+    m_ManualReloadNewMagGrabbed = false;
+    m_ManualReloadBoltPulled = false;
+    m_ManualReloadGripWasDown = false;
+    m_ManualReloadHidingViewmodel = m_ManualReloadHideAnimation;
+    m_ManualReloadLastGripTapTime = {};
+    m_ManualReloadGunAnchor = weaponHandPos;
+    m_ManualReloadBoltStart = weaponHandPos;
+
+    const Vector pouchSide = m_LeftHanded ? m_HmdRight : -m_HmdRight;
+    m_ManualReloadPouchAnchor = m_HmdPosAbs + pouchSide * m_ManualReloadPouchSideOffset + m_HmdUp * m_ManualReloadPouchVerticalOffset;
+
+    if (!weaponForward.IsZero())
+    {
+        Vector forwardNorm = weaponForward;
+        VectorNormalize(forwardNorm);
+        m_ManualReloadGunAnchor = weaponHandPos + forwardNorm * m_ManualReloadGunForwardOffset;
+    }
+
+    Game::logMsg("[VR] Manual reload start (anchors set, pouch at %.2f %.2f %.2f)",
+        m_ManualReloadPouchAnchor.x, m_ManualReloadPouchAnchor.y, m_ManualReloadPouchAnchor.z);
+
+    m_Game->ClientCmd_Unrestricted("+reload");
+    m_ManualReloadCommandIssued = true;
+}
+
+void VR::CancelManualReload()
+{
+    if (m_ManualReloadCommandIssued)
+    {
+        m_Game->ClientCmd_Unrestricted("-reload");
+    }
+
+    m_ManualReloadPhase = ManualReloadPhase::None;
+    m_ManualReloadCommandIssued = false;
+    m_ManualReloadOldMagGrabbed = false;
+    m_ManualReloadNewMagGrabbed = false;
+    m_ManualReloadBoltPulled = false;
+    m_ManualReloadGripWasDown = false;
+    m_ManualReloadHidingViewmodel = false;
+    m_ManualReloadLastGripTapTime = {};
+}
+
+void VR::UpdateManualReload(const Vector& weaponHandPos, const Vector& weaponForward, const Vector& offHandPos, bool reloadButtonDown, bool reloadJustPressed, bool reloadGestureTriggered, bool adjustViewmodelActive)
+{
+    if (!m_ManualReloadEnabled)
+        return;
+
+    const auto now = std::chrono::steady_clock::now();
+
+    Vector forwardNorm = weaponForward;
+    if (!forwardNorm.IsZero())
+        VectorNormalize(forwardNorm);
+    else
+        forwardNorm = Vector{ 1.0f, 0.0f, 0.0f };
+
+    const Vector pouchSide = m_LeftHanded ? m_HmdRight : -m_HmdRight;
+    m_ManualReloadPouchAnchor = m_HmdPosAbs + pouchSide * m_ManualReloadPouchSideOffset + m_HmdUp * m_ManualReloadPouchVerticalOffset;
+
+    if (adjustViewmodelActive)
+    {
+        CancelManualReload();
+        return;
+    }
+
+    if (reloadGestureTriggered && m_ManualReloadPhase == ManualReloadPhase::None)
+    {
+        BeginManualReload(weaponHandPos, weaponForward);
+    }
+
+    if (m_ManualReloadPhase == ManualReloadPhase::None)
+        return;
+
+    const float distanceToGunAnchor = VectorLength(offHandPos - m_ManualReloadGunAnchor);
+    const float distanceToPouch = VectorLength(offHandPos - m_ManualReloadPouchAnchor);
+
+    if (reloadJustPressed)
+    {
+        static constexpr float cancelDoubleTapSeconds = 0.35f;
+        if (m_ManualReloadLastGripTapTime.time_since_epoch().count() > 0)
+        {
+            const float elapsed = std::chrono::duration<float>(now - m_ManualReloadLastGripTapTime).count();
+            if (elapsed <= cancelDoubleTapSeconds)
+            {
+                CancelManualReload();
+                return;
+            }
+        }
+
+        m_ManualReloadLastGripTapTime = now;
+    }
+
+    const bool gripReleased = m_ManualReloadGripWasDown && !reloadButtonDown;
+    m_ManualReloadGripWasDown = reloadButtonDown;
+
+    switch (m_ManualReloadPhase)
+    {
+    case ManualReloadPhase::AwaitMagRelease:
+        if (distanceToGunAnchor <= m_ManualReloadGrabRadius && reloadButtonDown)
+        {
+            m_ManualReloadOldMagGrabbed = true;
+        }
+
+        if (m_ManualReloadOldMagGrabbed && gripReleased && distanceToGunAnchor >= m_ManualReloadRemoveDistance)
+        {
+            m_ManualReloadOldMagGrabbed = false;
+            m_ManualReloadPhase = ManualReloadPhase::AwaitNewMag;
+        }
+        break;
+
+    case ManualReloadPhase::AwaitNewMag:
+        if (distanceToPouch <= m_ManualReloadPouchRadius && reloadButtonDown)
+        {
+            m_ManualReloadNewMagGrabbed = true;
+            m_ManualReloadPhase = ManualReloadPhase::AwaitInsert;
+            m_ManualReloadGunAnchor = weaponHandPos + forwardNorm * m_ManualReloadGunForwardOffset;
+        }
+        break;
+
+    case ManualReloadPhase::AwaitInsert:
+        if (!reloadButtonDown)
+        {
+            if (m_ManualReloadNewMagGrabbed && distanceToGunAnchor <= m_ManualReloadInsertRadius)
+            {
+                m_ManualReloadPhase = ManualReloadPhase::AwaitBolt;
+                m_ManualReloadBoltStart = weaponHandPos;
+                m_ManualReloadBoltPulled = false;
+            }
+            else if (m_ManualReloadNewMagGrabbed)
+            {
+                m_ManualReloadNewMagGrabbed = false;
+                m_ManualReloadPhase = ManualReloadPhase::AwaitNewMag;
+            }
+        }
+        break;
+
+    case ManualReloadPhase::AwaitBolt:
+        {
+            const float pullAmount = DotProduct(weaponHandPos - m_ManualReloadBoltStart, -forwardNorm);
+            if (reloadButtonDown && pullAmount >= m_ManualReloadBoltDistance)
+            {
+                m_ManualReloadBoltPulled = true;
+            }
+
+            if (gripReleased && m_ManualReloadBoltPulled)
+            {
+                CancelManualReload();
+            }
+        }
+        break;
+
+    case ManualReloadPhase::None:
+    default:
+        break;
+    }
+}
+
+void VR::DrawManualReloadDebug() const
+{
+    if (m_ManualReloadPhase == ManualReloadPhase::None)
+        return;
+
+    if (!m_Game || !m_Game->m_DebugOverlay)
+        return;
+
+    const float duration = std::max(m_LastFrameDuration, 0.05f);
+    const Vector boxExtents{ 0.08f, 0.08f, 0.08f };
+
+    auto drawAnchorCross = [&](const Vector& center, float size, int r, int g, int b)
+        {
+            const Vector x(size, 0.0f, 0.0f);
+            const Vector y(0.0f, size, 0.0f);
+            const Vector z(0.0f, 0.0f, size);
+            m_Game->m_DebugOverlay->AddLineOverlay(center - x, center + x, r, g, b, true, duration);
+            m_Game->m_DebugOverlay->AddLineOverlay(center - y, center + y, r, g, b, true, duration);
+            m_Game->m_DebugOverlay->AddLineOverlay(center - z, center + z, r, g, b, true, duration);
+        };
+
+    const float crossSize = 0.16f;
+    const float boltBoxScale = 0.65f;
+
+    m_Game->m_DebugOverlay->AddBoxOverlay(m_ManualReloadGunAnchor, -boxExtents, boxExtents, QAngle(0, 0, 0), 0, 220, 255, 160, duration);
+    drawAnchorCross(m_ManualReloadGunAnchor, crossSize, 0, 220, 255);
+
+    m_Game->m_DebugOverlay->AddBoxOverlay(m_ManualReloadPouchAnchor, -boxExtents, boxExtents, QAngle(0, 0, 0), 255, 200, 0, 160, duration);
+    drawAnchorCross(m_ManualReloadPouchAnchor, crossSize, 255, 200, 0);
+
+    m_Game->m_DebugOverlay->AddBoxOverlay(m_ManualReloadBoltStart, -boxExtents * boltBoxScale, boxExtents * boltBoxScale, QAngle(0, 0, 0), 255, 64, 64, 160, duration);
+    drawAnchorCross(m_ManualReloadBoltStart, crossSize * 0.8f, 255, 64, 64);
 }
 
 VR::SpecialInfectedType VR::GetSpecialInfectedType(const std::string& modelName) const
@@ -2812,6 +3025,16 @@ void VR::ParseConfigFile()
     m_AimLineFrameDurationMultiplier = std::max(0.0f, getFloat("AimLineFrameDurationMultiplier", m_AimLineFrameDurationMultiplier));
     m_ForceNonVRServerMovement = getBool("ForceNonVRServerMovement", m_ForceNonVRServerMovement);
     m_RequireSecondaryAttackForItemSwitch = getBool("RequireSecondaryAttackForItemSwitch", m_RequireSecondaryAttackForItemSwitch);
+    m_ManualReloadEnabled = getBool("ManualReloadEnabled", m_ManualReloadEnabled);
+    m_ManualReloadHideAnimation = getBool("ManualReloadHideAnimation", m_ManualReloadHideAnimation);
+    m_ManualReloadGunForwardOffset = getFloat("ManualReloadGunForwardOffset", m_ManualReloadGunForwardOffset);
+    m_ManualReloadPouchSideOffset = getFloat("ManualReloadPouchSideOffset", m_ManualReloadPouchSideOffset);
+    m_ManualReloadPouchVerticalOffset = getFloat("ManualReloadPouchVerticalOffset", m_ManualReloadPouchVerticalOffset);
+    m_ManualReloadGrabRadius = std::max(0.0f, getFloat("ManualReloadGrabRadius", m_ManualReloadGrabRadius));
+    m_ManualReloadRemoveDistance = std::max(0.0f, getFloat("ManualReloadRemoveDistance", m_ManualReloadRemoveDistance));
+    m_ManualReloadInsertRadius = std::max(0.0f, getFloat("ManualReloadInsertRadius", m_ManualReloadInsertRadius));
+    m_ManualReloadPouchRadius = std::max(0.0f, getFloat("ManualReloadPouchRadius", m_ManualReloadPouchRadius));
+    m_ManualReloadBoltDistance = std::max(0.0f, getFloat("ManualReloadBoltDistance", m_ManualReloadBoltDistance));
     m_SpecialInfectedWarningActionEnabled = getBool("SpecialInfectedAutoEvade", m_SpecialInfectedWarningActionEnabled);
     m_SpecialInfectedArrowEnabled = getBool("SpecialInfectedArrowEnabled", m_SpecialInfectedArrowEnabled);
     m_SpecialInfectedArrowSize = std::max(0.0f, getFloat("SpecialInfectedArrowSize", m_SpecialInfectedArrowSize));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -294,6 +294,38 @@ public:
         std::chrono::steady_clock::time_point m_SecondaryGestureCooldownEnd{};
         std::chrono::steady_clock::time_point m_ReloadGestureCooldownEnd{};
         std::chrono::steady_clock::time_point m_JumpGestureCooldownEnd{};
+        bool m_ReloadGestureTriggered = false;
+
+        enum class ManualReloadPhase
+        {
+                None,
+                AwaitMagRelease,
+                AwaitNewMag,
+                AwaitInsert,
+                AwaitBolt
+        };
+
+        ManualReloadPhase m_ManualReloadPhase = ManualReloadPhase::None;
+        bool m_ManualReloadEnabled = true;
+        bool m_ManualReloadCommandIssued = false;
+        bool m_ManualReloadOldMagGrabbed = false;
+        bool m_ManualReloadNewMagGrabbed = false;
+        bool m_ManualReloadBoltPulled = false;
+        bool m_ManualReloadGripWasDown = false;
+        bool m_ManualReloadHideAnimation = false;
+        bool m_ManualReloadHidingViewmodel = false;
+        std::chrono::steady_clock::time_point m_ManualReloadLastGripTapTime{};
+        Vector m_ManualReloadGunAnchor = { 0,0,0 };
+        Vector m_ManualReloadPouchAnchor = { 0,0,0 };
+        Vector m_ManualReloadBoltStart = { 0,0,0 };
+        float m_ManualReloadGunForwardOffset = 0.05f;
+        float m_ManualReloadPouchSideOffset = 0.18f;
+        float m_ManualReloadPouchVerticalOffset = -0.35f;
+        float m_ManualReloadGrabRadius = 0.12f;
+        float m_ManualReloadRemoveDistance = 0.25f;
+        float m_ManualReloadPouchRadius = 0.18f;
+        float m_ManualReloadInsertRadius = 0.14f;
+        float m_ManualReloadBoltDistance = 0.16f;
 
 	bool m_ForceNonVRServerMovement = false;
 	bool m_RequireSecondaryAttackForItemSwitch = true;
@@ -407,14 +439,18 @@ public:
         void WaitForConfigUpdate();
 	bool GetWalkAxis(float& x, float& y);
 	bool m_EncodeVRUsercmd = true;
-	void UpdateAimingLaser(C_BasePlayer* localPlayer);
-	bool ShouldShowAimLine(C_WeaponCSBase* weapon) const;
-	bool IsThrowableWeapon(C_WeaponCSBase* weapon) const;
+        void UpdateAimingLaser(C_BasePlayer* localPlayer);
+        bool ShouldShowAimLine(C_WeaponCSBase* weapon) const;
+        bool IsThrowableWeapon(C_WeaponCSBase* weapon) const;
         float CalculateThrowArcDistance(const Vector& pitchSource, bool* clampedToMax = nullptr) const;
         void DrawAimLine(const Vector& start, const Vector& end);
         void DrawThrowArc(const Vector& origin, const Vector& forward, const Vector& pitchSource);
         void DrawThrowArcFromCache(float duration);
-	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
+        void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
+        void BeginManualReload(const Vector& weaponHandPos, const Vector& weaponForward);
+        void CancelManualReload();
+        void UpdateManualReload(const Vector& weaponHandPos, const Vector& weaponForward, const Vector& offHandPos, bool reloadButtonDown, bool reloadJustPressed, bool reloadGestureTriggered, bool adjustViewmodelActive);
+        void DrawManualReloadDebug() const;
         SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
         void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
         void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);


### PR DESCRIPTION
## Summary
- add a ManualReloadHideAnimation toggle to sample config and VR settings
- hide the first-person viewmodel while manual reload is running when the toggle is enabled
- reset the temporary viewmodel hiding when the reload flow cancels or completes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693aa88a84648321be88b165e27b2ef0)