### PR TITLE
Add toggle for bunny hop action

### DIFF
--- a/L4D2VR/SteamVRActionManifest/action_manifest.json
+++ b/L4D2VR/SteamVRActionManifest/action_manifest.json
@@ -85,15 +85,20 @@
 			"name": "/actions/main/in/Crouch",
 			"type": "boolean"
 		},
-		{
-			"name": "/actions/main/in/Flashlight",
-			"type": "boolean"
-		},
-		{
-			"name": "/actions/main/in/ActivateVR",
-			"type": "boolean"
-		},
-		{
+                {
+                        "name": "/actions/main/in/Flashlight",
+                        "type": "boolean"
+                },
+                {
+                        "name": "/actions/main/in/BunnyHop",
+                        "type": "boolean",
+                        "requirement": "optional"
+                },
+                {
+                        "name": "/actions/main/in/ActivateVR",
+                        "type": "boolean"
+                },
+                {
 			"name": "/actions/main/in/MenuSelect",
 			"type": "boolean"
 		},
@@ -195,11 +200,12 @@
 			"/actions/main/in/MenuUp" : "Menu Up",
 			"/actions/main/in/MenuDown" : "Menu Down",
 			"/actions/main/in/MenuLeft" : "Menu Left",
-			"/actions/main/in/MenuRight" : "Menu Right",
+                        "/actions/main/in/MenuRight" : "Menu Right",
                         "/actions/main/in/Spray" : "Spray",
                         "/actions/main/in/Scoreboard" : "Show Scoreboard",
                         "/actions/main/in/ShowHUD" : "Show HUD",
                         "/actions/main/in/Pause" : "Pause",
+                        "/actions/main/in/BunnyHop" : "Bunny Hop",
                         "/actions/main/in/CustomAction1" : "Custom Action 1",
                         "/actions/main/in/CustomAction2" : "Custom Action 2",
                         "/actions/main/in/CustomAction3" : "Custom Action 3",

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -8,6 +8,26 @@
 #include <iostream>
 #include <cstdint>
 #include <string>
+#include <algorithm>
+
+namespace
+{
+        constexpr int kInJump = 1 << 1;
+        constexpr int kInForward = 1 << 3;
+        constexpr int kInBack = 1 << 4;
+        constexpr int kInMoveLeft = 1 << 9;
+        constexpr int kInMoveRight = 1 << 10;
+
+        float NormalizeYaw(float yaw)
+        {
+                while (yaw > 180.f)
+                        yaw -= 360.f;
+                while (yaw < -180.f)
+                        yaw += 360.f;
+
+                return yaw;
+        }
+}
 bool Hooks::s_ServerUnderstandsVR = false;
 Hooks::Hooks(Game* game)
 {
@@ -260,11 +280,11 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 	if (!cmd->command_number)
 		return hkCreateMove.fOriginal(ecx, flInputSampleTime, cmd);
 
-	bool result = hkCreateMove.fOriginal(ecx, flInputSampleTime, cmd);
+        bool result = hkCreateMove.fOriginal(ecx, flInputSampleTime, cmd);
 
-	if (m_VR->m_IsVREnabled) {
-		const bool treatServerAsNonVR = m_VR->m_ForceNonVRServerMovement;
-		float ax = 0.f, ay = 0.f;
+        if (m_VR->m_IsVREnabled) {
+                const bool treatServerAsNonVR = m_VR->m_ForceNonVRServerMovement;
+                float ax = 0.f, ay = 0.f;
 		if (m_VR->GetWalkAxis(ax, ay)) {
 			// 死区 + 归一化（和平滑转向一致的 0.2 死区）
 			const float dz = 0.2f;
@@ -304,12 +324,60 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 			while (aim.y < -180.f) aim.y += 360.f;
 
 			cmd->viewangles.x = aim.x;   // pitch
-			cmd->viewangles.y = aim.y;   // yaw
-			cmd->viewangles.z = 0.f;     // roll 一般不用
-		}
-	}
+                        cmd->viewangles.y = aim.y;   // yaw
+                        cmd->viewangles.z = 0.f;     // roll 一般不用
+                }
+        }
 
-	return result;
+        static bool bunnyHopToggled = false;
+
+        const bool bunnyHopPressed = m_VR->m_IsVREnabled ? m_VR->PressedDigitalAction(m_VR->m_ActionBunnyHop, true) : false;
+        const bool bunnyHopHeld = m_VR->m_IsVREnabled ? m_VR->PressedDigitalAction(m_VR->m_ActionBunnyHop) : false;
+
+        if (!m_Game->m_EngineClient->IsInGame())
+        {
+                bunnyHopToggled = false;
+        }
+        else if (bunnyHopPressed)
+        {
+                bunnyHopToggled = !bunnyHopToggled;
+        }
+
+        if ((bunnyHopHeld || bunnyHopToggled) && m_Game->m_EngineClient->IsInGame())
+        {
+                const int playerIndex = m_Game->m_EngineClient->GetLocalPlayer();
+                auto* localPlayer = static_cast<C_BasePlayer*>(m_Game->GetClientEntity(playerIndex));
+
+                if (localPlayer)
+                {
+                        // 覆盖玩家输入，避免影响自动加速逻辑
+                        cmd->buttons &= ~(kInForward | kInBack | kInMoveLeft | kInMoveRight);
+                        cmd->forwardmove = 0.f;
+                        cmd->sidemove = 0.f;
+
+                        const bool onGround = localPlayer->m_hGroundEntity != -1;
+
+                        if (onGround)
+                        {
+                                cmd->buttons |= kInJump;
+                        }
+                        else
+                        {
+                                static bool strafeRight = false;
+                                strafeRight = !strafeRight;
+
+                                cmd->sidemove = strafeRight ? 450.f : -450.f;
+
+                                const float speed = std::max(localPlayer->m_vecVelocity.Length2D(), 0.01f);
+                                const float idealTurn = std::clamp(30.f / speed, 0.5f, 5.f);
+                                const float yawDelta = strafeRight ? idealTurn : -idealTurn;
+
+                                cmd->viewangles.y = NormalizeYaw(cmd->viewangles.y + yawDelta);
+                        }
+                }
+        }
+
+        return result;
 }
 
 void __fastcall Hooks::dEndFrame(void* ecx, void* edx)

