### PR TITLE
Make special-infected auto-aim momentary on crouch-hold; ignore ragdolls

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -41,6 +41,7 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
 SpecialInfectedPreWarningAutoAimEnabled=false
+SpecialInfectedPreWarningAutoAimCrouchHoldDuration=0.6
 SpecialInfectedPreWarningDistance=450.0
 SpecialInfectedPreWarningAimOffsetBoomer=0,0,0
 SpecialInfectedPreWarningAimOffsetSmoker=0,0,0

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -686,9 +686,13 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
 		if (infectedType != VR::SpecialInfectedType::None)
 		{
-			m_VR->RefreshSpecialInfectedPreWarning(info.origin, infectedType);
-			m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
-			m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
+			const bool isRagdoll = modelName.find("ragdoll") != std::string::npos;
+			if (!isRagdoll)
+			{
+				m_VR->RefreshSpecialInfectedPreWarning(info.origin, infectedType);
+				m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
+				m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
+			}
 		}
 	}
 

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1163,6 +1163,32 @@ void VR::ProcessInput()
         crouchJustPressed = false;
     }
 
+    if (!crouchButtonDown)
+    {
+        m_SpecialInfectedPreWarningCrouchHoldActive = false;
+        if (m_SpecialInfectedPreWarningAutoAimEnabled)
+        {
+            m_SpecialInfectedPreWarningAutoAimEnabled = false;
+        }
+    }
+    else
+    {
+        if (!m_SpecialInfectedPreWarningCrouchHoldActive)
+        {
+            m_SpecialInfectedPreWarningCrouchHoldActive = true;
+            m_SpecialInfectedPreWarningCrouchHoldStart = currentTime;
+        }
+
+        if (m_SpecialInfectedPreWarningAutoAimConfigEnabled)
+        {
+            const float holdSeconds = std::chrono::duration<float>(currentTime - m_SpecialInfectedPreWarningCrouchHoldStart).count();
+            if (holdSeconds >= m_SpecialInfectedPreWarningAutoAimCrouchHoldDuration)
+            {
+                m_SpecialInfectedPreWarningAutoAimEnabled = true;
+            }
+        }
+    }
+
     if (primaryAttackDown)
     {
         m_Game->ClientCmd_Unrestricted("+attack");
@@ -1241,14 +1267,6 @@ void VR::ProcessInput()
         else
         {
             m_CrouchToggleActive = !m_CrouchToggleActive;
-            if (m_SpecialInfectedPreWarningAutoAimConfigEnabled)
-            {
-                m_SpecialInfectedPreWarningAutoAimEnabled = !m_SpecialInfectedPreWarningAutoAimEnabled;
-            }
-            else
-            {
-                m_SpecialInfectedPreWarningAutoAimEnabled = false;
-            }
             ResetPosition();
         }
     }
@@ -3226,6 +3244,7 @@ void VR::ParseConfigFile()
     m_SpecialInfectedPreWarningAutoAimConfigEnabled = getBool("SpecialInfectedPreWarningAutoAimEnabled", m_SpecialInfectedPreWarningAutoAimConfigEnabled);
     if (!m_SpecialInfectedPreWarningAutoAimConfigEnabled)
         m_SpecialInfectedPreWarningAutoAimEnabled = false;
+    m_SpecialInfectedPreWarningAutoAimCrouchHoldDuration = std::max(0.0f, getFloat("SpecialInfectedPreWarningAutoAimCrouchHoldDuration", m_SpecialInfectedPreWarningAutoAimCrouchHoldDuration));
     m_SpecialInfectedPreWarningDistance = std::max(0.0f, getFloat("SpecialInfectedPreWarningDistance", m_SpecialInfectedPreWarningDistance));
     m_SpecialInfectedWarningSecondaryHoldDuration = std::max(0.0f, getFloat("SpecialInfectedWarningSecondaryHoldDuration", m_SpecialInfectedWarningSecondaryHoldDuration));
     m_SpecialInfectedWarningPostAttackDelay = std::max(0.0f, getFloat("SpecialInfectedWarningPostAttackDelay", m_SpecialInfectedWarningPostAttackDelay));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -371,8 +371,11 @@ public:
         float m_SpecialInfectedPreWarningDistance = 450.0f;
         bool m_SpecialInfectedPreWarningAutoAimConfigEnabled = false;
         bool m_SpecialInfectedPreWarningAutoAimEnabled = false;
+        float m_SpecialInfectedPreWarningAutoAimCrouchHoldDuration = 0.6f;
         bool m_SpecialInfectedPreWarningActive = false;
         bool m_SpecialInfectedPreWarningInRange = false;
+        bool m_SpecialInfectedPreWarningCrouchHoldActive = false;
+        std::chrono::steady_clock::time_point m_SpecialInfectedPreWarningCrouchHoldStart{};
         Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
         std::array<Vector, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedPreWarningAimOffsets{
             Vector{ 0.0f, 0.0f, 0.0f }, // Boomer


### PR DESCRIPTION
### Motivation
- Reduce accidental flips by making Special Infected pre-warning auto-aim a deliberate crouch long-press that only remains active while held.
- Allow users to tune the hold threshold with a config value.
- Ensure auto-aim is cleared immediately when the player releases crouch.
- Avoid holding/locking onto dead infected by ignoring ragdoll models when refreshing warnings.

### Description
- Add a new config key: `SpecialInfectedPreWarningAutoAimCrouchHoldDuration` (default `0.6`) in `L4D2VR/config.txt` and parse it in `ParseConfigFile`.
- Add hold-tracking fields to `L4D2VR/vr.h`: `m_SpecialInfectedPreWarningAutoAimCrouchHoldDuration`, `m_SpecialInfectedPreWarningCrouchHoldActive`, and `m_SpecialInfectedPreWarningCrouchHoldStart`.
- Change `VR::ProcessInput` (`L4D2VR/vr.cpp`) to: start timing when crouch is pressed; enable `m_SpecialInfectedPreWarningAutoAimEnabled` only after the configured hold duration; and immediately disable it on release (momentary behavior). Also remove the old toggle-on-reset behavior so `ResetPosition()` no longer flips the auto-aim setting.
- Prevent ragdoll models from re-triggering/holding the lock by skipping `RefreshSpecialInfectedPreWarning`/arrow refresh for models whose name contains `"ragdoll"` in `Hooks::dDrawModelExecute` (`L4D2VR/hooks.cpp`).
- Modified files: `L4D2VR/vr.cpp`, `L4D2VR/vr.h`, `L4D2VR/hooks.cpp`, `L4D2VR/config.txt`.

### Testing
- Automated tests: none were run for these changes.
- (No automated test results to report.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945472ff25083218beaffbe77f41079)