### PR TITLE
Disable special infected auto-aim when line of sight is blocked

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -467,6 +467,7 @@ public:
 	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
 	void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type);
 	void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
+	bool HasLineOfSightToSpecialInfected(const Vector& infectedOrigin) const;
 	bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;
 	void UpdateSpecialInfectedWarningState();
 	void UpdateSpecialInfectedPreWarningState();


### PR DESCRIPTION
### Motivation
- Prevent the special infected pre-warning auto-aim from locking onto targets that are behind cover or otherwise not visible.
- Keep existing pre-warning timeout behavior so brief occlusions don't immediately clear state.

### Description
- Added a new method `HasLineOfSightToSpecialInfected` and declared it in `vr.h` to test visibility using `TraceRay`.
- Implemented LOS check in `RefreshSpecialInfectedPreWarning` to early-return when the infected is occluded, so auto-aim won't engage through obstacles.
- The change uses the right controller position (`m_RightControllerPosAbs`) as the ray origin and skips NPCs/players with `CTraceFilterSkipNPCsAndPlayers`.

### Testing
- No automated tests were executed as part of this change.
- Changes were compiled and committed locally (no CI results included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69460ef0f3c083219dac421b066ea28c)