### PR TITLE
Force right-hand aim during special-infected pre-warning and blind-spot warnings

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -40,6 +40,8 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 # Any combo can be disabled by setting it to "false".
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
+SpecialInfectedPreWarningDistance=450.0
+SpecialInfectedPreWarningDuration=2.0
 # Console commands executed when pressing the custom SteamVR bindings (leave empty to disable)
 # Prefix a value with "key:" to send a keyboard key instead of a console command (e.g. key:space, key:f5, key:k)
 CustomAction1Command=

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -686,6 +686,7 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
 		if (infectedType != VR::SpecialInfectedType::None)
 		{
+			m_VR->RefreshSpecialInfectedPreWarning(info.origin);
 			m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
 			m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
 		}

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1771,6 +1771,26 @@ void VR::UpdateTracking()
     m_RightControllerForward = VectorRotate(m_RightControllerForward, m_RightControllerRight, -45.0);
     m_RightControllerUp = VectorRotate(m_RightControllerUp, m_RightControllerRight, -45.0);
 
+    const bool shouldForceBlindSpotAim = m_SpecialInfectedWarningActionEnabled
+        && m_SpecialInfectedBlindSpotWarningActive
+        && m_SpecialInfectedWarningTargetActive;
+    const bool shouldForcePreWarningAim = m_SpecialInfectedPreWarningActive && !shouldForceBlindSpotAim;
+    const bool shouldForceAim = shouldForceBlindSpotAim || shouldForcePreWarningAim;
+    const Vector forcedTarget = shouldForceBlindSpotAim ? m_SpecialInfectedWarningTarget : m_SpecialInfectedPreWarningTarget;
+
+    if (shouldForceAim)
+    {
+        Vector toTarget = forcedTarget - m_RightControllerPosAbs;
+        if (!toTarget.IsZero())
+        {
+            VectorNormalize(toTarget);
+
+            QAngle forcedAngles;
+            QAngle::VectorAngles(toTarget, m_HmdUp, forcedAngles);
+            QAngle::AngleVectors(forcedAngles, &m_RightControllerForward, &m_RightControllerRight, &m_RightControllerUp);
+        }
+    }
+
     UpdateAimingLaser(localPlayer);
 
     // controller angles
@@ -1926,6 +1946,7 @@ void VR::UpdateMotionGestures(C_BasePlayer* localPlayer)
 void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
 {
     UpdateSpecialInfectedWarningState();
+    UpdateSpecialInfectedPreWarningState();
 
     if (!m_Game->m_DebugOverlay)
         return;
@@ -2326,6 +2347,9 @@ void VR::RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin)
     if (!IsSpecialInfectedInBlindSpot(infectedOrigin))
         return;
 
+    m_SpecialInfectedWarningTarget = infectedOrigin;
+    m_SpecialInfectedWarningTargetActive = true;
+
     const bool wasActive = m_SpecialInfectedBlindSpotWarningActive;
     m_SpecialInfectedBlindSpotWarningActive = true;
     m_LastSpecialInfectedWarningTime = std::chrono::steady_clock::now();
@@ -2349,16 +2373,70 @@ bool VR::IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const
     return toInfected.LengthSqr() <= maxDistanceSq;
 }
 
+void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin)
+{
+    if (m_SpecialInfectedPreWarningDistance <= 0.0f)
+        return;
+
+    Vector toInfected = infectedOrigin - m_HmdPosAbs;
+    toInfected.z = 0.0f;
+    if (toInfected.IsZero())
+        return;
+
+    const float maxDistanceSq = m_SpecialInfectedPreWarningDistance * m_SpecialInfectedPreWarningDistance;
+    const bool inRange = toInfected.LengthSqr() <= maxDistanceSq;
+    const auto now = std::chrono::steady_clock::now();
+
+    if (inRange)
+    {
+        m_SpecialInfectedPreWarningTarget = infectedOrigin;
+        m_SpecialInfectedPreWarningActive = true;
+        m_SpecialInfectedPreWarningEndTime = now
+            + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                std::chrono::duration<float>(m_SpecialInfectedPreWarningDuration));
+        m_SpecialInfectedPreWarningInRange = true;
+        m_LastSpecialInfectedPreWarningSeenTime = now;
+        return;
+    }
+
+    m_SpecialInfectedPreWarningInRange = false;
+}
+
 void VR::UpdateSpecialInfectedWarningState()
 {
     if (!m_SpecialInfectedBlindSpotWarningActive)
+    {
+        m_SpecialInfectedWarningTargetActive = false;
         return;
+    }
 
     const auto now = std::chrono::steady_clock::now();
     const auto elapsedSeconds = std::chrono::duration<float>(now - m_LastSpecialInfectedWarningTime).count();
 
     if (elapsedSeconds > m_SpecialInfectedBlindSpotWarningDuration)
+    {
         m_SpecialInfectedBlindSpotWarningActive = false;
+        m_SpecialInfectedWarningTargetActive = false;
+    }
+}
+
+void VR::UpdateSpecialInfectedPreWarningState()
+{
+    const auto now = std::chrono::steady_clock::now();
+    const float seenTimeout = 0.1f;
+
+    if (m_SpecialInfectedPreWarningInRange)
+    {
+        const auto elapsed = std::chrono::duration<float>(now - m_LastSpecialInfectedPreWarningSeenTime).count();
+        if (elapsed > seenTimeout)
+            m_SpecialInfectedPreWarningInRange = false;
+    }
+
+    if (!m_SpecialInfectedPreWarningActive)
+        return;
+
+    if (now >= m_SpecialInfectedPreWarningEndTime)
+        m_SpecialInfectedPreWarningActive = false;
 }
 
 void VR::StartSpecialInfectedWarningAction()
