### PR TITLE
Add SteamVR toggle for Non-VR server movement aim override

### DIFF
--- a/L4D2VR/SteamVRActionManifest/action_manifest.json
+++ b/L4D2VR/SteamVRActionManifest/action_manifest.json
@@ -141,6 +141,11 @@
                         "type": "boolean"
                 },
                 {
+                        "name": "/actions/main/in/NonVRServerMovementAngleToggle",
+                        "type": "boolean",
+                        "requirement": "optional"
+                },
+                {
                         "name": "/actions/main/in/CustomAction1",
                         "type": "boolean",
                         "requirement": "optional"
@@ -206,6 +211,7 @@
                         "/actions/main/in/Scoreboard" : "Show Scoreboard",
                         "/actions/main/in/ShowHUD" : "Show HUD",
                         "/actions/main/in/Pause" : "Pause",
+                        "/actions/main/in/NonVRServerMovementAngleToggle" : "Non-VR Server Movement Aim Override",
                         "/actions/main/in/CustomAction1" : "Custom Action 1",
                         "/actions/main/in/CustomAction2" : "Custom Action 2",
                         "/actions/main/in/CustomAction3" : "Custom Action 3",

--- a/L4D2VR/SteamVRActionManifest/bindings_knuckles.json
+++ b/L4D2VR/SteamVRActionManifest/bindings_knuckles.json
@@ -191,7 +191,7 @@
                "mode" : "button",
                "path" : "/user/hand/left/input/a"
             },
