### PR TITLE
Improve left swing gesture detection

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1881,7 +1881,9 @@ void VR::UpdateMotionGestures(C_BasePlayer* localPlayer)
         ? leftForwardHorizontal / leftForwardHorizontalLength
         : Vector(0.0f, 0.0f, 0.0f);
 
-    const float leftOutwardSpeed = std::max(0.0f, DotProduct(leftDelta, leftForwardHorizontalNorm)) / deltaSeconds;
+    const float leftOutwardHorizontalSpeed = std::max(0.0f, DotProduct(leftDelta, leftForwardHorizontalNorm)) / deltaSeconds;
+    const float leftHorizontalSpeed = VectorLength(Vector(leftDelta.x, leftDelta.y, 0.0f)) / deltaSeconds;
+    const float leftOutwardSpeed = leftForwardHorizontalLength > 0.01f ? leftOutwardHorizontalSpeed : leftHorizontalSpeed;
     const float rightDownSpeed = (-rightDelta.z) / deltaSeconds;
     const float hmdVerticalSpeed = hmdDelta.z / deltaSeconds;
 


### PR DESCRIPTION
## Summary
- add a fallback for the left swing gesture that uses controller horizontal speed when the forward horizontal vector is too small
- keep motion gesture thresholds unchanged while improving recognition for flat forward swings

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69423ed27c9c83219004a2892f06eb4c)