### PR TITLE
Keep auto‑aim locked until death; broaden special infected detection and guard entity reads

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -686,15 +686,23 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 
 		VR::SpecialInfectedType infectedType = VR::SpecialInfectedType::None;
 		bool isAlive = true;
-		if (info.entity_index >= 0)
+		const C_BaseEntity* entity = nullptr;
+		if (m_Game->m_ClientEntityList && info.entity_index > 0)
 		{
-			C_BaseEntity* entity = m_Game->GetClientEntity(info.entity_index);
-			const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(entity));
-			if (className && (std::strcmp(className, "CTerrorPlayer") == 0 || std::strcmp(className, "C_TerrorPlayer") == 0))
+			const int maxEntityIndex = m_Game->m_ClientEntityList->GetHighestEntityIndex();
+			if (info.entity_index <= maxEntityIndex)
+				entity = m_Game->GetClientEntity(info.entity_index);
+		}
+		bool isPlayerClass = false;
+		if (entity)
+		{
+			const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(const_cast<C_BaseEntity*>(entity)));
+			isPlayerClass = className && (std::strcmp(className, "CTerrorPlayer") == 0 || std::strcmp(className, "C_TerrorPlayer") == 0);
+			if (isPlayerClass)
 			{
 				isAlive = m_VR->IsEntityAlive(entity);
-				infectedType = m_VR->GetSpecialInfectedType(entity);
 			}
+			infectedType = m_VR->GetSpecialInfectedType(entity);
 		}
 
 		if (isAlive && infectedType == VR::SpecialInfectedType::None)
@@ -709,7 +717,7 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 			const bool isRagdoll = modelName.find("ragdoll") != std::string::npos;
 			if (!isRagdoll)
 			{
-				m_VR->RefreshSpecialInfectedPreWarning(info.origin, infectedType);
+				m_VR->RefreshSpecialInfectedPreWarning(info.origin, infectedType, info.entity_index, isPlayerClass);
 				m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
 				m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
 			}

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -15,6 +15,7 @@
 #include <cctype>
 #include <array>
 #include <cmath>
+#include <cstring>
 #include <cstdint>
 #include <vector>
 #include <d3d9_vr.h>
@@ -1183,10 +1184,22 @@ void VR::ProcessInput()
     if (!m_SpecialInfectedPreWarningAutoAimConfigEnabled)
     {
         m_SpecialInfectedPreWarningAutoAimEnabled = false;
+        m_SpecialInfectedPreWarningTargetEntityIndex = -1;
+        m_SpecialInfectedPreWarningTargetIsPlayer = false;
+        m_SpecialInfectedPreWarningActive = false;
+        m_SpecialInfectedPreWarningInRange = false;
+        m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
+        m_SpecialInfectedAutoAimDirection = {};
     }
     else if (autoAimToggleJustPressed)
     {
         m_SpecialInfectedPreWarningAutoAimEnabled = !m_SpecialInfectedPreWarningAutoAimEnabled;
+        m_SpecialInfectedPreWarningTargetEntityIndex = -1;
+        m_SpecialInfectedPreWarningTargetIsPlayer = false;
+        m_SpecialInfectedPreWarningActive = false;
+        m_SpecialInfectedPreWarningInRange = false;
+        m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
+        m_SpecialInfectedAutoAimDirection = {};
     }
 
     if (nonVrServerMovementToggleJustPressed)
@@ -2464,10 +2477,16 @@ bool VR::HasLineOfSightToSpecialInfected(const Vector& infectedOrigin) const
     return trace.fraction >= 1.0f;
 }
 
-void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type)
+void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type, int entityIndex, bool isPlayerClass)
 {
     if (m_SpecialInfectedPreWarningDistance <= 0.0f || !m_SpecialInfectedPreWarningAutoAimEnabled)
         return;
+
+    if (m_SpecialInfectedPreWarningTargetEntityIndex != -1 && entityIndex != m_SpecialInfectedPreWarningTargetEntityIndex)
+    {
+        if (m_SpecialInfectedPreWarningTargetIsPlayer)
+            return;
+    }
 
     Vector toInfected = infectedOrigin - m_HmdPosAbs;
     toInfected.z = 0.0f;
@@ -2484,8 +2503,10 @@ void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialI
         if (!HasLineOfSightToSpecialInfected(infectedOrigin))
             return;
 
+        const bool isLockedTarget = m_SpecialInfectedPreWarningTargetEntityIndex != -1
+            && entityIndex == m_SpecialInfectedPreWarningTargetEntityIndex;
         const bool isCloser = distanceSq < m_SpecialInfectedPreWarningTargetDistanceSq;
-        const bool isCandidate = isCloser || distanceSq <= (m_SpecialInfectedPreWarningTargetDistanceSq + 0.01f);
+        const bool isCandidate = isLockedTarget || isCloser || distanceSq <= (m_SpecialInfectedPreWarningTargetDistanceSq + 0.01f);
         const float updateInterval = std::max(0.0f, m_SpecialInfectedPreWarningTargetUpdateInterval);
         const auto elapsedUpdate = std::chrono::duration<float>(now - m_LastSpecialInfectedPreWarningTargetUpdateTime).count();
         if (isCandidate && (isCloser || updateInterval <= 0.0f || elapsedUpdate >= updateInterval))
@@ -2500,8 +2521,12 @@ void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialI
 
             m_SpecialInfectedPreWarningTarget = adjustedTarget;
             m_LastSpecialInfectedPreWarningTargetUpdateTime = now;
-            if (isCloser)
-                m_SpecialInfectedPreWarningTargetDistanceSq = distanceSq;
+            m_SpecialInfectedPreWarningTargetDistanceSq = distanceSq;
+            if (!isLockedTarget && entityIndex > 0)
+            {
+                m_SpecialInfectedPreWarningTargetEntityIndex = entityIndex;
+                m_SpecialInfectedPreWarningTargetIsPlayer = isPlayerClass;
+            }
         }
 
         m_SpecialInfectedPreWarningActive = true;
