### PR TITLE
Toggleable pre-warning auto-aim and force right-controller aim for special infected

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -40,6 +40,8 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 # Any combo can be disabled by setting it to "false".
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
+SpecialInfectedPreWarningAutoAimEnabled=false
+SpecialInfectedPreWarningDistance=450.0
 # Console commands executed when pressing the custom SteamVR bindings (leave empty to disable)
 # Prefix a value with "key:" to send a keyboard key instead of a console command (e.g. key:space, key:f5, key:k)
 CustomAction1Command=

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -686,6 +686,7 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
 		if (infectedType != VR::SpecialInfectedType::None)
 		{
+			m_VR->RefreshSpecialInfectedPreWarning(info.origin);
 			m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
 			m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
 		}

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -368,6 +368,15 @@ public:
         float m_SpecialInfectedWarningPostAttackDelay = 0.1f;
         float m_SpecialInfectedWarningJumpHoldDuration = 0.2f;
         bool m_SpecialInfectedWarningActionEnabled = false;
+        float m_SpecialInfectedPreWarningDistance = 450.0f;
+        bool m_SpecialInfectedPreWarningAutoAimConfigEnabled = false;
+        bool m_SpecialInfectedPreWarningAutoAimEnabled = false;
+        bool m_SpecialInfectedPreWarningActive = false;
+        bool m_SpecialInfectedPreWarningInRange = false;
+        Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
+        std::chrono::steady_clock::time_point m_LastSpecialInfectedPreWarningSeenTime{};
+        Vector m_SpecialInfectedWarningTarget = { 0.0f, 0.0f, 0.0f };
+        bool m_SpecialInfectedWarningTargetActive = false;
         bool m_SuppressPlayerInput = false;
         enum class SpecialInfectedWarningActionStep
         {
@@ -445,9 +454,11 @@ public:
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
         SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
         void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
+        void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin);
         void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
         bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;
         void UpdateSpecialInfectedWarningState();
+        void UpdateSpecialInfectedPreWarningState();
         void StartSpecialInfectedWarningAction();
         void UpdateSpecialInfectedWarningAction();
         void ResetSpecialInfectedWarningAction();


### PR DESCRIPTION
### Motivation
- Blind-spot auto-evade (`attack2`/`jump`) can fail if the right controller is not pointed at a special infected; forcing the right-controller aim improves effectiveness.
- Provide a larger, opt-in pre-warning radius that can auto-aim the right controller to nearby special infected so the player has time to react, but do not trigger auto-evade actions from pre-warning.
- Make the pre-warning auto-aim explicitly controllable via config and user crouch-toggle so players can enable/disable it at will.

### Description
- Added a pre-warning auto-aim feature and config keys in `VR/config.txt`: `SpecialInfectedPreWarningAutoAimEnabled` and `SpecialInfectedPreWarningDistance`.
- New/changed runtime state and functions in `VR`:
  - Added members: `m_SpecialInfectedPreWarningAutoAimConfigEnabled`, `m_SpecialInfectedPreWarningAutoAimEnabled`, `m_SpecialInfectedPreWarningTarget`, etc. (`L4D2VR/vr.h`).
  - Implemented `RefreshSpecialInfectedPreWarning` and `UpdateSpecialInfectedPreWarningState` in `L4D2VR/vr.cpp` and call them from the model-draw hook so pre-warning target follows moving infected.
  - Integrated forced-aim override into controller update logic (controller smoothing / tracking) so the right-controller `forward/right/up` vectors are overwritten to point at either the blind-spot target (priority) or the pre-warning target when active.
  - Changed aim line color to green while pre-warning auto-aim is active by updating `GetAimLineColor`.
  - Tied enabling/disabling of pre-warning auto-aim to the crouch toggle: when the player toggles crouch (`m_CrouchToggleActive`) the code flips `m_SpecialInfectedPreWarningAutoAimEnabled`, but only if the config gate `SpecialInfectedPreWarningAutoAimEnabled` is `true`; if config is `false` the feature is globally disabled.
- Hook update: `Hooks::dDrawModelExecute` now calls `RefreshSpecialInfectedPreWarning(info.origin)` alongside existing blind-spot handling so pre-warning is updated during model rendering.
- Files modified: `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, `L4D2VR/hooks.cpp`, `L4D2VR/config.txt`.

### Testing
- No automated tests were run for this change.
- Please build and perform an in-game playtest to validate behavior and tune `SpecialInfectedPreWarningDistance` and the config toggle: set `SpecialInfectedPreWarningAutoAimEnabled=true` to allow crouch-toggle to enable pre-warning auto-aim, set it to `false` to keep the feature globally off.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ec74a3308321b0f39396abbb596d)