### PR TITLE
Gate special infected auto-aim on firing

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -818,7 +818,10 @@ void VR::ProcessInput()
     UpdateSpecialInfectedWarningAction();
 
     if (m_SuppressPlayerInput)
+    {
+        m_PrimaryAttackDown = false;
         return;
+    }
 
     vr::InputAnalogActionData_t analogActionData;
 
@@ -964,6 +967,7 @@ void VR::ProcessInput()
     bool primaryAttackDown = false;
     bool primaryAttackJustPressed = false;
     getActionState(&m_ActionPrimaryAttack, primaryAttackActionData, primaryAttackDown, primaryAttackJustPressed);
+    m_PrimaryAttackDown = primaryAttackDown;
 
     vr::InputDigitalActionData_t crouchActionData{};
     bool crouchButtonDown = false;
@@ -1786,7 +1790,7 @@ void VR::UpdateTracking()
     m_RightControllerForward = VectorRotate(m_RightControllerForward, m_RightControllerRight, -45.0);
     m_RightControllerUp = VectorRotate(m_RightControllerUp, m_RightControllerRight, -45.0);
 
-    const bool shouldForceAim = m_SpecialInfectedPreWarningActive;
+    const bool shouldForceAim = m_SpecialInfectedPreWarningActive && m_PrimaryAttackDown;
     const Vector forcedTarget = m_SpecialInfectedPreWarningTarget;
 
     if (shouldForceAim)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -219,6 +219,7 @@ public:
 	bool m_CrouchToggleActive = false;
 	bool m_VoiceRecordActive = false;
 	bool m_QuickTurnTriggered = false;
+	bool m_PrimaryAttackDown = false;
 
 	struct ActionCombo
 	{


### PR DESCRIPTION
### Motivation

- Prevent the special-infected pre-warning auto-aim from constantly forcing aim when enabled and instead only apply it while the player is actively firing.
- Avoid surprising aim overrides during moments when player input is suppressed (e.g. scripted warnings/actions).

### Description

- Added a new per-frame state `m_PrimaryAttackDown` to `VR` to track whether the primary attack is currently held.
- Cleared `m_PrimaryAttackDown` when `m_SuppressPlayerInput` is set so suppressed frames do not keep the flag set.
- Updated input handling to set `m_PrimaryAttackDown` from the primary attack action state each frame via `getActionState`.
- Require `m_PrimaryAttackDown` in addition to `m_SpecialInfectedPreWarningActive` before forcing controller aim (i.e. gated the forced aim by `m_PrimaryAttackDown`).

### Testing

- No automated tests were executed for this change.
- The change is limited to input-state tracking and aim gating logic and should be safe to build and run in normal runtime tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694616994ea48321a91b4b7da720ba42)