### PR TITLE
Toggleable pre-warning auto-aim + force right-controller aim for blind-spot

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -40,6 +40,8 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 # Any combo can be disabled by setting it to "false".
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
+SpecialInfectedPreWarningAutoAimEnabled=false
+SpecialInfectedPreWarningDistance=450.0
 # Console commands executed when pressing the custom SteamVR bindings (leave empty to disable)
 # Prefix a value with "key:" to send a keyboard key instead of a console command (e.g. key:space, key:f5, key:k)
 CustomAction1Command=

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -686,6 +686,7 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
 		if (infectedType != VR::SpecialInfectedType::None)
 		{
+			m_VR->RefreshSpecialInfectedPreWarning(info.origin);
 			m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
 			m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
 		}

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1241,6 +1241,7 @@ void VR::ProcessInput()
         else
         {
             m_CrouchToggleActive = !m_CrouchToggleActive;
+            m_SpecialInfectedPreWarningAutoAimEnabled = !m_SpecialInfectedPreWarningAutoAimEnabled;
             ResetPosition();
         }
     }
@@ -1771,6 +1772,26 @@ void VR::UpdateTracking()
     m_RightControllerForward = VectorRotate(m_RightControllerForward, m_RightControllerRight, -45.0);
     m_RightControllerUp = VectorRotate(m_RightControllerUp, m_RightControllerRight, -45.0);
 
+    const bool shouldForceBlindSpotAim = m_SpecialInfectedWarningActionEnabled
+        && m_SpecialInfectedBlindSpotWarningActive
+        && m_SpecialInfectedWarningTargetActive;
+    const bool shouldForcePreWarningAim = m_SpecialInfectedPreWarningActive && !shouldForceBlindSpotAim;
+    const bool shouldForceAim = shouldForceBlindSpotAim || shouldForcePreWarningAim;
+    const Vector forcedTarget = shouldForceBlindSpotAim ? m_SpecialInfectedWarningTarget : m_SpecialInfectedPreWarningTarget;
+
+    if (shouldForceAim)
+    {
+        Vector toTarget = forcedTarget - m_RightControllerPosAbs;
+        if (!toTarget.IsZero())
+        {
+            VectorNormalize(toTarget);
+
+            QAngle forcedAngles;
+            QAngle::VectorAngles(toTarget, m_HmdUp, forcedAngles);
+            QAngle::AngleVectors(forcedAngles, &m_RightControllerForward, &m_RightControllerRight, &m_RightControllerUp);
+        }
+    }
+
     UpdateAimingLaser(localPlayer);
 
     // controller angles
@@ -1926,6 +1947,7 @@ void VR::UpdateMotionGestures(C_BasePlayer* localPlayer)
 void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
 {
     UpdateSpecialInfectedWarningState();
+    UpdateSpecialInfectedPreWarningState();
 
     if (!m_Game->m_DebugOverlay)
         return;
@@ -2326,6 +2348,9 @@ void VR::RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin)
     if (!IsSpecialInfectedInBlindSpot(infectedOrigin))
         return;
 
+    m_SpecialInfectedWarningTarget = infectedOrigin;
+    m_SpecialInfectedWarningTargetActive = true;
+
     const bool wasActive = m_SpecialInfectedBlindSpotWarningActive;
     m_SpecialInfectedBlindSpotWarningActive = true;
     m_LastSpecialInfectedWarningTime = std::chrono::steady_clock::now();
@@ -2349,16 +2374,71 @@ bool VR::IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const
     return toInfected.LengthSqr() <= maxDistanceSq;
 }
 
