### PR TITLE
Add configurable auto-aim cone angle for special infected pre-warning

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -42,6 +42,7 @@ ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
 SpecialInfectedPreWarningAutoAimEnabled=false
 SpecialInfectedPreWarningDistance=450.0
+SpecialInfectedPreWarningAimAngle=30.0
 SpecialInfectedPreWarningTargetUpdateInterval=0.2
 SpecialInfectedAutoAimLerp=0.2
 SpecialInfectedPreWarningAimOffsetBoomer=0,0,0

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2500,6 +2500,24 @@ void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialI
 
     if (inRange)
     {
+        const float maxAimAngle = std::clamp(m_SpecialInfectedPreWarningAimAngle, 0.0f, 180.0f);
+        if (maxAimAngle > 0.0f)
+        {
+            Vector aimDirection = m_RightControllerForward;
+            if (aimDirection.IsZero())
+                aimDirection = m_LastAimDirection;
+
+            Vector toTarget = infectedOrigin - m_RightControllerPosAbs;
+            if (!aimDirection.IsZero() && !toTarget.IsZero())
+            {
+                VectorNormalize(aimDirection);
+                VectorNormalize(toTarget);
+                const float minDot = std::cos(DEG2RAD(maxAimAngle));
+                if (DotProduct(aimDirection, toTarget) < minDot)
+                    return;
+            }
+        }
+
         if (!HasLineOfSightToSpecialInfected(infectedOrigin))
             return;
 
@@ -3401,6 +3419,7 @@ void VR::ParseConfigFile()
         m_SpecialInfectedPreWarningAutoAimEnabled = false;
     m_SpecialInfectedPreWarningDistance = std::max(0.0f, getFloat("SpecialInfectedPreWarningDistance", m_SpecialInfectedPreWarningDistance));
     m_SpecialInfectedPreWarningTargetUpdateInterval = std::max(0.0f, getFloat("SpecialInfectedPreWarningTargetUpdateInterval", m_SpecialInfectedPreWarningTargetUpdateInterval));
+    m_SpecialInfectedPreWarningAimAngle = std::clamp(getFloat("SpecialInfectedPreWarningAimAngle", m_SpecialInfectedPreWarningAimAngle), 0.0f, 180.0f);
     m_SpecialInfectedAutoAimLerp = std::clamp(getFloat("SpecialInfectedAutoAimLerp", m_SpecialInfectedAutoAimLerp), 0.0f, 1.0f);
     m_SpecialInfectedWarningSecondaryHoldDuration = std::max(0.0f, getFloat("SpecialInfectedWarningSecondaryHoldDuration", m_SpecialInfectedWarningSecondaryHoldDuration));
     m_SpecialInfectedWarningPostAttackDelay = std::max(0.0f, getFloat("SpecialInfectedWarningPostAttackDelay", m_SpecialInfectedWarningPostAttackDelay));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -379,6 +379,7 @@ public:
 	bool m_SpecialInfectedWarningActionEnabled = false;
 	float m_SpecialInfectedPreWarningDistance = 450.0f;
 	float m_SpecialInfectedPreWarningTargetUpdateInterval = 0.2f;
+	float m_SpecialInfectedPreWarningAimAngle = 30.0f;
 	bool m_SpecialInfectedPreWarningAutoAimConfigEnabled = false;
 	bool m_SpecialInfectedPreWarningAutoAimEnabled = false;
 	bool m_SpecialInfectedPreWarningActive = false;


### PR DESCRIPTION
### Motivation

- Limit auto-aim target selection to a cone centered on the aim line so pre-warning only locks targets the player is actually aiming toward.
- Expose the cone angle as a configuration option to allow tuning of how permissive the auto-aim should be.

### Description

- Added a new member `m_SpecialInfectedPreWarningAimAngle` (default `30.0f`) in `vr.h` to store the configured cone angle.
- In `RefreshSpecialInfectedPreWarning` an aim-angle check was added that compares the controller aim (`m_RightControllerForward` or `m_LastAimDirection`) to the vector to the infected and rejects targets outside the cone using `DotProduct` and `DEG2RAD`.
- The new config value is read and clamped in `ParseConfigFile` via `getFloat`, and the setting `SpecialInfectedPreWarningAimAngle` was added to `config.txt`.

### Testing

- No automated tests were run for this change.
- Manual verification is expected to be performed during runtime to confirm the aim-cone filtering behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946b5e078e08321be372371367c65d3)