### PR TITLE
Fix client entity type for player lookup

### DIFF
--- a/L4D2VR/game.cpp
+++ b/L4D2VR/game.cpp
@@ -180,12 +180,12 @@ void Game::ResetAllPlayerVRInfo()
 }
 
 // === Entity Access ===
-CBaseEntity* Game::GetClientEntity(int entityIndex)
+C_BaseEntity* Game::GetClientEntity(int entityIndex)
 {
     if (!m_ClientEntityList)
         return nullptr;
 
-    return static_cast<CBaseEntity*>(m_ClientEntityList->GetClientEntity(entityIndex));
+    return static_cast<C_BaseEntity*>(m_ClientEntityList->GetClientEntity(entityIndex));
 }
 
 // === Network Name Utility ===

--- a/L4D2VR/game.h
+++ b/L4D2VR/game.h
@@ -19,7 +19,7 @@ class IModelRender;
 class IMaterial;
 class IInput;
 class ISurface;
-class CBaseEntity;
+class C_BaseEntity;
 class C_BasePlayer;
 struct model_t;
 class IVDebugOverlay;
@@ -97,7 +97,7 @@ public:
 
     // === Interface Utilities ===
     void* GetInterface(const char* dllname, const char* interfacename);
-    CBaseEntity* GetClientEntity(int entityIndex);
+    C_BaseEntity* GetClientEntity(int entityIndex);
     char* getNetworkName(uintptr_t* entity);
 
     // === Command Execution ===


### PR DESCRIPTION
## Summary
- align the Game::GetClientEntity return type with client entity base class
- use the correct client entity type to allow casting to C_BasePlayer without errors

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4c7e8c588321a0fd853468684719)