### PR TITLE
Add configurable delay to special-infected pre-warning auto-aim

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -42,6 +42,7 @@ ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
 SpecialInfectedPreWarningAutoAimEnabled=false
 SpecialInfectedPreWarningAutoAimCrouchHoldDuration=0.6
+SpecialInfectedPreWarningAimDelay=0.0
 SpecialInfectedPreWarningDistance=450.0
 SpecialInfectedPreWarningAimOffsetBoomer=0,0,0
 SpecialInfectedPreWarningAimOffsetSmoker=0,0,0

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -5,6 +5,7 @@
 #include "vector.h"
 #include <array>
 #include <chrono>
+#include <deque>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -372,11 +373,13 @@ public:
         bool m_SpecialInfectedPreWarningAutoAimConfigEnabled = false;
         bool m_SpecialInfectedPreWarningAutoAimEnabled = false;
         float m_SpecialInfectedPreWarningAutoAimCrouchHoldDuration = 0.6f;
+        float m_SpecialInfectedPreWarningAimDelay = 0.0f;
         bool m_SpecialInfectedPreWarningActive = false;
         bool m_SpecialInfectedPreWarningInRange = false;
         bool m_SpecialInfectedPreWarningCrouchHoldActive = false;
         std::chrono::steady_clock::time_point m_SpecialInfectedPreWarningCrouchHoldStart{};
         Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
+        std::deque<std::pair<std::chrono::steady_clock::time_point, Vector>> m_SpecialInfectedPreWarningTargetHistory{};
         std::array<Vector, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedPreWarningAimOffsets{
             Vector{ 0.0f, 0.0f, 0.0f }, // Boomer
             Vector{ 0.0f, 0.0f, 0.0f }, // Smoker


### PR DESCRIPTION
### Motivation

- Provide a way to avoid instantaneous aim snaps when a special infected enters pre-warning range by introducing a fixed, configurable delay so the aim target can be sampled and applied with latency.
- Allow users to tune how the auto-aim target is applied via `config.txt` instead of forcing immediate snaps.

### Description

- Added a new config option `SpecialInfectedPreWarningAimDelay` (default `0.0`) to `L4D2VR/config.txt` and parsed it in `VR::ParseConfigFile()`.
- Implemented a time-buffered target history in `VR` to record pre-warning targets: added `m_SpecialInfectedPreWarningAimDelay` and `m_SpecialInfectedPreWarningTargetHistory` (`std::deque`) in `L4D2VR/vr.h` and included `<deque>`.
- When an infected enters range, push a timestamped target into the history (instead of immediately setting the forced target). In `UpdateSpecialInfectedPreWarningState()` the code trims history, samples/interpolates the buffered targets according to the configured delay, and assigns `m_SpecialInfectedPreWarningTarget` appropriately (supports zero-delay, delayed, and interpolated values).
- Clear the history when pre-warning is disabled or when the pre-warning ends to avoid stale entries. Changes applied across `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, and `L4D2VR/config.txt`.

### Testing

- No automated tests were run as part of this change.
- Changes were compiled/committed in the working tree (no runtime validation included in this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694551a7bdd083218e1fc9c247f0db6a)