### PR TITLE
Add SteamVR toggle action for Special Infected auto-aim (replace crouch-hold)

### DIFF
--- a/L4D2VR/SteamVRActionManifest/action_manifest.json
+++ b/L4D2VR/SteamVRActionManifest/action_manifest.json
@@ -90,6 +90,11 @@
 			"type": "boolean"
 		},
 		{
+			"name": "/actions/main/in/SpecialInfectedAutoAimToggle",
+			"type": "boolean",
+			"requirement": "optional"
+		},
+		{
 			"name": "/actions/main/in/ActivateVR",
 			"type": "boolean"
 		},
@@ -189,6 +194,7 @@
 			"/actions/main/in/ResetPosition" : "Reset Position",
 			"/actions/main/in/Crouch" : "Crouch",
 			"/actions/main/in/Flashlight" : "Flashlight",
+			"/actions/main/in/SpecialInfectedAutoAimToggle" : "Special Infected Auto Aim Toggle",
 			"/actions/main/in/ActivateVR" : "Activate VR",
 			"/actions/main/in/MenuSelect" : "Menu Select",
 			"/actions/main/in/MenuBack" : "Menu Back",

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -247,6 +247,7 @@ public:
 	vr::VRActionHandle_t m_ActionResetPosition;
 	vr::VRActionHandle_t m_ActionCrouch;
 	vr::VRActionHandle_t m_ActionFlashlight;
+	vr::VRActionHandle_t m_ActionSpecialInfectedAutoAimToggle;
 	vr::VRActionHandle_t m_ActionActivateVR;
 	vr::VRActionHandle_t m_MenuSelect;
 	vr::VRActionHandle_t m_MenuBack;
@@ -371,11 +372,8 @@ public:
 	float m_SpecialInfectedPreWarningDistance = 450.0f;
 	bool m_SpecialInfectedPreWarningAutoAimConfigEnabled = false;
 	bool m_SpecialInfectedPreWarningAutoAimEnabled = false;
-	float m_SpecialInfectedPreWarningAutoAimCrouchHoldDuration = 0.6f;
 	bool m_SpecialInfectedPreWarningActive = false;
 	bool m_SpecialInfectedPreWarningInRange = false;
-	bool m_SpecialInfectedPreWarningCrouchHoldActive = false;
-	std::chrono::steady_clock::time_point m_SpecialInfectedPreWarningCrouchHoldStart{};
 	Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
 	std::array<Vector, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedPreWarningAimOffsets{
 		Vector{ 0.0f, 0.0f, 0.0f }, // Boomer


### PR DESCRIPTION
### Motivation

- Replace the previous long-press-crouch trigger for Special Infected pre-warning auto-aim with a dedicated SteamVR button toggle so users can bind a discrete input for the feature.
- Move control of the auto-aim feature out of gesture/hold timing logic and into an explicit action so it is easier to configure per-controller via SteamVR bindings.

### Description

- Added a new SteamVR action `SpecialInfectedAutoAimToggle` to `action_manifest.json` and localization for the action name.
- Exposed a new action handle `m_ActionSpecialInfectedAutoAimToggle` in `vr.h` and obtained it in `SetActionManifest`.
- Read the new action state in `ProcessInput` and use `autoAimToggleJustPressed` to flip `m_SpecialInfectedPreWarningAutoAimEnabled` when the config option is enabled, removing the previous crouch-hold timing/hold-duration logic and members.
- Removed the config-based crouch-hold handshake (`m_SpecialInfectedPreWarningAutoAimCrouchHoldDuration`, hold start/active members) and simplified enablement checks to rely on the new toggle.

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460dd7c2e08321990f6d29a0e9f7ca)