@@ -3126,6 +3204,8 @@ void VR::ParseConfigFile()
     m_SpecialInfectedArrowHeight = std::max(0.0f, getFloat("SpecialInfectedArrowHeight", m_SpecialInfectedArrowHeight));
     m_SpecialInfectedArrowThickness = std::max(0.0f, getFloat("SpecialInfectedArrowThickness", m_SpecialInfectedArrowThickness));
     m_SpecialInfectedBlindSpotDistance = std::max(0.0f, getFloat("SpecialInfectedBlindSpotDistance", m_SpecialInfectedBlindSpotDistance));
+    m_SpecialInfectedPreWarningDistance = std::max(0.0f, getFloat("SpecialInfectedPreWarningDistance", m_SpecialInfectedPreWarningDistance));
+    m_SpecialInfectedPreWarningDuration = std::max(0.0f, getFloat("SpecialInfectedPreWarningDuration", m_SpecialInfectedPreWarningDuration));
     m_SpecialInfectedWarningSecondaryHoldDuration = std::max(0.0f, getFloat("SpecialInfectedWarningSecondaryHoldDuration", m_SpecialInfectedWarningSecondaryHoldDuration));
     m_SpecialInfectedWarningPostAttackDelay = std::max(0.0f, getFloat("SpecialInfectedWarningPostAttackDelay", m_SpecialInfectedWarningPostAttackDelay));
     m_SpecialInfectedWarningJumpHoldDuration = std::max(0.0f, getFloat("SpecialInfectedWarningJumpHoldDuration", m_SpecialInfectedWarningJumpHoldDuration));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -368,6 +368,15 @@ public:
         float m_SpecialInfectedWarningPostAttackDelay = 0.1f;
         float m_SpecialInfectedWarningJumpHoldDuration = 0.2f;
         bool m_SpecialInfectedWarningActionEnabled = false;
+        float m_SpecialInfectedPreWarningDistance = 450.0f;
+        float m_SpecialInfectedPreWarningDuration = 2.0f;
+        bool m_SpecialInfectedPreWarningActive = false;
+        bool m_SpecialInfectedPreWarningInRange = false;
+        Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
+        std::chrono::steady_clock::time_point m_SpecialInfectedPreWarningEndTime{};
+        std::chrono::steady_clock::time_point m_LastSpecialInfectedPreWarningSeenTime{};
+        Vector m_SpecialInfectedWarningTarget = { 0.0f, 0.0f, 0.0f };
+        bool m_SpecialInfectedWarningTargetActive = false;
         bool m_SuppressPlayerInput = false;
         enum class SpecialInfectedWarningActionStep
         {
@@ -445,9 +454,11 @@ public:
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
         SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
         void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
+        void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin);
         void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
         bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;
         void UpdateSpecialInfectedWarningState();
+        void UpdateSpecialInfectedPreWarningState();
         void StartSpecialInfectedWarningAction();
         void UpdateSpecialInfectedWarningAction();
         void ResetSpecialInfectedWarningAction();


### PR DESCRIPTION
### Motivation
- Blind-spot auto-evade (`attack2`/`jump`) can fail if the right controller isn't pointed at the special infected; force aim so those actions align with the target.
- Add a larger, non-action pre-warning radius that briefly (configurable, default 2s) forces the right controller to point at nearby special infected so the player has time to react.
- Keep behavior localized to existing detection/render hooks and the VR tracking/update pipeline; pre-warning must not trigger the auto-evade action sequence.

### Description
- Added configuration and runtime state:
  - New config keys: `SpecialInfectedPreWarningDistance` and `SpecialInfectedPreWarningDuration` (defaults added to `L4D2VR/config.txt`).
  - New state variables in `VR` (`L4D2VR/vr.h`) to track pre-warning target, timers and flags.
- Detection / hook changes:
  - Call `RefreshSpecialInfectedPreWarning` from `Hooks::dDrawModelExecute` alongside the existing blind-spot refresh so pre-warning is updated when models are drawn.
- Aim override implementation:
  - Implemented `RefreshSpecialInfectedPreWarning` and `UpdateSpecialInfectedPreWarningState` in `L4D2VR/vr.cpp`.
  - Integrated forced-aim logic into the controller tracking path so the right controller forward/right/up vectors are overridden to point at the pre-warning or blind-spot target (blind-spot aim takes priority).
  - Pre-warning locks and follows the target for the full configured duration (default 2s) and refreshes while the special infected remains in range.
- Config parsing:
  - `ParseConfigFile` now reads `SpecialInfectedPreWarningDistance` and `SpecialInfectedPreWarningDuration` so behavior can be tuned via `VR/config.txt`.
- Safety/behavior notes:
  - Pre-warning only forces aim and does not trigger the existing auto-evade action sequence; blind-spot warnings still trigger auto-actions as before.

### Testing
- Automated tests: none were run.
- Runtime/manual: no runtime validation (no manual playtest or logs included with this change).
- Notes: changes are limited to `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, `L4D2VR/hooks.cpp`, and `L4D2VR/config.txt`; please run a build and in-game test to verify the forced-aim timing and to tune `SpecialInfectedPreWarningDistance`/`SpecialInfectedPreWarningDuration` as desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ec74a3308321b0f39396abbb596d)