@@ -2535,6 +2560,9 @@ void VR::UpdateSpecialInfectedPreWarningState()
     {
         m_SpecialInfectedPreWarningActive = false;
         m_SpecialInfectedPreWarningInRange = false;
+        m_SpecialInfectedPreWarningTargetEntityIndex = -1;
+        m_SpecialInfectedPreWarningTargetIsPlayer = false;
+        m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
         return;
     }
 
@@ -2543,7 +2571,23 @@ void VR::UpdateSpecialInfectedPreWarningState()
     const auto now = std::chrono::steady_clock::now();
     const float seenTimeout = 0.1f;
 
-    if (m_SpecialInfectedPreWarningInRange)
+    if (m_SpecialInfectedPreWarningTargetEntityIndex != -1 && m_SpecialInfectedPreWarningTargetIsPlayer)
+    {
+        C_BaseEntity* entity = m_Game ? m_Game->GetClientEntity(m_SpecialInfectedPreWarningTargetEntityIndex) : nullptr;
+        const char* className = entity ? m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(entity)) : nullptr;
+        const bool isPlayerClass = className && (std::strcmp(className, "CTerrorPlayer") == 0 || std::strcmp(className, "C_TerrorPlayer") == 0);
+        const bool isAlive = entity && isPlayerClass && IsEntityAlive(entity);
+        const bool isSpecialInfected = entity && (GetSpecialInfectedType(entity) != SpecialInfectedType::None);
+        if (!isAlive || !isSpecialInfected)
+        {
+            m_SpecialInfectedPreWarningTargetEntityIndex = -1;
+            m_SpecialInfectedPreWarningTargetIsPlayer = false;
+            m_SpecialInfectedPreWarningActive = false;
+            m_SpecialInfectedPreWarningInRange = false;
+            return;
+        }
+    }
+    else if (m_SpecialInfectedPreWarningInRange)
     {
         const auto elapsed = std::chrono::duration<float>(now - m_LastSpecialInfectedPreWarningSeenTime).count();
         if (elapsed > seenTimeout)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -384,6 +384,8 @@ public:
 	bool m_SpecialInfectedPreWarningActive = false;
 	bool m_SpecialInfectedPreWarningInRange = false;
 	Vector m_SpecialInfectedPreWarningTarget = { 0.0f, 0.0f, 0.0f };
+	int m_SpecialInfectedPreWarningTargetEntityIndex = -1;
+	bool m_SpecialInfectedPreWarningTargetIsPlayer = false;
 	float m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
 	Vector m_SpecialInfectedAutoAimDirection = { 0.0f, 0.0f, 0.0f };
 	float m_SpecialInfectedAutoAimLerp = 0.2f;
@@ -480,7 +482,7 @@ public:
 	SpecialInfectedType GetSpecialInfectedTypeFromModel(const std::string& modelName) const;
 	bool IsEntityAlive(const C_BaseEntity* entity) const;
 	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
-	void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type);
+	void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type, int entityIndex, bool isPlayerClass);
 	void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
 	bool HasLineOfSightToSpecialInfected(const Vector& infectedOrigin) const;
 	bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;


### PR DESCRIPTION
### Motivation
- Broaden special infected detection to match thirdparty behavior while avoiding crashes from invalid memory reads during level transitions. 
- Prevent reading `lifeState` from arbitrary entity memory which can cause crashes when the entity is not a player. 
- Stop auto‑aim from switching away from a tracked target unless that target actually dies or is no longer a special infected. 
- Ensure toggling or disabling auto‑aim clears any stale lock state to avoid persistent erroneous targeting. 

### Description
- Resolve entities via `m_Game->m_ClientEntityList` with bounds checks in `L4D2VR/hooks.cpp` and call `GetSpecialInfectedType` for any valid entity, while computing an `isPlayerClass` flag to gate `IsEntityAlive` reads. 
- Add members `m_SpecialInfectedPreWarningTargetEntityIndex` and `m_SpecialInfectedPreWarningTargetIsPlayer` to `vr.h` and change `RefreshSpecialInfectedPreWarning` signature to `(..., int entityIndex, bool isPlayerClass)` to track and persist a locked target. 
- Update `RefreshSpecialInfectedPreWarning` and `UpdateSpecialInfectedPreWarningState` in `vr.cpp` to: lock the auto‑aim target (by entity index) until it dies or is no longer a special infected, avoid locking invalid indices, and validate that a locked player is still alive and infected before keeping the lock. 
- Clear lock state and reset `m_SpecialInfectedAutoAimDirection` when auto‑aim is toggled or disabled, and add a small include (`<cstring>`) needed by new code. 

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69469be1784883218cdb45a1237b0f5d)