### PR TITLE
Guard special infected netvar access and log entity classes once during draw

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <string>
 #include <cstring>
+#include <unordered_set>
 bool Hooks::s_ServerUnderstandsVR = false;
 Hooks::Hooks(Game* game)
 {
@@ -677,6 +678,8 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 	if (m_Game->m_SwitchedWeapons)
 		m_Game->m_CachedArmsModel = false;
 
+	static std::unordered_set<int> s_LoggedEntityIndices;
+
 	bool hideArms = m_Game->m_IsMeleeWeaponActive || m_VR->m_HideArms;
 
 	std::string modelName;
@@ -698,6 +701,13 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		{
 			const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(const_cast<C_BaseEntity*>(entity)));
 			isPlayerClass = className && (std::strcmp(className, "CTerrorPlayer") == 0 || std::strcmp(className, "C_TerrorPlayer") == 0);
+			if (s_LoggedEntityIndices.insert(info.entity_index).second)
+			{
+				Game::logMsg("[EntityDebug] index=%d class=%s model=%s",
+					info.entity_index,
+					className ? className : "null",
+					modelName.empty() ? "null" : modelName.c_str());
+			}
 			if (isPlayerClass)
 			{
 				isAlive = m_VR->IsEntityAlive(entity);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2305,7 +2305,12 @@ void VR::DrawLineWithThickness(const Vector& start, const Vector& end, float dur
 
 VR::SpecialInfectedType VR::GetSpecialInfectedType(const C_BaseEntity* entity) const
 {
-    if (!entity)
+    if (!entity || !m_Game)
+        return SpecialInfectedType::None;
+
+    const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(const_cast<C_BaseEntity*>(entity)));
+    const bool isPlayerClass = className && (std::strcmp(className, "CTerrorPlayer") == 0 || std::strcmp(className, "C_TerrorPlayer") == 0);
+    if (!isPlayerClass)
         return SpecialInfectedType::None;
 
     const auto base = reinterpret_cast<const std::uint8_t*>(entity);


### PR DESCRIPTION
### Motivation
- Reading special infected netvars could dereference invalid memory when the entity provided by rendering callbacks is not a player, causing crashes.
- `VR::GetSpecialInfectedType` previously assumed player entities and read offsets unconditionally which is unsafe after netvars became networked.
- It is necessary to limit netvar reads to appropriate owner classes and to discover which entity classes/models are being rendered so ownership can be diagnosed.
- Logging entity index/class/model once during drawing helps identify which non-player/network-only entities are passed to the code.

### Description
- Add a guard in `VR::GetSpecialInfectedType` to verify `m_Game` is present and that the entity's network class (via `m_Game->GetNetworkClassName`) is `CTerrorPlayer` or `C_TerrorPlayer` before reading netvar offsets, returning `SpecialInfectedType::None` otherwise.
- Add an `std::unordered_set<int>` `s_LoggedEntityIndices` and a one-time log per entity index in `Hooks::dDrawModelExecute` to write `index/class/model` to `test.log` via `Game::logMsg` for debugging netvar ownership.
- Include the `<unordered_set>` header and keep all other logic unchanged.
- Changes are restricted to `L4D2VR/vr.cpp` and `L4D2VR/hooks.cpp`.

### Testing
- No automated tests were run.
- Runtime behavior should now avoid invalid netvar reads for non-player entities and produce entries in `test.log` for inspected entity indices.
- Manual validation is recommended to inspect `test.log` output and confirm crashes are resolved in scenarios that previously triggered invalid reads.
- If further unexpected classes appear in `test.log`, additional handling or mapping can be implemented based on those results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ed6ac4608321b1450bbbbc59d466)