### PR TITLE
Use controller aim for client prediction even when forcing non‑VR server movement

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -358,12 +358,18 @@ int Hooks::dClientFireTerrorBullets(int playerId, const Vector& vecOrigin, const
 	QAngle vecNewAngles = vecAngles;
 
 	// 只有当本局服务器端确实运行了 VR 钩子时，才用控制器射线做本地预测
-	if (m_VR->m_IsVREnabled
-		&& !m_VR->m_ForceNonVRServerMovement
-		&& playerId == m_Game->m_EngineClient->GetLocalPlayer())
+	if (m_VR->m_IsVREnabled && playerId == m_Game->m_EngineClient->GetLocalPlayer())
 	{
-		vecNewOrigin = m_VR->GetRightControllerAbsPos();
-		vecNewAngles = m_VR->GetRightControllerAbsAngle();
+		if (!m_VR->m_ForceNonVRServerMovement)
+		{
+			vecNewOrigin = m_VR->GetRightControllerAbsPos();
+			vecNewAngles = m_VR->GetRightControllerAbsAngle();
+		}
+		else
+		{
+			// 非 VR 服务器：服务器仍以常规射线起点为准，但视角需要跟随控制器
+			vecNewAngles = m_VR->GetRightControllerAbsAngle();
+		}
 	}
 
 	return hkClientFireTerrorBullets.fOriginal(playerId, vecNewOrigin, vecNewAngles, a4, a5, a6, a7);


### PR DESCRIPTION
### Motivation
- Players reported much wider bullet spread when `ForceNonVRServerMovement=true` compared to `false`.
- Investigation showed client prediction and usercmd encoding are disabled for the VR controller path when forcing non‑VR server movement, causing prediction to use non‑controller angles and feel inaccurate.
- The change aims to keep local aim/prediction aligned with the controller direction even when the server is being treated as a non‑VR server, reducing perceived spread.

### Description
- Modified `L4D2VR/hooks.cpp` in `Hooks::dClientFireTerrorBullets`.
- Behavior before: local prediction used controller origin/angles only when `!m_VR->m_ForceNonVRServerMovement`.
- New behavior: when `m_VR->m_IsVREnabled` and the `playerId` is the local player, the client will always use the controller angles (`GetRightControllerAbsAngle()`) for local prediction; the origin (`GetRightControllerAbsPos()`) is still only applied when `!m_ForceNonVRServerMovement` to preserve non‑VR server origin behavior.
- Added a comment explaining the rationale for keeping the non‑VR origin but aligning the aim direction with the controller.

### Testing
- No automated tests were run on this change.
- Manual runtime/compile verification was not requested; please build and test in your environment (pay special attention to client prediction and multiplayer behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944e8a959a48321a51a31bdf8d6eedf)