### PR TITLE
Fix inventory grip slot mapping

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1120,13 +1120,13 @@ void VR::ProcessInput()
                 return;
             }
 
-            if (nearChest)
+            if (nearLeftWaist)
             {
                 m_Game->ClientCmd_Unrestricted("slot3");
                 return;
             }
 
-            if (nearLeftWaist)
+            if (nearChest)
             {
                 m_Game->ClientCmd_Unrestricted("slot4");
                 return;


### PR DESCRIPTION
## Summary
- corrected inventory grip gesture mapping so left waist selects throwables, chest selects healing items, and right waist selects pills

## Testing
- not run (not available)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c5843b9e883218280a4f13f713d6e)