### PR TITLE
Fix custom action bindings naming collision

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -41,6 +41,7 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
 # Console commands executed when pressing the custom SteamVR bindings (leave empty to disable)
+# Prefix a value with "key:" to send a keyboard key instead of a console command (e.g. key:space, key:f5, key:k)
 CustomAction1Command=
 CustomAction2Command=
 CustomAction3Command=

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1324,28 +1324,32 @@ void VR::ProcessInput()
         m_Game->ClientCmd_Unrestricted("impulse 201");
     }
 
-    auto triggerCustomAction = [&](const std::string& command)
+    auto triggerCustomAction = [&](const CustomActionBinding& binding)
         {
-            if (command.empty())
+            if (binding.virtualKey.has_value())
+            {
+                SendVirtualKey(*binding.virtualKey);
                 return;
+            }
 
-            m_Game->ClientCmd_Unrestricted(command.c_str());
+            if (!binding.command.empty())
+                m_Game->ClientCmd_Unrestricted(binding.command.c_str());
         };
 
     if (PressedDigitalAction(m_CustomAction1, true))
-        triggerCustomAction(m_CustomAction1Command);
+        triggerCustomAction(m_CustomAction1Binding);
 
     if (PressedDigitalAction(m_CustomAction2, true))
-        triggerCustomAction(m_CustomAction2Command);
+        triggerCustomAction(m_CustomAction2Binding);
 
     if (PressedDigitalAction(m_CustomAction3, true))
-        triggerCustomAction(m_CustomAction3Command);
+        triggerCustomAction(m_CustomAction3Binding);
 
     if (PressedDigitalAction(m_CustomAction4, true))
-        triggerCustomAction(m_CustomAction4Command);
+        triggerCustomAction(m_CustomAction4Binding);
 
     if (PressedDigitalAction(m_CustomAction5, true))
-        triggerCustomAction(m_CustomAction5Command);
+        triggerCustomAction(m_CustomAction5Binding);
 
     auto showHudOverlays = [&](bool attachToControllers)
         {
@@ -1399,7 +1403,7 @@ void VR::ProcessInput()
     }
 }
 
-void VR::SendFunctionKey(WORD virtualKey)
+void VR::SendVirtualKey(WORD virtualKey)
 {
     INPUT inputs[2] = {};
 
@@ -1411,6 +1415,11 @@ void VR::SendFunctionKey(WORD virtualKey)
     inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
 
     SendInput(2, inputs, sizeof(INPUT));
+}
+
+void VR::SendFunctionKey(WORD virtualKey)
+{
+    SendVirtualKey(virtualKey);
 }
 
 VMatrix VR::VMatrixFromHmdMatrix(const vr::HmdMatrix34_t& hmdMat)
@@ -2905,6 +2914,72 @@ void VR::ParseConfigFile()
         return value.empty() ? defVal : value;
         };
 
+    auto parseVirtualKey = [&](const std::string& rawValue)->std::optional<WORD>
+        {
+            std::string value = rawValue;
+            trim(value);
+            if (value.size() < 5) // key:<x>
+                return std::nullopt;
+
+            std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) { return std::tolower(c); });
+
+            const std::string prefix = "key:";
+            if (value.rfind(prefix, 0) != 0)
+                return std::nullopt;
+
+            std::string keyToken = value.substr(prefix.size());
+            trim(keyToken);
+            if (keyToken.empty())
+                return std::nullopt;
+
+            static const std::unordered_map<std::string, WORD> keyLookup = {
+                { "space", VK_SPACE }, { "enter", VK_RETURN }, { "return", VK_RETURN },
+                { "tab", VK_TAB }, { "escape", VK_ESCAPE }, { "esc", VK_ESCAPE },
+                { "shift", VK_SHIFT }, { "lshift", VK_LSHIFT }, { "rshift", VK_RSHIFT },
+                { "ctrl", VK_CONTROL }, { "lctrl", VK_LCONTROL }, { "rctrl", VK_RCONTROL },
+                { "alt", VK_MENU }, { "lalt", VK_LMENU }, { "ralt", VK_RMENU },
+                { "backspace", VK_BACK }, { "delete", VK_DELETE }, { "insert", VK_INSERT },
+                { "home", VK_HOME }, { "end", VK_END }, { "pageup", VK_PRIOR }, { "pagedown", VK_NEXT },
+                { "up", VK_UP }, { "down", VK_DOWN }, { "left", VK_LEFT }, { "right", VK_RIGHT }
+            };
+
+            auto lookupIt = keyLookup.find(keyToken);
+            if (lookupIt != keyLookup.end())
+                return lookupIt->second;
+
+            if (keyToken.size() == 1)
+            {
+                char ch = keyToken[0];
+                if (ch >= 'a' && ch <= 'z')
+                    return static_cast<WORD>('A' + (ch - 'a'));
+                if (ch >= '0' && ch <= '9')
+                    return static_cast<WORD>(ch);
+            }
+
+            if (keyToken.size() > 1 && keyToken[0] == 'f')
+            {
+                try
+                {
+                    int functionIndex = std::stoi(keyToken.substr(1));
+                    if (functionIndex >= 1 && functionIndex <= 24)
+                        return static_cast<WORD>(VK_F1 + functionIndex - 1);
+                }
+                catch (...)
+                {
+                }
+            }
+
+            return std::nullopt;
+        };
+
+    auto parseCustomActionBinding = [&](const char* key, CustomActionBinding& binding)
+        {
+            binding.command = getString(key, binding.command);
+            binding.virtualKey = parseVirtualKey(binding.command);
+            if (!binding.command.empty() && binding.virtualKey.has_value())
+                Game::logMsg("[VR] %s mapped to virtual key 0x%02X", key, *binding.virtualKey);
+        };
+
     // 用当前成员的值作为默认值（构造时已初始化）
     m_SnapTurning = getBool("SnapTurning", m_SnapTurning);
     m_SnapTurnAngle = getFloat("SnapTurnAngle", m_SnapTurnAngle);
