### PR TITLE
Avoid corpse arrows, prefer nearest special-infected for auto-aim, restrict model fallback

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -685,18 +685,26 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		modelName = m_Game->m_ModelInfo->GetModelName(info.pModel);
 
 		VR::SpecialInfectedType infectedType = VR::SpecialInfectedType::None;
+		bool isAlive = true;
 		if (info.entity_index >= 0)
 		{
 			C_BaseEntity* entity = m_Game->GetClientEntity(info.entity_index);
 			const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(entity));
-			if (className && std::strcmp(className, "CTerrorPlayer") == 0)
+			if (className && (std::strcmp(className, "CTerrorPlayer") == 0 || std::strcmp(className, "C_TerrorPlayer") == 0))
+			{
+				isAlive = m_VR->IsEntityAlive(entity);
 				infectedType = m_VR->GetSpecialInfectedTypeFromNetvar(entity);
+			}
 		}
 
-		if (infectedType == VR::SpecialInfectedType::None)
-			infectedType = m_VR->GetSpecialInfectedType(modelName);
+		if (isAlive && infectedType == VR::SpecialInfectedType::None)
+		{
+			const auto modelType = m_VR->GetSpecialInfectedType(modelName);
+			if (modelType == VR::SpecialInfectedType::Tank || modelType == VR::SpecialInfectedType::Witch)
+				infectedType = modelType;
+		}
 
-		if (infectedType != VR::SpecialInfectedType::None)
+		if (isAlive && infectedType != VR::SpecialInfectedType::None)
 		{
 			const bool isRagdoll = modelName.find("ragdoll") != std::string::npos;
 			if (!isRagdoll)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -5,6 +5,7 @@
 #include "vector.h"
 #include <array>
 #include <chrono>
+#include <limits>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -351,6 +352,7 @@ public:
 	};
 
 	static constexpr int kZombieClassOffset = 0x1c90;
+	static constexpr int kLifeStateOffset = 0x147;
 
 	bool m_SpecialInfectedArrowEnabled = false;
 	float m_SpecialInfectedArrowSize = 12.0f;
@@ -382,6 +384,7 @@ public:
 	bool m_SpecialInfectedPreWarningActive = false;
 	bool m_SpecialInfectedPreWarningInRange = false;
 	Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
+	float m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
 	Vector m_SpecialInfectedAutoAimDirection = { 0.0f, 0.0f, 0.0f };
 	float m_SpecialInfectedAutoAimLerp = 0.2f;
 	std::array<Vector, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedPreWarningAimOffsets{
@@ -475,6 +478,7 @@ public:
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
 	SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
 	SpecialInfectedType GetSpecialInfectedTypeFromNetvar(const C_BaseEntity* entity) const;
+	bool IsEntityAlive(const C_BaseEntity* entity) const;
 	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
 	void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type);
 	void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);


### PR DESCRIPTION
### Motivation
- Prevent arrows/warnings from being shown for dead special infected by checking entity life state instead of relying on model names alone. 
- Keep model-based detection only for persistently visible large enemies so visual indicators for ragdolls/corpses stop when appropriate. 
- Ensure pre-warning auto-aim locks to the nearest special infected to target the closest threat. 

### Description
- Add `kLifeStateOffset` and implement `IsEntityAlive(const C_BaseEntity*)` to read the `lifeState` netvar and determine if an entity is alive. 
- Update `Hooks::dDrawModelExecute` to consult `IsEntityAlive`, accept both `CTerrorPlayer` and `C_TerrorPlayer` class names, skip netvar/model detection for non-alive entities, and keep model-name fallback only for `Tank` and `Witch`. 
- Introduce `m_SpecialInfectedPreWarningTargetDistanceSq` (add `#include <limits>`) and change `RefreshSpecialInfectedPreWarning` / `UpdateSpecialInfectedPreWarningState` so the pre-warning auto-aim target is updated only when a candidate is closer (or when the interval elapses) and reset the nearest-distance sentinel each frame. 
- Modified files: `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, and `L4D2VR/hooks.cpp` (helper, offsets, selection logic, and auto-aim prioritization). 

### Testing
- No automated tests were run for these changes. 
- Changes were committed locally and verified via static code inspection only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694680a589808321b37757e19f5e9d8a)