### PR TITLE
Add inline Vector length implementations

### DIFF
--- a/L4D2VR/SteamVRActionManifest/action_manifest.json
+++ b/L4D2VR/SteamVRActionManifest/action_manifest.json
@@ -85,15 +85,20 @@
 			"name": "/actions/main/in/Crouch",
 			"type": "boolean"
 		},
-		{
-			"name": "/actions/main/in/Flashlight",
-			"type": "boolean"
-		},
-		{
-			"name": "/actions/main/in/ActivateVR",
-			"type": "boolean"
-		},
-		{
+                {
+                        "name": "/actions/main/in/Flashlight",
+                        "type": "boolean"
+                },
+                {
+                        "name": "/actions/main/in/BunnyHop",
+                        "type": "boolean",
+                        "requirement": "optional"
+                },
+                {
+                        "name": "/actions/main/in/ActivateVR",
+                        "type": "boolean"
+                },
+                {
 			"name": "/actions/main/in/MenuSelect",
 			"type": "boolean"
 		},
@@ -195,11 +200,12 @@
 			"/actions/main/in/MenuUp" : "Menu Up",
 			"/actions/main/in/MenuDown" : "Menu Down",
 			"/actions/main/in/MenuLeft" : "Menu Left",
-			"/actions/main/in/MenuRight" : "Menu Right",
+                        "/actions/main/in/MenuRight" : "Menu Right",
                         "/actions/main/in/Spray" : "Spray",
                         "/actions/main/in/Scoreboard" : "Show Scoreboard",
                         "/actions/main/in/ShowHUD" : "Show HUD",
                         "/actions/main/in/Pause" : "Pause",
+                        "/actions/main/in/BunnyHop" : "Bunny Hop",
                         "/actions/main/in/CustomAction1" : "Custom Action 1",
                         "/actions/main/in/CustomAction2" : "Custom Action 2",
                         "/actions/main/in/CustomAction3" : "Custom Action 3",

--- a/L4D2VR/sdk/vector.h
+++ b/L4D2VR/sdk/vector.h
@@ -302,6 +302,21 @@ inline vec_t Vector::operator[](int i) const
 	return ((vec_t *)this)[i];
 }
 
+inline vec_t Vector::Length() const
+{
+	return static_cast<vec_t>(sqrt(x * x + y * y + z * z));
+}
+
+inline vec_t Vector::Length2D(void) const
+{
+	return static_cast<vec_t>(sqrt(x * x + y * y));
+}
+
+inline vec_t Vector::Length2DSqr(void) const
+{
+	return (x * x + y * y);
+}
+
 class VectorByValue : public Vector
 {
 public:

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -168,6 +168,7 @@ int VR::SetActionManifest(const char* fileName)
     m_Input->GetActionHandle("/actions/main/in/ResetPosition", &m_ActionResetPosition);
     m_Input->GetActionHandle("/actions/main/in/Crouch", &m_ActionCrouch);
     m_Input->GetActionHandle("/actions/main/in/Flashlight", &m_ActionFlashlight);
+    m_Input->GetActionHandle("/actions/main/in/BunnyHop", &m_ActionBunnyHop);
     m_Input->GetActionHandle("/actions/main/in/MenuSelect", &m_MenuSelect);
     m_Input->GetActionHandle("/actions/main/in/MenuBack", &m_MenuBack);
     m_Input->GetActionHandle("/actions/main/in/MenuUp", &m_MenuUp);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -244,14 +244,15 @@ public:
 	vr::VRActionHandle_t m_ActionUse;
 	vr::VRActionHandle_t m_ActionNextItem;
 	vr::VRActionHandle_t m_ActionPrevItem;
-	vr::VRActionHandle_t m_ActionResetPosition;
-	vr::VRActionHandle_t m_ActionCrouch;
-	vr::VRActionHandle_t m_ActionFlashlight;
-	vr::VRActionHandle_t m_ActionActivateVR;
-	vr::VRActionHandle_t m_MenuSelect;
-	vr::VRActionHandle_t m_MenuBack;
-	vr::VRActionHandle_t m_MenuUp;
-	vr::VRActionHandle_t m_MenuDown;
+        vr::VRActionHandle_t m_ActionResetPosition;
+        vr::VRActionHandle_t m_ActionCrouch;
+        vr::VRActionHandle_t m_ActionFlashlight;
+        vr::VRActionHandle_t m_ActionBunnyHop;
+        vr::VRActionHandle_t m_ActionActivateVR;
+        vr::VRActionHandle_t m_MenuSelect;
+        vr::VRActionHandle_t m_MenuBack;
+        vr::VRActionHandle_t m_MenuUp;
+        vr::VRActionHandle_t m_MenuDown;
 	vr::VRActionHandle_t m_MenuLeft;
 	vr::VRActionHandle_t m_MenuRight;
         vr::VRActionHandle_t m_Spray;
@@ -322,12 +323,12 @@ public:
         int m_InventoryAnchorColorB = 255;
         int m_InventoryAnchorColorA = 64;
 
-	bool m_ForceNonVRServerMovement = false;
-	bool m_RequireSecondaryAttackForItemSwitch = true;
-	struct RgbColor
-	{
-		int r;
-		int g;
+        bool m_ForceNonVRServerMovement = false;
+        bool m_RequireSecondaryAttackForItemSwitch = true;
+        struct RgbColor
+        {
+                int r;
+                int g;
 		int b;
 	};
 


### PR DESCRIPTION
## Summary
- add inline implementations for Vector length helpers including Length2D and Length2DSqr
- resolve missing symbol errors from CreateMove bunny hop speed usage

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d507b6adc83219353980dad51dd42)