### PR TITLE
Add cooldown for special infected pre-warning auto-aim

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -45,6 +45,7 @@ SpecialInfectedPreWarningDistance=450.0
 SpecialInfectedPreWarningAimAngle=30.0
 SpecialInfectedPreWarningTargetUpdateInterval=0.2
 SpecialInfectedAutoAimLerp=0.2
+SpecialInfectedAutoAimCooldown=0.0
 SpecialInfectedPreWarningAimOffsetBoomer=0,0,0
 SpecialInfectedPreWarningAimOffsetSmoker=0,0,0
 SpecialInfectedPreWarningAimOffsetHunter=0,0,0

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -390,6 +390,8 @@ public:
 	float m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
 	Vector m_SpecialInfectedAutoAimDirection = { 0.0f, 0.0f, 0.0f };
 	float m_SpecialInfectedAutoAimLerp = 0.2f;
+	float m_SpecialInfectedAutoAimCooldown = 0.0f;
+	std::chrono::steady_clock::time_point m_SpecialInfectedAutoAimCooldownEnd{};
 	std::array<Vector, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedPreWarningAimOffsets{
 		Vector{ 0.0f, 0.0f, 0.0f }, // Boomer
 		Vector{ 0.0f, 0.0f, 0.0f }, // Smoker


### PR DESCRIPTION
### Motivation
- Prevent immediate re-locking of special-infected auto-aim by introducing a cooldown after a lock ends.
- Make the cooldown configurable so behavior can be tuned via the config file as `SpecialInfectedAutoAimCooldown`.
- Ensure auto-aim state is cleared when toggled or disabled to avoid stale targets during the cooldown.

### Description
- Added `m_SpecialInfectedAutoAimCooldown` and `m_SpecialInfectedAutoAimCooldownEnd` members in `vr.h` to track the cooldown value and expiration.
- Exposed the setting in the default `config.txt` and parsed it in `ParseConfigFile` via `getFloat`.
- Blocked pre-warning auto-aim activation in `RefreshSpecialInfectedPreWarning` and `UpdateSpecialInfectedPreWarningState` while the cooldown is active, and set `m_SpecialInfectedAutoAimCooldownEnd` when the pre-warning becomes inactive.
- Reset the cooldown end when auto-aim is toggled or disabled in the input processing logic to avoid carrying over stale cooldown state.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946c55d0fd4832191c0f8ddc443701c)