### PR TITLE
Use m_zombieClass netvar for special infected detection with entity-lookup guards and Tank/Witch fallback

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -683,7 +683,14 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 	{
 		modelName = m_Game->m_ModelInfo->GetModelName(info.pModel);
 
-		const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
+		const C_BaseEntity* entity = nullptr;
+		if (m_Game->m_ClientEntityList && info.entity_index > 0)
+		{
+			const int maxEntityIndex = m_Game->m_ClientEntityList->GetHighestEntityIndex();
+			if (info.entity_index <= maxEntityIndex)
+				entity = m_Game->GetClientEntity(info.entity_index);
+		}
+		const auto infectedType = m_VR->GetSpecialInfectedType(entity, modelName);
 		if (infectedType != VR::SpecialInfectedType::None)
 		{
 			const bool isRagdoll = modelName.find("ragdoll") != std::string::npos;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -13,6 +13,7 @@
 
 class Game;
 class C_BasePlayer;
+class C_BaseEntity;
 class C_WeaponCSBase;
 class IDirect3DTexture9;
 class IDirect3DSurface9;
@@ -470,7 +471,7 @@ public:
 	void DrawThrowArc(const Vector& origin, const Vector& forward, const Vector& pitchSource);
 	void DrawThrowArcFromCache(float duration);
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
-	SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
+	SpecialInfectedType GetSpecialInfectedType(const C_BaseEntity* entity, const std::string& modelName) const;
 	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
 	void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type);
 	void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);


### PR DESCRIPTION
### Motivation
- The previous keyword-based detection produced false positives and the user requested using offsets to improve accuracy.  
- Reading the `m_zombieClass` netvar from entity memory is a more direct way to classify special infected.  
- Direct memory reads from draw callbacks risk invalid access during level/map transitions, so entity lookups must be guarded.  
- Tank and Witch models may not always be classified via the netvar, so a restricted model-name fallback is needed for those cases.

### Description
- Implemented `GetSpecialInfectedType(const C_BaseEntity* entity, const std::string& modelName)` and added a documented constant `kZombieClassOffset = 0x1c90` (from `thirdparty/minhook/offsets.txt`) to read `m_zombieClass` and map integer values to `SpecialInfectedType` in `L4D2VR/vr.cpp`.  
- Guarded entity lookup in `Hooks::dDrawModelExecute` by checking `m_ClientEntityList` and using `GetHighestEntityIndex()` before calling `m_Game->GetClientEntity`, passing `nullptr` when out-of-range or invalid, and updated call sites accordingly in `L4D2VR/hooks.cpp` and `L4D2VR/vr.h`.  
- Restored a limited model-name fallback that only checks normalized model paths under `/infected/` and only for `witch` and `tank`/`hulk` to reduce false positives while covering cases where the netvar is absent or unexpected.  
- Added required headers (`<cstddef>`, `<cstdint>`), comments documenting offset source, and adjusted related code paths in `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, and `L4D2VR/hooks.cpp`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69464a8be3ec8321a4bb68580edaa55d)