-			{
+            {
                "inputs" : {
                   "click" : {
                      "output" : "/actions/main/in/Pause"
@@ -199,6 +199,15 @@
                },
                "mode" : "button",
                "path" : "/user/hand/left/input/b"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/main/in/NonVRServerMovementAngleToggle"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/menu"
             },
             {
                "inputs" : {
@@ -233,4 +242,3 @@
    "options" : {},
    "simulated_actions" : []
 }
-

--- a/L4D2VR/SteamVRActionManifest/bindings_oculus_touch.json
+++ b/L4D2VR/SteamVRActionManifest/bindings_oculus_touch.json
@@ -186,7 +186,7 @@
                "mode" : "button",
                "path" : "/user/hand/left/input/x"
             },
-			{
+            {
                "inputs" : {
                   "click" : {
                      "output" : "/actions/main/in/Pause"
@@ -194,6 +194,15 @@
                },
                "mode" : "button",
                "path" : "/user/hand/left/input/y"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/main/in/NonVRServerMovementAngleToggle"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/menu"
             },
             {
                "inputs" : {
@@ -223,4 +232,3 @@
    "options" : {},
    "simulated_actions" : []
 }
-

--- a/L4D2VR/SteamVRActionManifest/bindings_vive_cosmos_controller.json
+++ b/L4D2VR/SteamVRActionManifest/bindings_vive_cosmos_controller.json
@@ -186,7 +186,7 @@
                "mode" : "button",
                "path" : "/user/hand/left/input/x"
             },
-			{
+            {
                "inputs" : {
                   "click" : {
                      "output" : "/actions/main/in/Pause"
@@ -194,6 +194,15 @@
                },
                "mode" : "button",
                "path" : "/user/hand/left/input/y"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/main/in/NonVRServerMovementAngleToggle"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/menu"
             },
             {
                "inputs" : {
@@ -223,4 +232,3 @@
    "options" : {},
    "simulated_actions" : []
 }
-

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -365,7 +365,7 @@ int Hooks::dClientFireTerrorBullets(int playerId, const Vector& vecOrigin, const
 			vecNewOrigin = m_VR->GetRightControllerAbsPos();
 			vecNewAngles = m_VR->GetRightControllerAbsAngle();
 		}
-		else
+		else if (m_VR->m_NonVRServerMovementAngleOverride)
 		{
 			// 非 VR 服务器：服务器仍以常规射线起点为准，但视角需要跟随控制器
 			vecNewAngles = m_VR->GetRightControllerAbsAngle();

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -179,6 +179,7 @@ int VR::SetActionManifest(const char* fileName)
     m_Input->GetActionHandle("/actions/main/in/Scoreboard", &m_Scoreboard);
     m_Input->GetActionHandle("/actions/main/in/ShowHUD", &m_ShowHUD);
     m_Input->GetActionHandle("/actions/main/in/Pause", &m_Pause);
+    m_Input->GetActionHandle("/actions/main/in/NonVRServerMovementAngleToggle", &m_NonVRServerMovementAngleToggle);
     m_Input->GetActionHandle("/actions/main/in/CustomAction1", &m_CustomAction1);
     m_Input->GetActionHandle("/actions/main/in/CustomAction2", &m_CustomAction2);
     m_Input->GetActionHandle("/actions/main/in/CustomAction3", &m_CustomAction3);
@@ -1002,6 +1003,11 @@ void VR::ProcessInput()
     bool autoAimToggleJustPressed = false;
     [[maybe_unused]] bool autoAimToggleDataValid = getActionState(&m_ActionSpecialInfectedAutoAimToggle, autoAimToggleActionData, autoAimToggleDown, autoAimToggleJustPressed);
 
+    vr::InputDigitalActionData_t nonVrServerMovementToggleActionData{};
+    [[maybe_unused]] bool nonVrServerMovementToggleDown = false;
+    bool nonVrServerMovementToggleJustPressed = false;
+    [[maybe_unused]] bool nonVrServerMovementToggleDataValid = getActionState(&m_NonVRServerMovementAngleToggle, nonVrServerMovementToggleActionData, nonVrServerMovementToggleDown, nonVrServerMovementToggleJustPressed);
+
     C_BasePlayer* localPlayer = nullptr;
     {
         const int playerIndex = m_Game->m_EngineClient->GetLocalPlayer();
@@ -1180,6 +1186,12 @@ void VR::ProcessInput()
     else if (autoAimToggleJustPressed)
     {
         m_SpecialInfectedPreWarningAutoAimEnabled = !m_SpecialInfectedPreWarningAutoAimEnabled;
+    }
+
+    if (nonVrServerMovementToggleJustPressed)
+    {
+        m_NonVRServerMovementAngleOverride = !m_NonVRServerMovementAngleOverride;
+        Game::logMsg("[VR] Non-VR server movement aim override %s", m_NonVRServerMovementAngleOverride ? "enabled" : "disabled");
     }
 
     if (primaryAttackDown)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -260,6 +260,7 @@ public:
 	vr::VRActionHandle_t m_Scoreboard;
 	vr::VRActionHandle_t m_ShowHUD;
 	vr::VRActionHandle_t m_Pause;
+	vr::VRActionHandle_t m_NonVRServerMovementAngleToggle;
 	vr::VRActionHandle_t m_CustomAction1;
 	vr::VRActionHandle_t m_CustomAction2;
 	vr::VRActionHandle_t m_CustomAction3;
@@ -325,6 +326,7 @@ public:
 	int m_InventoryAnchorColorA = 64;
 
 	bool m_ForceNonVRServerMovement = false;
+	bool m_NonVRServerMovementAngleOverride = false;
 	bool m_RequireSecondaryAttackForItemSwitch = true;
 	struct RgbColor
 	{


### PR DESCRIPTION
### Motivation
- Provide a runtime SteamVR-controlled switch to choose between the existing repo behavior and the user's original logic for client-side bullet aim when `ForceNonVRServerMovement` is enabled.
- Ensure the toggle is off by default so existing behavior does not change unless the user enables it.
- Allow local players to use controller-only view angle override on non-VR servers while preserving the ability to fully skip controller-based prediction.

### Description
- Added a new SteamVR action handle `m_NonVRServerMovementAngleToggle` and a boolean state `m_NonVRServerMovementAngleOverride` in `vr.h` to track the toggle (default `false`).
- Hooked the action in `VR::SetActionManifest` and read its press state in `VR::ProcessInput`, flipping `m_NonVRServerMovementAngleOverride` on just-presses and logging the change.
- Updated `Hooks::dClientFireTerrorBullets` in `hooks.cpp` to apply the repository "angle-only" behavior only when `m_VR->m_ForceNonVRServerMovement` is true and the new `m_NonVRServerMovementAngleOverride` is enabled, otherwise preserve the alternate logic.
- Added the new action to the SteamVR manifest and added bindings for Oculus Touch, Index (Knuckles), and Vive Cosmos controller presets to map the toggle to the left controller `menu` button.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69461e6ca9708321b01635c28f0aa985)