### PR TITLE
Add opt-in pre-warning auto-aim with per‑SI aim offsets and config toggle

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -40,6 +40,16 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 # Any combo can be disabled by setting it to "false".
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
+SpecialInfectedPreWarningAutoAimEnabled=false
+SpecialInfectedPreWarningDistance=450.0
+SpecialInfectedPreWarningAimOffsetBoomer=0,0,0
+SpecialInfectedPreWarningAimOffsetSmoker=0,0,0
+SpecialInfectedPreWarningAimOffsetHunter=0,0,0
+SpecialInfectedPreWarningAimOffsetSpitter=0,0,0
+SpecialInfectedPreWarningAimOffsetJockey=0,0,0
+SpecialInfectedPreWarningAimOffsetCharger=0,0,0
+SpecialInfectedPreWarningAimOffsetTank=0,0,0
+SpecialInfectedPreWarningAimOffsetWitch=0,0,0
 # Console commands executed when pressing the custom SteamVR bindings (leave empty to disable)
 # Prefix a value with "key:" to send a keyboard key instead of a console command (e.g. key:space, key:f5, key:k)
 CustomAction1Command=

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -686,6 +686,7 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
 		if (infectedType != VR::SpecialInfectedType::None)
 		{
+			m_VR->RefreshSpecialInfectedPreWarning(info.origin, infectedType);
 			m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
 			m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
 		}

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -368,6 +368,25 @@ public:
         float m_SpecialInfectedWarningPostAttackDelay = 0.1f;
         float m_SpecialInfectedWarningJumpHoldDuration = 0.2f;
         bool m_SpecialInfectedWarningActionEnabled = false;
+        float m_SpecialInfectedPreWarningDistance = 450.0f;
+        bool m_SpecialInfectedPreWarningAutoAimConfigEnabled = false;
+        bool m_SpecialInfectedPreWarningAutoAimEnabled = false;
+        bool m_SpecialInfectedPreWarningActive = false;
+        bool m_SpecialInfectedPreWarningInRange = false;
+        Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
+        std::array<Vector, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedPreWarningAimOffsets{
+            Vector{ 0.0f, 0.0f, 0.0f }, // Boomer
+            Vector{ 0.0f, 0.0f, 0.0f }, // Smoker
+            Vector{ 0.0f, 0.0f, 0.0f }, // Hunter
+            Vector{ 0.0f, 0.0f, 0.0f }, // Spitter
+            Vector{ 0.0f, 0.0f, 0.0f }, // Jockey
+            Vector{ 0.0f, 0.0f, 0.0f }, // Charger
+            Vector{ 0.0f, 0.0f, 0.0f }, // Tank
+            Vector{ 0.0f, 0.0f, 0.0f }  // Witch
+        };
+        std::chrono::steady_clock::time_point m_LastSpecialInfectedPreWarningSeenTime{};
+        Vector m_SpecialInfectedWarningTarget = { 0.0f, 0.0f, 0.0f };
+        bool m_SpecialInfectedWarningTargetActive = false;
         bool m_SuppressPlayerInput = false;
         enum class SpecialInfectedWarningActionStep
         {
@@ -445,9 +464,11 @@ public:
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
         SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
         void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
+        void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type);
         void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
         bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;
         void UpdateSpecialInfectedWarningState();
+        void UpdateSpecialInfectedPreWarningState();
         void StartSpecialInfectedWarningAction();
         void UpdateSpecialInfectedWarningAction();
         void ResetSpecialInfectedWarningAction();


### PR DESCRIPTION
### Motivation
- Blind-spot shove/jump sequence can be ineffective if the right-controller is not aimed at the special infected; provide a safe, opt‑in pre-warning auto-aim that helps the player react without changing blind-spot auto-actions.
- Give per-special-infected tuning so different SI types can be aimed at with different height/side offsets.
- Make the feature explicitly controllable from `config.txt` and by the in-game crouch toggle (config must enable the feature for crouch toggle to matter).

### Description
- Added a new opt-in pre-warning auto-aim feature and per‑SI offsets:
  - New config keys in `VR/config.txt`: `SpecialInfectedPreWarningAutoAimEnabled` (global gate), `SpecialInfectedPreWarningDistance`, and per-type offsets `SpecialInfectedPreWarningAimOffset{Boomer,Smoker,Hunter,...}`.
  - New state and offsets stored on the `VR` object (`L4D2VR/vr.h`): `m_SpecialInfectedPreWarning*` members and `m_SpecialInfectedPreWarningAimOffsets` array.
- Hook & detection changes:
  - `Hooks::dDrawModelExecute` now calls `RefreshSpecialInfectedPreWarning(info.origin, infectedType)` (passes the detected SI type so the correct offset can be applied).
  - Implemented `RefreshSpecialInfectedPreWarning` and `UpdateSpecialInfectedPreWarningState` in `L4D2VR/vr.cpp` to update a pre-warning target that tracks moving SI when in range.
- Aim override & UI feedback:
  - While pre-warning auto-aim is active the right-controller `forward/right/up` vectors are overridden to aim at the pre-warning target (this is done in the controller tracking update path) so subsequent inputs line up with the SI.
  - The aim line color is tinted green when pre-warning auto-aim is active by updating `GetAimLineColor`.
- Controls & behavior:
  - The timed auto-lock behavior was removed; instead pre-warning auto-aim is only active while an SI is within `SpecialInfectedPreWarningDistance` and the feature is enabled.
  - Crouch toggle flips the in-game pre-warning auto-aim state only when the config gate `SpecialInfectedPreWarningAutoAimEnabled` is `true`; if the config gate is `false` the feature is globally disabled.
  - Blind-spot behavior (shove/jump auto-actions) is left intact, but blind-spot forced controller-aiming was removed so only pre-warning drives the aim override.
- Files changed (high level): `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, `L4D2VR/hooks.cpp`, `L4D2VR/config.txt`.

### Testing
- Automated tests: none were run for these changes.
- Please build and perform an in-game playtest to verify: the pre-warning distance/offset tuning, that the crouch toggle only enables auto-aim when the config gate is `true`, and that blind-spot shove/jump still behaves as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ec74a3308321b0f39396abbb596d)