### PR TITLE
Add configurable SteamVR custom console command actions

### DIFF
--- a/L4D2VR/SteamVRActionManifest/action_manifest.json
+++ b/L4D2VR/SteamVRActionManifest/action_manifest.json
@@ -122,20 +122,30 @@
 			"type": "boolean",
 			"requirement": "optional"
 		},
-		{
-			"name": "/actions/main/in/Scoreboard",
-			"type": "boolean"
-		},
-		{
-			"name": "/actions/main/in/ShowHUD",
-			"type": "boolean",
-			"requirement": "optional"
-		},
-		{
-			"name": "/actions/main/in/Pause",
-			"type": "boolean"
-		}
-	],
+                {
+                        "name": "/actions/main/in/Scoreboard",
+                        "type": "boolean"
+                },
+                {
+                        "name": "/actions/main/in/ShowHUD",
+                        "type": "boolean",
+                        "requirement": "optional"
+                },
+                {
+                        "name": "/actions/main/in/Pause",
+                        "type": "boolean"
+                },
+                {
+                        "name": "/actions/main/in/CustomAction1",
+                        "type": "boolean",
+                        "requirement": "optional"
+                },
+                {
+                        "name": "/actions/main/in/CustomAction2",
+                        "type": "boolean",
+                        "requirement": "optional"
+                }
+        ],
 
 	"action_sets": [
 		{
@@ -171,10 +181,12 @@
 			"/actions/main/in/MenuDown" : "Menu Down",
 			"/actions/main/in/MenuLeft" : "Menu Left",
 			"/actions/main/in/MenuRight" : "Menu Right",
-			"/actions/main/in/Spray" : "Spray",
-			"/actions/main/in/Scoreboard" : "Show Scoreboard",
-			"/actions/main/in/ShowHUD" : "Show HUD",
-			"/actions/main/in/Pause" : "Pause"
-		}
-	]
+                        "/actions/main/in/Spray" : "Spray",
+                        "/actions/main/in/Scoreboard" : "Show Scoreboard",
+                        "/actions/main/in/ShowHUD" : "Show HUD",
+                        "/actions/main/in/Pause" : "Pause",
+                        "/actions/main/in/CustomAction1" : "Custom Action 1",
+                        "/actions/main/in/CustomAction2" : "Custom Action 2"
+                }
+        ]
 }

--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -40,3 +40,6 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 # Any combo can be disabled by setting it to "false".
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
+# Console commands executed when pressing the custom SteamVR bindings (leave empty to disable)
+CustomAction1Command=
+CustomAction2Command=

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -178,6 +178,8 @@ int VR::SetActionManifest(const char* fileName)
     m_Input->GetActionHandle("/actions/main/in/Scoreboard", &m_Scoreboard);
     m_Input->GetActionHandle("/actions/main/in/ShowHUD", &m_ShowHUD);
     m_Input->GetActionHandle("/actions/main/in/Pause", &m_Pause);
+    m_Input->GetActionHandle("/actions/main/in/CustomAction1", &m_CustomAction1);
+    m_Input->GetActionHandle("/actions/main/in/CustomAction2", &m_CustomAction2);
 
     m_Input->GetActionSetHandle("/actions/main", &m_ActionSet);
     m_ActiveActionSet = {};
@@ -1318,6 +1320,20 @@ void VR::ProcessInput()
     {
         m_Game->ClientCmd_Unrestricted("impulse 201");
     }
+
+    auto triggerCustomAction = [&](const std::string& command)
+        {
+            if (command.empty())
+                return;
+
+            m_Game->ClientCmd_Unrestricted(command.c_str());
+        };
+
+    if (PressedDigitalAction(m_CustomAction1, true))
+        triggerCustomAction(m_CustomAction1Command);
+
+    if (PressedDigitalAction(m_CustomAction2, true))
+        triggerCustomAction(m_CustomAction2Command);
 
     auto showHudOverlays = [&](bool attachToControllers)
         {
@@ -2866,6 +2882,17 @@ void VR::ParseConfigFile()
         return result;
         };
 
+    auto getString = [&](const char* k, const std::string& defVal)->std::string {
+        auto it = userConfig.find(k);
+        if (it == userConfig.end())
+            return defVal;
+
+        std::string value = it->second;
+        trim(value);
+
+        return value.empty() ? defVal : value;
+        };
+
     // 用当前成员的值作为默认值（构造时已初始化）
     m_SnapTurning = getBool("SnapTurning", m_SnapTurning);
     m_SnapTurnAngle = getFloat("SnapTurnAngle", m_SnapTurnAngle);
@@ -2962,6 +2989,8 @@ void VR::ParseConfigFile()
     m_VoiceRecordCombo = parseActionCombo("VoiceRecordCombo", m_VoiceRecordCombo);
     m_QuickTurnCombo = parseActionCombo("QuickTurnCombo", m_QuickTurnCombo);
     m_ViewmodelAdjustCombo = parseActionCombo("ViewmodelAdjustCombo", m_ViewmodelAdjustCombo);
+    m_CustomAction1Command = getString("CustomAction1Command", m_CustomAction1Command);
+    m_CustomAction2Command = getString("CustomAction2Command", m_CustomAction2Command);
 
     m_LeftHanded = getBool("LeftHanded", m_LeftHanded);
     m_VRScale = getFloat("VRScale", m_VRScale);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -247,10 +247,12 @@ public:
 	vr::VRActionHandle_t m_MenuDown;
 	vr::VRActionHandle_t m_MenuLeft;
 	vr::VRActionHandle_t m_MenuRight;
-	vr::VRActionHandle_t m_Spray;
-	vr::VRActionHandle_t m_Scoreboard;
-	vr::VRActionHandle_t m_ShowHUD;
-	vr::VRActionHandle_t m_Pause;
+        vr::VRActionHandle_t m_Spray;
+        vr::VRActionHandle_t m_Scoreboard;
+        vr::VRActionHandle_t m_ShowHUD;
+        vr::VRActionHandle_t m_Pause;
+        vr::VRActionHandle_t m_CustomAction1;
+        vr::VRActionHandle_t m_CustomAction2;
 
 	TrackedDevicePoseData m_HmdPose;
 	TrackedDevicePoseData m_LeftControllerPose;
@@ -271,12 +273,14 @@ public:
 	float m_HudSize = 1.1;
 	float m_ControllerHudSize = 0.5f;
 	float m_ControllerHudYOffset = 0.12f;
-	float m_ControllerHudZOffset = 0.0f;
-	float m_ControllerHudRotation = 0.0f;
-	float m_ControllerHudXOffset = 0.0f;
+        float m_ControllerHudZOffset = 0.0f;
+        float m_ControllerHudRotation = 0.0f;
+        float m_ControllerHudXOffset = 0.0f;
         bool m_HudAlwaysVisible = false;
         float m_ControllerSmoothing = 0.0f;
         bool m_ControllerSmoothingInitialized = false;
+        std::string m_CustomAction1Command{};
+        std::string m_CustomAction2Command{};
 
         float m_MotionGestureSwingThreshold = 1.1f;
         float m_MotionGestureDownSwingThreshold = 1.0f;


### PR DESCRIPTION
## Summary
- add two optional SteamVR actions for custom console commands with manifest and localization entries
- load configurable console strings from config.txt for the new bindings
- execute the configured commands when the SteamVR actions are pressed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cf603a95c8321acceb50c7180e9a6)