### PR TITLE
Smooth special infected pre-warning auto-aim transitions

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -43,6 +43,7 @@ SpecialInfectedBlindSpotDistance=300.0
 SpecialInfectedPreWarningAutoAimEnabled=false
 SpecialInfectedPreWarningDistance=450.0
 SpecialInfectedPreWarningAimDelay=0.1
+SpecialInfectedPreWarningAimSmoothing=0.0
 SpecialInfectedPreWarningAimOffsetBoomer=0,0,0
 SpecialInfectedPreWarningAimOffsetSmoker=0,0,0
 SpecialInfectedPreWarningAimOffsetHunter=0,0,0

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -376,6 +376,9 @@ public:
         bool m_SpecialInfectedPreWarningActive = false;
         bool m_SpecialInfectedPreWarningInRange = false;
         float m_SpecialInfectedPreWarningAimDelay = 0.1f;
+        float m_SpecialInfectedPreWarningAimSmoothing = 0.0f;
+        Vector m_SpecialInfectedPreWarningSmoothedTarget = Vector(0.0f, 0.0f, 0.0f);
+        bool m_SpecialInfectedPreWarningSmoothedTargetValid = false;
         struct TimedPreWarningTarget
         {
                 std::chrono::steady_clock::time_point time;


### PR DESCRIPTION
### Motivation
- Prevent instant snapping when the special-infected pre-warning auto-aim switches targets; provide a smooth, configurable transition.
- Expose the smoothing parameter in `config.txt` so users can tune the interpolation time.
- Keep smoothing state in sync with auto-aim lifecycle so stale smoothing state doesn't cause jumps.

### Description
- Added a new config key `SpecialInfectedPreWarningAimSmoothing` (default `0.0`) to `L4D2VR/config.txt` and wired it into the config parser (`ParseConfigFile`) as `m_SpecialInfectedPreWarningAimSmoothing`.
- Added members to `vr.h`: `m_SpecialInfectedPreWarningAimSmoothing`, `m_SpecialInfectedPreWarningSmoothedTarget`, and `m_SpecialInfectedPreWarningSmoothedTargetValid` to track smoothing state.
- In `vr.cpp` (controller/aim update path) interpolate the forced pre-warning target towards the current target when smoothing is enabled. The interpolation factor is computed from `m_LastFrameDuration / m_SpecialInfectedPreWarningAimSmoothing` and clamped to [0,1]. If smoothing is disabled or auto-aim deactivates, the smoothed state is reset.
- Ensure smoothing state is cleared when pre-warning auto-aim is disabled or when the target goes out of range (`UpdateSpecialInfectedPreWarningState`).

### Testing
- No automated tests were run for this change.
- Change set was built/committed locally (no CI results available in this PR description).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694570db37f883219e86836d4abfc9ef)