### PR TITLE
Suppress corpse arrows, use netvar detection, and prefer nearest auto-aim target

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -685,18 +685,26 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		modelName = m_Game->m_ModelInfo->GetModelName(info.pModel);
 
 		VR::SpecialInfectedType infectedType = VR::SpecialInfectedType::None;
+		bool isAlive = true;
 		if (info.entity_index >= 0)
 		{
 			C_BaseEntity* entity = m_Game->GetClientEntity(info.entity_index);
 			const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(entity));
-			if (className && std::strcmp(className, "CTerrorPlayer") == 0)
-				infectedType = m_VR->GetSpecialInfectedTypeFromNetvar(entity);
+			if (className && (std::strcmp(className, "CTerrorPlayer") == 0 || std::strcmp(className, "C_TerrorPlayer") == 0))
+			{
+				isAlive = m_VR->IsEntityAlive(entity);
+				infectedType = m_VR->GetSpecialInfectedType(entity);
+			}
 		}
 
-		if (infectedType == VR::SpecialInfectedType::None)
-			infectedType = m_VR->GetSpecialInfectedType(modelName);
+		if (isAlive && infectedType == VR::SpecialInfectedType::None)
+		{
+			const auto modelType = m_VR->GetSpecialInfectedTypeFromModel(modelName);
+			if (modelType == VR::SpecialInfectedType::Tank || modelType == VR::SpecialInfectedType::Witch)
+				infectedType = modelType;
+		}
 
-		if (infectedType != VR::SpecialInfectedType::None)
+		if (isAlive && infectedType != VR::SpecialInfectedType::None)
 		{
 			const bool isRagdoll = modelName.find("ragdoll") != std::string::npos;
 			if (!isRagdoll)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -5,6 +5,7 @@
 #include "vector.h"
 #include <array>
 #include <chrono>
+#include <limits>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -351,6 +352,7 @@ public:
 	};
 
 	static constexpr int kZombieClassOffset = 0x1c90;
+	static constexpr int kLifeStateOffset = 0x147;
 
 	bool m_SpecialInfectedArrowEnabled = false;
 	float m_SpecialInfectedArrowSize = 12.0f;
@@ -382,6 +384,7 @@ public:
 	bool m_SpecialInfectedPreWarningActive = false;
 	bool m_SpecialInfectedPreWarningInRange = false;
 	Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
+	float m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
 	Vector m_SpecialInfectedAutoAimDirection = { 0.0f, 0.0f, 0.0f };
 	float m_SpecialInfectedAutoAimLerp = 0.2f;
 	std::array<Vector, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedPreWarningAimOffsets{
@@ -473,8 +476,9 @@ public:
 	void DrawThrowArc(const Vector& origin, const Vector& forward, const Vector& pitchSource);
 	void DrawThrowArcFromCache(float duration);
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
-	SpecialInfectedType GetSpecialInfectedType(const std::string& modelName) const;
-	SpecialInfectedType GetSpecialInfectedTypeFromNetvar(const C_BaseEntity* entity) const;
+	SpecialInfectedType GetSpecialInfectedType(const C_BaseEntity* entity) const;
+	SpecialInfectedType GetSpecialInfectedTypeFromModel(const std::string& modelName) const;
+	bool IsEntityAlive(const C_BaseEntity* entity) const;
 	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
 	void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type);
 	void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);


### PR DESCRIPTION
### Motivation
- Avoid drawing arrows or triggering pre-warnings for dead special infected by relying on entity netvars rather than model names alone. 
- Keep a model-name fallback only for large persistently-visible enemies so ragdolls/corpses don't keep overlays. 
- Make pre-warning auto-aim prefer the nearest visible special infected so aim locks to the closest threat.

### Description
- Move netvar-based detection into `VR::GetSpecialInfectedType(const C_BaseEntity*)` which reads `m_zombieClass` at `kZombieClassOffset` and maps values to `SpecialInfectedType`.
- Add `kLifeStateOffset` and `VR::IsEntityAlive(const C_BaseEntity*)` to gate drawing/warnings on `m_lifeState == 0`, and update hooks to check both `CTerrorPlayer` and `C_TerrorPlayer` network class names before using netvar detection.
- Rename the model helper to `GetSpecialInfectedTypeFromModel(const std::string&)` and restrict model-name fallback to only `Tank` and `Witch` to preserve model-based indicators that should remain until the model disappears.
- Prioritize nearest pre-warning auto-aim by adding `m_SpecialInfectedPreWarningTargetDistanceSq`, resetting it each frame, and only updating the pre-warning target when a candidate is closer (or when the update interval elapses); also added `#include <limits>` for the sentinel value.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694680a589808321b37757e19f5e9d8a)