### PR TITLE
Remove network class filter for special infected detection

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -686,15 +686,17 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 
 		VR::SpecialInfectedType infectedType = VR::SpecialInfectedType::None;
 		bool isAlive = true;
-		if (info.entity_index >= 0)
+		const C_BaseEntity* entity = nullptr;
+		if (m_Game->m_ClientEntityList && info.entity_index > 0)
 		{
-			C_BaseEntity* entity = m_Game->GetClientEntity(info.entity_index);
-			const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(entity));
-			if (className && (std::strcmp(className, "CTerrorPlayer") == 0 || std::strcmp(className, "C_TerrorPlayer") == 0))
-			{
-				isAlive = m_VR->IsEntityAlive(entity);
-				infectedType = m_VR->GetSpecialInfectedType(entity);
-			}
+			const int maxEntityIndex = m_Game->m_ClientEntityList->GetHighestEntityIndex();
+			if (info.entity_index <= maxEntityIndex)
+				entity = m_Game->GetClientEntity(info.entity_index);
+		}
+		if (entity)
+		{
+			isAlive = m_VR->IsEntityAlive(entity);
+			infectedType = m_VR->GetSpecialInfectedType(entity);
 		}
 
 		if (isAlive && infectedType == VR::SpecialInfectedType::None)


### PR DESCRIPTION
### Motivation
- The previous implementation only read `m_zombieClass` when the network class name was `CTerrorPlayer`/`C_TerrorPlayer`, causing many special infected to be missed. 
- The thirdparty implementation queried entity data directly and was more permissive, so detection regressed when the class-name filter was added. 
- The intent is to match the thirdparty behavior and reliably detect special infected regardless of the network class string. 
- Safely access the entity list to avoid out-of-bounds reads when resolving `m_zombieClass`.

### Description
- Removed the network class name check and now directly resolve the `entity` via `m_Game->m_ClientEntityList` and `GetClientEntity` with bounds checks. 
- Replaced the old `GetNetworkClassName` gating logic in `DrawModelExecute` with a guarded `entity` lookup and then call `m_VR->GetSpecialInfectedType(entity)` when available. 
- Kept the existing model-name fallback via `GetSpecialInfectedTypeFromModel` for `Tank`/`Witch` detection. 
- Changed only `L4D2VR/hooks.cpp` to implement these adjustments and preserved existing behavior for ragdolls and arrow drawing.

### Testing
- No automated tests were run on the modified code. 
- A local commit was created for the change and the repository status shows the modified file `L4D2VR/hooks.cpp`. 
- Code was compiled/inspected via searches to verify affected call sites (`GetSpecialInfectedType`, `GetSpecialInfectedTypeFromModel`). 
- Manual runtime testing was not performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469be1784883218cdb45a1237b0f5d)