@@ -3001,11 +3076,11 @@ void VR::ParseConfigFile()
     m_VoiceRecordCombo = parseActionCombo("VoiceRecordCombo", m_VoiceRecordCombo);
     m_QuickTurnCombo = parseActionCombo("QuickTurnCombo", m_QuickTurnCombo);
     m_ViewmodelAdjustCombo = parseActionCombo("ViewmodelAdjustCombo", m_ViewmodelAdjustCombo);
-    m_CustomAction1Command = getString("CustomAction1Command", m_CustomAction1Command);
-    m_CustomAction2Command = getString("CustomAction2Command", m_CustomAction2Command);
-    m_CustomAction3Command = getString("CustomAction3Command", m_CustomAction3Command);
-    m_CustomAction4Command = getString("CustomAction4Command", m_CustomAction4Command);
-    m_CustomAction5Command = getString("CustomAction5Command", m_CustomAction5Command);
+    parseCustomActionBinding("CustomAction1Command", m_CustomAction1Binding);
+    parseCustomActionBinding("CustomAction2Command", m_CustomAction2Binding);
+    parseCustomActionBinding("CustomAction3Command", m_CustomAction3Binding);
+    parseCustomActionBinding("CustomAction4Command", m_CustomAction4Binding);
+    parseCustomActionBinding("CustomAction5Command", m_CustomAction5Binding);
 
     m_LeftHanded = getBool("LeftHanded", m_LeftHanded);
     m_VRScale = getFloat("VRScale", m_VRScale);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -5,6 +5,7 @@
 #include "vector.h"
 #include <array>
 #include <chrono>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -35,8 +36,14 @@ struct TrackedDevicePoseData
 
 struct SharedTextureHolder
 {
-	vr::VRVulkanTextureData_t m_VulkanData;
-	vr::Texture_t m_VRTexture;
+        vr::VRVulkanTextureData_t m_VulkanData;
+        vr::Texture_t m_VRTexture;
+};
+
+struct CustomActionBinding
+{
+        std::string command;
+        std::optional<WORD> virtualKey;
 };
 
 
@@ -272,21 +279,21 @@ public:
 	float m_VRScale = 43.2;
 	float m_IpdScale = 1.0;
 	bool m_HideArms = false;
-	float m_HudDistance = 1.3;
-	float m_HudSize = 1.1;
-	float m_ControllerHudSize = 0.5f;
-	float m_ControllerHudYOffset = 0.12f;
+        float m_HudDistance = 1.3;
+        float m_HudSize = 1.1;
+        float m_ControllerHudSize = 0.5f;
+        float m_ControllerHudYOffset = 0.12f;
         float m_ControllerHudZOffset = 0.0f;
         float m_ControllerHudRotation = 0.0f;
         float m_ControllerHudXOffset = 0.0f;
         bool m_HudAlwaysVisible = false;
         float m_ControllerSmoothing = 0.0f;
         bool m_ControllerSmoothingInitialized = false;
-        std::string m_CustomAction1Command{};
-        std::string m_CustomAction2Command{};
-        std::string m_CustomAction3Command{};
-        std::string m_CustomAction4Command{};
-        std::string m_CustomAction5Command{};
+        CustomActionBinding m_CustomAction1Binding{};
+        CustomActionBinding m_CustomAction2Binding{};
+        CustomActionBinding m_CustomAction3Binding{};
+        CustomActionBinding m_CustomAction4Binding{};
+        CustomActionBinding m_CustomAction5Binding{};
 
         float m_MotionGestureSwingThreshold = 1.1f;
         float m_MotionGestureDownSwingThreshold = 1.0f;
@@ -390,8 +397,9 @@ public:
 	bool UpdatePosesAndActions();
 	void GetViewParameters();
 	void ProcessMenuInput();
-	void ProcessInput();
-	void SendFunctionKey(WORD virtualKey);
+        void ProcessInput();
+        void SendVirtualKey(WORD virtualKey);
+        void SendFunctionKey(WORD virtualKey);
 	VMatrix VMatrixFromHmdMatrix(const vr::HmdMatrix34_t& hmdMat);
 	vr::HmdMatrix34_t VMatrixToHmdMatrix(const VMatrix& vMat);
 	vr::HmdMatrix34_t GetControllerTipMatrix(vr::ETrackedControllerRole controllerRole);


### PR DESCRIPTION
## Summary
- rename custom action binding members so they no longer collide with VR action handles
- use the dedicated binding members when parsing custom action config and triggering actions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d4b7e411483218231d324d6bb6f79)