### PR TITLE
Prefer netvar special infected detection with model-name fallback

### DIFF
--- a/L4D2VR/game.cpp
+++ b/L4D2VR/game.cpp
@@ -213,6 +213,26 @@ char* Game::getNetworkName(uintptr_t* entity)
     return name;
 }
 
+const char* Game::GetNetworkClassName(uintptr_t* entity) const
+{
+    if (!entity)
+        return nullptr;
+
+    uintptr_t* vtable = reinterpret_cast<uintptr_t*>(*(entity + 0x8));
+    if (!vtable)
+        return nullptr;
+
+    uintptr_t* getClientClassFn = reinterpret_cast<uintptr_t*>(*(vtable + 0x8));
+    if (!getClientClassFn)
+        return nullptr;
+
+    uintptr_t* clientClass = reinterpret_cast<uintptr_t*>(*(getClientClassFn + 0x1));
+    if (!clientClass)
+        return nullptr;
+
+    return reinterpret_cast<const char*>(*(clientClass + 0x8));
+}
+
 // === Commands ===
 void Game::ClientCmd(const char* szCmdString)
 {

--- a/L4D2VR/game.h
+++ b/L4D2VR/game.h
@@ -99,6 +99,7 @@ public:
     void* GetInterface(const char* dllname, const char* interfacename);
     C_BaseEntity* GetClientEntity(int entityIndex);
     char* getNetworkName(uintptr_t* entity);
+    const char* GetNetworkClassName(uintptr_t* entity) const;
 
     // === Command Execution ===
     void ClientCmd(const char* szCmdString);

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <cstdint>
 #include <string>
+#include <cstring>
 bool Hooks::s_ServerUnderstandsVR = false;
 Hooks::Hooks(Game* game)
 {
@@ -683,7 +684,18 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 	{
 		modelName = m_Game->m_ModelInfo->GetModelName(info.pModel);
 
-		const auto infectedType = m_VR->GetSpecialInfectedType(modelName);
+		VR::SpecialInfectedType infectedType = VR::SpecialInfectedType::None;
+		if (info.entity_index >= 0)
+		{
+			C_BaseEntity* entity = m_Game->GetClientEntity(info.entity_index);
+			const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(entity));
+			if (className && std::strcmp(className, "CTerrorPlayer") == 0)
+				infectedType = m_VR->GetSpecialInfectedTypeFromNetvar(entity);
+		}
+
+		if (infectedType == VR::SpecialInfectedType::None)
+			infectedType = m_VR->GetSpecialInfectedType(modelName);
+
 		if (infectedType != VR::SpecialInfectedType::None)
 		{
 			const bool isRagdoll = modelName.find("ragdoll") != std::string::npos;

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -15,6 +15,7 @@
 #include <cctype>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <vector>
 #include <d3d9_vr.h>
 
@@ -2326,6 +2327,37 @@ VR::SpecialInfectedType VR::GetSpecialInfectedType(const std::string& modelName)
         return it->second;
 
     return SpecialInfectedType::None;
+}
+
+VR::SpecialInfectedType VR::GetSpecialInfectedTypeFromNetvar(const C_BaseEntity* entity) const
+{
+    if (!entity)
+        return SpecialInfectedType::None;
+
+    const auto base = reinterpret_cast<const std::uint8_t*>(entity);
+    const int zombieClass = *reinterpret_cast<const int*>(base + kZombieClassOffset);
+
+    switch (zombieClass)
+    {
+    case 1:
+        return SpecialInfectedType::Smoker;
+    case 2:
+        return SpecialInfectedType::Boomer;
+    case 3:
+        return SpecialInfectedType::Hunter;
+    case 4:
+        return SpecialInfectedType::Spitter;
+    case 5:
+        return SpecialInfectedType::Jockey;
+    case 6:
+        return SpecialInfectedType::Charger;
+    case 7:
+        return SpecialInfectedType::Witch;
+    case 8:
+        return SpecialInfectedType::Tank;
+    default:
+        return SpecialInfectedType::None;
+    }
 }
 
 void VR::DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -12,6 +12,7 @@
 #define MAX_STR_LEN 256
 
 class Game;
+class C_BaseEntity;
 class C_BasePlayer;
 class C_WeaponCSBase;
 class IDirect3DTexture9;
@@ -349,6 +350,8 @@ public:
 		Count
 	};
 
+	static constexpr int kZombieClassOffset = 0x1c90;
+
 	bool m_SpecialInfectedArrowEnabled = false;
 	float m_SpecialInfectedArrowSize = 12.0f;
 	float m_SpecialInfectedArrowHeight = 36.0f;
@@ -471,6 +474,7 @@ public:
 	void DrawThrowArcFromCache(float duration);
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
 	SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
+	SpecialInfectedType GetSpecialInfectedTypeFromNetvar(const C_BaseEntity* entity) const;
 	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
 	void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type);
 	void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);


### PR DESCRIPTION
### Motivation
- Model-name substring matching for special infected is fragile and can misidentify entities when models are renamed or modded.
- Using the `m_zombieClass` netvar gives a logic-layer, authoritative source for infected type and is more robust.
- Keep model-name detection as a fallback to preserve behavior when netvar data is unavailable.
- Provide a non-logging network class name accessor to safely gate netvar reads to the expected entity type.

### Description
- Add a non-logging `Game::GetNetworkClassName` accessor declared in `game.h` and implemented in `game.cpp` to read the entity client-class name without printing logs. (files: `L4D2VR/game.h`, `L4D2VR/game.cpp`).
- Add `kZombieClassOffset` and `VR::GetSpecialInfectedTypeFromNetvar` to map the `m_zombieClass` integer netvar to `SpecialInfectedType`, implemented in `vr.h` and `vr.cpp` and using `<cstdint>`; the mapping returns `None` when unknown. (files: `L4D2VR/vr.h`, `L4D2VR/vr.cpp`).
- Update `Hooks::dDrawModelExecute` to prefer netvar-based detection: if `info.entity_index` exists and the network class name is `CTerrorPlayer`, read `m_zombieClass` via the netvar routine and use that type; if the netvar returns `None` then fall back to the existing model-name matching. (file: `L4D2VR/hooks.cpp`).
- Add small include additions (`<cstring>` in `hooks.cpp`, `<cstdint>` in `vr.cpp`) and commit changes. (modified files: `L4D2VR/game.h`, `L4D2VR/game.cpp`, `L4D2VR/hooks.cpp`, `L4D2VR/vr.h`, `L4D2VR/vr.cpp`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69465baab8e08321a0ca90ea5ab31cb8)