+void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin)
+{
+    if (m_SpecialInfectedPreWarningDistance <= 0.0f || !m_SpecialInfectedPreWarningAutoAimEnabled)
+        return;
+
+    Vector toInfected = infectedOrigin - m_HmdPosAbs;
+    toInfected.z = 0.0f;
+    if (toInfected.IsZero())
+        return;
+
+    const float maxDistanceSq = m_SpecialInfectedPreWarningDistance * m_SpecialInfectedPreWarningDistance;
+    const bool inRange = toInfected.LengthSqr() <= maxDistanceSq;
+    const auto now = std::chrono::steady_clock::now();
+
+    if (inRange)
+    {
+        m_SpecialInfectedPreWarningTarget = infectedOrigin;
+        m_SpecialInfectedPreWarningActive = true;
+        m_SpecialInfectedPreWarningInRange = true;
+        m_LastSpecialInfectedPreWarningSeenTime = now;
+        return;
+    }
+
+    m_SpecialInfectedPreWarningInRange = false;
+}
+
 void VR::UpdateSpecialInfectedWarningState()
 {
     if (!m_SpecialInfectedBlindSpotWarningActive)
+    {
+        m_SpecialInfectedWarningTargetActive = false;
         return;
+    }
 
     const auto now = std::chrono::steady_clock::now();
     const auto elapsedSeconds = std::chrono::duration<float>(now - m_LastSpecialInfectedWarningTime).count();
 
     if (elapsedSeconds > m_SpecialInfectedBlindSpotWarningDuration)
+    {
         m_SpecialInfectedBlindSpotWarningActive = false;
+        m_SpecialInfectedWarningTargetActive = false;
+    }
+}
+
+void VR::UpdateSpecialInfectedPreWarningState()
+{
+    if (!m_SpecialInfectedPreWarningAutoAimEnabled)
+    {
+        m_SpecialInfectedPreWarningActive = false;
+        m_SpecialInfectedPreWarningInRange = false;
+        return;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    const float seenTimeout = 0.1f;
+
+    if (m_SpecialInfectedPreWarningInRange)
+    {
+        const auto elapsed = std::chrono::duration<float>(now - m_LastSpecialInfectedPreWarningSeenTime).count();
+        if (elapsed > seenTimeout)
+            m_SpecialInfectedPreWarningInRange = false;
+    }
+
+    if (m_SpecialInfectedPreWarningActive && !m_SpecialInfectedPreWarningInRange)
+        m_SpecialInfectedPreWarningActive = false;
 }
 
 void VR::StartSpecialInfectedWarningAction()
@@ -2445,6 +2525,12 @@ void VR::GetAimLineColor(int& r, int& g, int& b, int& a) const
         r = m_AimLineWarningColorR;
         g = m_AimLineWarningColorG;
         b = m_AimLineWarningColorB;
+    }
+    else if (m_SpecialInfectedPreWarningActive)
+    {
+        r = 0;
+        g = 255;
+        b = 0;
     }
     else
     {
@@ -3126,6 +3212,8 @@ void VR::ParseConfigFile()
     m_SpecialInfectedArrowHeight = std::max(0.0f, getFloat("SpecialInfectedArrowHeight", m_SpecialInfectedArrowHeight));
     m_SpecialInfectedArrowThickness = std::max(0.0f, getFloat("SpecialInfectedArrowThickness", m_SpecialInfectedArrowThickness));
     m_SpecialInfectedBlindSpotDistance = std::max(0.0f, getFloat("SpecialInfectedBlindSpotDistance", m_SpecialInfectedBlindSpotDistance));
+    m_SpecialInfectedPreWarningAutoAimEnabled = getBool("SpecialInfectedPreWarningAutoAimEnabled", m_SpecialInfectedPreWarningAutoAimEnabled);
+    m_SpecialInfectedPreWarningDistance = std::max(0.0f, getFloat("SpecialInfectedPreWarningDistance", m_SpecialInfectedPreWarningDistance));
     m_SpecialInfectedWarningSecondaryHoldDuration = std::max(0.0f, getFloat("SpecialInfectedWarningSecondaryHoldDuration", m_SpecialInfectedWarningSecondaryHoldDuration));
     m_SpecialInfectedWarningPostAttackDelay = std::max(0.0f, getFloat("SpecialInfectedWarningPostAttackDelay", m_SpecialInfectedWarningPostAttackDelay));
     m_SpecialInfectedWarningJumpHoldDuration = std::max(0.0f, getFloat("SpecialInfectedWarningJumpHoldDuration", m_SpecialInfectedWarningJumpHoldDuration));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -368,6 +368,14 @@ public:
         float m_SpecialInfectedWarningPostAttackDelay = 0.1f;
         float m_SpecialInfectedWarningJumpHoldDuration = 0.2f;
         bool m_SpecialInfectedWarningActionEnabled = false;
+        float m_SpecialInfectedPreWarningDistance = 450.0f;
+        bool m_SpecialInfectedPreWarningAutoAimEnabled = false;
+        bool m_SpecialInfectedPreWarningActive = false;
+        bool m_SpecialInfectedPreWarningInRange = false;
+        Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
+        std::chrono::steady_clock::time_point m_LastSpecialInfectedPreWarningSeenTime{};
+        Vector m_SpecialInfectedWarningTarget = { 0.0f, 0.0f, 0.0f };
+        bool m_SpecialInfectedWarningTargetActive = false;
         bool m_SuppressPlayerInput = false;
         enum class SpecialInfectedWarningActionStep
         {
@@ -445,9 +453,11 @@ public:
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
         SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
         void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
+        void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin);
         void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
         bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;
         void UpdateSpecialInfectedWarningState();
+        void UpdateSpecialInfectedPreWarningState();
         void StartSpecialInfectedWarningAction();
         void UpdateSpecialInfectedWarningAction();
         void ResetSpecialInfectedWarningAction();


### PR DESCRIPTION
### Motivation
- Blind-spot auto-evade (`attack2`/`jump`) can fail if the right controller isn't pointed at the special infected; forcing the right-controller aim improves effectiveness.  
- Provide a larger pre-warning radius that can optionally auto-aim toward nearby special infected so the player has time to react, but keep that feature opt-in.  
- Give visual feedback for pre-warning auto-aim (distinct aim-line color) and avoid changing blind-spot action behavior.  

### Description
- Config: added `SpecialInfectedPreWarningAutoAimEnabled` and `SpecialInfectedPreWarningDistance` to `L4D2VR/config.txt` and parsed them in `ParseConfigFile()` (`getBool`/`getFloat`).  
- Detection hook: call `RefreshSpecialInfectedPreWarning(info.origin)` from `Hooks::dDrawModelExecute` alongside existing blind-spot refresh so pre-warning targets update when models are drawn.  
- State & logic: implemented `RefreshSpecialInfectedPreWarning` and `UpdateSpecialInfectedPreWarningState` and keep a pre-warning target; pre-warning no longer uses a timed auto-lock — it is controlled by the config flag and by a crouch toggle.  
- Forced-aim: integrated an aim override into the controller update path so the right-controller forward/right/up vectors are overwritten to point at the pre-warning or blind-spot target (blind-spot takes priority). The crouch toggle flips `m_SpecialInfectedPreWarningAutoAimEnabled` in the crouch handling path.  
- Visual: `GetAimLineColor` now returns green when pre-warning auto-aim is active so the aim line visibly indicates pre-warning mode.  
- Files changed: `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, `L4D2VR/hooks.cpp`, `L4D2VR/config.txt`.

### Testing
- Automated tests: none were run.  
- Manual/runtime: no in-game playtest or automated run was performed as part of this change (please build and validate in-game to tune `SpecialInfectedPreWarningDistance` and confirm behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ec74a3308321b0f39396abbb596d)