--- a/L4D2VR/sdk/vector.h
+++ b/L4D2VR/sdk/vector.h
@@ -302,6 +302,21 @@ inline vec_t Vector::operator[](int i) const
 	return ((vec_t *)this)[i];
 }
 
+inline vec_t Vector::Length() const
+{
+	return static_cast<vec_t>(sqrt(x * x + y * y + z * z));
+}
+
+inline vec_t Vector::Length2D(void) const
+{
+	return static_cast<vec_t>(sqrt(x * x + y * y));
+}
+
+inline vec_t Vector::Length2DSqr(void) const
+{
+	return (x * x + y * y);
+}
+
 class VectorByValue : public Vector
 {
 public:

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -168,6 +168,7 @@ int VR::SetActionManifest(const char* fileName)
     m_Input->GetActionHandle("/actions/main/in/ResetPosition", &m_ActionResetPosition);
     m_Input->GetActionHandle("/actions/main/in/Crouch", &m_ActionCrouch);
     m_Input->GetActionHandle("/actions/main/in/Flashlight", &m_ActionFlashlight);
+    m_Input->GetActionHandle("/actions/main/in/BunnyHop", &m_ActionBunnyHop);
     m_Input->GetActionHandle("/actions/main/in/MenuSelect", &m_MenuSelect);
     m_Input->GetActionHandle("/actions/main/in/MenuBack", &m_MenuBack);
     m_Input->GetActionHandle("/actions/main/in/MenuUp", &m_MenuUp);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -244,14 +244,15 @@ public:
 	vr::VRActionHandle_t m_ActionUse;
 	vr::VRActionHandle_t m_ActionNextItem;
 	vr::VRActionHandle_t m_ActionPrevItem;
-	vr::VRActionHandle_t m_ActionResetPosition;
-	vr::VRActionHandle_t m_ActionCrouch;
-	vr::VRActionHandle_t m_ActionFlashlight;
-	vr::VRActionHandle_t m_ActionActivateVR;
-	vr::VRActionHandle_t m_MenuSelect;
-	vr::VRActionHandle_t m_MenuBack;
-	vr::VRActionHandle_t m_MenuUp;
-	vr::VRActionHandle_t m_MenuDown;
+        vr::VRActionHandle_t m_ActionResetPosition;
+        vr::VRActionHandle_t m_ActionCrouch;
+        vr::VRActionHandle_t m_ActionFlashlight;
+        vr::VRActionHandle_t m_ActionBunnyHop;
+        vr::VRActionHandle_t m_ActionActivateVR;
+        vr::VRActionHandle_t m_MenuSelect;
+        vr::VRActionHandle_t m_MenuBack;
+        vr::VRActionHandle_t m_MenuUp;
+        vr::VRActionHandle_t m_MenuDown;
 	vr::VRActionHandle_t m_MenuLeft;
 	vr::VRActionHandle_t m_MenuRight;
         vr::VRActionHandle_t m_Spray;
@@ -322,12 +323,12 @@ public:
         int m_InventoryAnchorColorB = 255;
         int m_InventoryAnchorColorA = 64;
 
-	bool m_ForceNonVRServerMovement = false;
-	bool m_RequireSecondaryAttackForItemSwitch = true;
-	struct RgbColor
-	{
-		int r;
-		int g;
+        bool m_ForceNonVRServerMovement = false;
+        bool m_RequireSecondaryAttackForItemSwitch = true;
+        struct RgbColor
+        {
+                int r;
+                int g;
 		int b;
 	};
 


### PR DESCRIPTION
## Summary
- add a toggle state for the BunnyHop action so short presses latch the auto bunny-hop logic
- reset the toggle when leaving a game and keep holding behavior working when the action is held

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d507b6adc83219353980dad51dd42)