### PR TITLE
Force right controller aim during special-infected blind-spot warnings

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -368,6 +368,8 @@ public:
         float m_SpecialInfectedWarningPostAttackDelay = 0.1f;
         float m_SpecialInfectedWarningJumpHoldDuration = 0.2f;
         bool m_SpecialInfectedWarningActionEnabled = false;
+        Vector m_SpecialInfectedWarningTarget = { 0.0f, 0.0f, 0.0f };
+        bool m_SpecialInfectedWarningTargetActive = false;
         bool m_SuppressPlayerInput = false;
         enum class SpecialInfectedWarningActionStep
         {


### PR DESCRIPTION
### Motivation
- Blind-spot warning currently triggers an automatic `attack2`/`jump` sequence but does not ensure the right controller is aimed at the special infected, which can make the action ineffective.
- Ensure the right-hand controller is forcibly aimed at the detected special infected while the blind-spot warning/action is active so push/attack actions align with the target.
- Keep the change scoped to the existing warning/action pipeline and rendering/hooks already used for special infected detection.

### Description
- Added per-warning target state to `VR`:
  - `m_SpecialInfectedWarningTarget` and `m_SpecialInfectedWarningTargetActive` in `L4D2VR/vr.h`.
- When a blind-spot warning is refreshed, store the infected world position (`RefreshSpecialInfectedBlindSpotWarning`) and mark the target active.
- During tracking update (`UpdateTracking` / controller smoothing code in `L4D2VR/vr.cpp`), if the warning action is enabled/active and the target is active, compute a direction from the right controller to the target and overwrite the right controller forward/right/up vectors so the controller is aimed at the target before aiming/attack logic runs.
- Clear the forced-target state when the blind-spot warning expires in `UpdateSpecialInfectedWarningState`.
- Files changed: `L4D2VR/vr.h`, `L4D2VR/vr.cpp`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ec74a3308321b0f39396abbb596d)