### PR TITLE
Stop special infected arrows on death and prioritize nearest auto-aim target

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -685,18 +685,22 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		modelName = m_Game->m_ModelInfo->GetModelName(info.pModel);
 
 		VR::SpecialInfectedType infectedType = VR::SpecialInfectedType::None;
+		bool isAlive = true;
 		if (info.entity_index >= 0)
 		{
 			C_BaseEntity* entity = m_Game->GetClientEntity(info.entity_index);
 			const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(entity));
 			if (className && std::strcmp(className, "CTerrorPlayer") == 0)
+			{
+				isAlive = m_VR->IsEntityAlive(entity);
 				infectedType = m_VR->GetSpecialInfectedTypeFromNetvar(entity);
+			}
 		}
 
-		if (infectedType == VR::SpecialInfectedType::None)
+		if (isAlive && infectedType == VR::SpecialInfectedType::None)
 			infectedType = m_VR->GetSpecialInfectedType(modelName);
 
-		if (infectedType != VR::SpecialInfectedType::None)
+		if (isAlive && infectedType != VR::SpecialInfectedType::None)
 		{
 			const bool isRagdoll = modelName.find("ragdoll") != std::string::npos;
 			if (!isRagdoll)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -5,6 +5,7 @@
 #include "vector.h"
 #include <array>
 #include <chrono>
+#include <limits>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -351,6 +352,7 @@ public:
 	};
 
 	static constexpr int kZombieClassOffset = 0x1c90;
+	static constexpr int kLifeStateOffset = 0x147;
 
 	bool m_SpecialInfectedArrowEnabled = false;
 	float m_SpecialInfectedArrowSize = 12.0f;
@@ -382,6 +384,7 @@ public:
 	bool m_SpecialInfectedPreWarningActive = false;
 	bool m_SpecialInfectedPreWarningInRange = false;
 	Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
+	float m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
 	Vector m_SpecialInfectedAutoAimDirection = { 0.0f, 0.0f, 0.0f };
 	float m_SpecialInfectedAutoAimLerp = 0.2f;
 	std::array<Vector, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedPreWarningAimOffsets{
@@ -475,6 +478,7 @@ public:
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
 	SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
 	SpecialInfectedType GetSpecialInfectedTypeFromNetvar(const C_BaseEntity* entity) const;
+	bool IsEntityAlive(const C_BaseEntity* entity) const;
 	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
 	void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type);
 	void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);


### PR DESCRIPTION
### Motivation

- Avoid drawing special infected arrows or triggering pre-warning/evade actions for dead ragdolls/corpses so overlays don't persist after death.  
- Use entity life-state (netvar) to determine whether a `CTerrorPlayer` is alive before treating it as a special infected.  
- Improve pre-warning auto-aim by preferring the nearest special infected so automatic aim locks to the closest threat.  
- Reduce spurious target updates by tracking and resetting nearest-target distance per frame.

### Description

- Added a `kLifeStateOffset` constant and implemented `IsEntityAlive(const C_BaseEntity*)` in `vr.h`/`vr.cpp` to read the life-state netvar and return alive/dead via `lifeState == 0`.  
- Updated `Hooks::dDrawModelExecute` to call `IsEntityAlive` and skip `GetSpecialInfectedType`, `RefreshSpecialInfectedPreWarning`, `RefreshSpecialInfectedBlindSpotWarning`, and `DrawSpecialInfectedArrow` for non-alive entities.  
- Introduced `m_SpecialInfectedPreWarningTargetDistanceSq` (with `#include <limits>`) and changed `RefreshSpecialInfectedPreWarning` and `UpdateSpecialInfectedPreWarningState` so the pre-warning auto-aim target only updates when a candidate is closer or when the update interval elapses, and the nearest-distance sentinel is reset each frame.  
- Modified files: `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, and `L4D2VR/hooks.cpp` to implement these behaviors.

### Testing

- No automated tests were run for this change.  
- Changes were committed to the local branch and verified via static inspection only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694680a589808321b37757e19f5e9d8a)