### PR TITLE
Common infected auto-aim override, detection, offset and debug arrows

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -40,12 +40,15 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 # Any combo can be disabled by setting it to "false".
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
+CommonInfectedArrowEnabled=true
 SpecialInfectedPreWarningAutoAimEnabled=false
 SpecialInfectedPreWarningDistance=450.0
 SpecialInfectedPreWarningAimAngle=30.0
 SpecialInfectedPreWarningTargetUpdateInterval=0.2
 SpecialInfectedAutoAimLerp=0.2
 SpecialInfectedAutoAimCooldown=0.0
+CommonInfectedAutoAimDistance=0.0
+CommonInfectedAutoAimOffset=0,0,0
 SpecialInfectedPreWarningAimOffsetBoomer=0,0,0
 SpecialInfectedPreWarningAimOffsetSmoker=0,0,0
 SpecialInfectedPreWarningAimOffsetHunter=0,0,0

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -687,6 +687,7 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		VR::SpecialInfectedType infectedType = VR::SpecialInfectedType::None;
 		bool isAlive = true;
 		const C_BaseEntity* entity = nullptr;
+		bool isCommonInfected = false;
 		if (m_Game->m_ClientEntityList && info.entity_index > 0)
 		{
 			const int maxEntityIndex = m_Game->m_ClientEntityList->GetHighestEntityIndex();
@@ -698,11 +699,9 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 		{
 			const char* className = m_Game->GetNetworkClassName(reinterpret_cast<uintptr_t*>(const_cast<C_BaseEntity*>(entity)));
 			isPlayerClass = className && (std::strcmp(className, "CTerrorPlayer") == 0 || std::strcmp(className, "C_TerrorPlayer") == 0);
-			if (isPlayerClass)
-			{
-				isAlive = m_VR->IsEntityAlive(entity);
-			}
+			isAlive = m_VR->IsEntityAlive(entity);
 			infectedType = m_VR->GetSpecialInfectedType(entity);
+			isCommonInfected = !isPlayerClass && m_VR->IsCommonInfectedClass(className);
 		}
 
 		if (isAlive && infectedType == VR::SpecialInfectedType::None)
@@ -710,6 +709,11 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 			const auto modelType = m_VR->GetSpecialInfectedTypeFromModel(modelName);
 			if (modelType == VR::SpecialInfectedType::Tank || modelType == VR::SpecialInfectedType::Witch)
 				infectedType = modelType;
+		}
+
+		if (!isCommonInfected && !isPlayerClass && infectedType == VR::SpecialInfectedType::None)
+		{
+			isCommonInfected = m_VR->IsCommonInfectedModelName(modelName);
 		}
 
 		if (isAlive && infectedType != VR::SpecialInfectedType::None)
@@ -720,6 +724,15 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 				m_VR->RefreshSpecialInfectedPreWarning(info.origin, infectedType, info.entity_index, isPlayerClass);
 				m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
 				m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
+			}
+		}
+		else if (isAlive && isCommonInfected)
+		{
+			const bool isRagdoll = modelName.find("ragdoll") != std::string::npos;
+			if (!isRagdoll)
+			{
+				m_VR->RefreshCommonInfectedAutoAim(info.origin, info.entity_index);
+				m_VR->DrawCommonInfectedArrow(info.origin);
 			}
 		}
 	}

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1191,6 +1191,9 @@ void VR::ProcessInput()
         m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
         m_SpecialInfectedAutoAimDirection = {};
         m_SpecialInfectedAutoAimCooldownEnd = {};
+        m_CommonInfectedAutoAimActive = false;
+        m_CommonInfectedAutoAimInRange = false;
+        m_CommonInfectedAutoAimTargetDistanceSq = std::numeric_limits<float>::max();
     }
     else if (autoAimToggleJustPressed)
     {
@@ -1202,6 +1205,9 @@ void VR::ProcessInput()
         m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
         m_SpecialInfectedAutoAimDirection = {};
         m_SpecialInfectedAutoAimCooldownEnd = {};
+        m_CommonInfectedAutoAimActive = false;
+        m_CommonInfectedAutoAimInRange = false;
+        m_CommonInfectedAutoAimTargetDistanceSq = std::numeric_limits<float>::max();
     }
 
     if (nonVrServerMovementToggleJustPressed)
@@ -1818,8 +1824,8 @@ void VR::UpdateTracking()
     m_RightControllerForward = VectorRotate(m_RightControllerForward, m_RightControllerRight, -45.0);
     m_RightControllerUp = VectorRotate(m_RightControllerUp, m_RightControllerRight, -45.0);
 
-    const bool shouldForceAim = m_SpecialInfectedPreWarningActive;
-    const Vector forcedTarget = m_SpecialInfectedPreWarningTarget;
+    const bool shouldForceAim = m_CommonInfectedAutoAimActive || m_SpecialInfectedPreWarningActive;
+    const Vector forcedTarget = m_CommonInfectedAutoAimActive ? m_CommonInfectedAutoAimTarget : m_SpecialInfectedPreWarningTarget;
 
     if (shouldForceAim)
     {
@@ -2002,6 +2008,7 @@ void VR::UpdateMotionGestures(C_BasePlayer* localPlayer)
 void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
 {
     UpdateSpecialInfectedWarningState();
+    UpdateCommonInfectedAutoAimState();
     UpdateSpecialInfectedPreWarningState();
 
     if (!m_Game->m_DebugOverlay)
@@ -2374,6 +2381,66 @@ bool VR::IsEntityAlive(const C_BaseEntity* entity) const
     return lifeState == 0;
 }
 
+bool VR::IsCommonInfectedClass(const char* className) const
+{
+    if (!className)
+        return false;
+
+    std::string lower = className;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    static const std::array<const char*, 4> commonClassNames =
+    {
+        "infected",
+        "cinfected",
+        "commoninfected",
+        "ccommoninfected"
+    };
+
+    for (const char* name : commonClassNames)
+    {
+        if (lower == name)
+            return true;
+    }
+
+    return false;
+}
+
+bool VR::IsCommonInfectedModelName(const std::string& modelName) const
+{
+    if (modelName.empty())
+        return false;
+
+    std::string lower = modelName;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+    if (lower.find("infected") == std::string::npos)
+        return false;
+
+    static const std::array<const char*, 9> specialKeywords =
+    {
+        "smoker",
+        "boomer",
+        "hunter",
+        "spitter",
+        "jockey",
+        "charger",
+        "tank",
+        "witch",
+        "hulk"
+    };
+
+    for (const char* keyword : specialKeywords)
+    {
+        if (lower.find(keyword) != std::string::npos)
+            return false;
+    }
+
+    return true;
+}
+
 void VR::DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type)
 {
     if (!m_SpecialInfectedArrowEnabled || m_SpecialInfectedArrowSize <= 0.0f || type == SpecialInfectedType::None)
@@ -2415,6 +2482,55 @@ void VR::DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type
             for (const auto& lineOffset : offsets)
             {
                 m_Game->m_DebugOverlay->AddLineOverlay(start + lineOffset, end + lineOffset, arrowColor.r, arrowColor.g, arrowColor.b, true, duration);
+            }
+        };
+
+    drawArrowLine(base, tip);
+    drawArrowLine(base + Vector(wingLength, 0.0f, 0.0f), tip);
+    drawArrowLine(base + Vector(-wingLength, 0.0f, 0.0f), tip);
+    drawArrowLine(base + Vector(0.0f, wingLength, 0.0f), tip);
+    drawArrowLine(base + Vector(0.0f, -wingLength, 0.0f), tip);
+}
+
+void VR::DrawCommonInfectedArrow(const Vector& origin)
+{
+    if (!m_CommonInfectedArrowEnabled || m_SpecialInfectedArrowSize <= 0.0f)
+        return;
+
+    if (!m_Game || !m_Game->m_DebugOverlay)
+        return;
+
+    const float baseHeight = m_SpecialInfectedArrowHeight;
+    const float wingLength = m_SpecialInfectedArrowSize;
+    const Vector base = origin + Vector(0.0f, 0.0f, baseHeight);
+    const Vector tip = base + Vector(0.0f, 0.0f, -m_SpecialInfectedArrowSize);
+    const float duration = std::max(m_LastFrameDuration, 0.03f);
+    const int colorR = 255;
+    const int colorG = 255;
+    const int colorB = 0;
+
+    auto drawArrowLine = [&](const Vector& start, const Vector& end)
+        {
+            const float offset = m_SpecialInfectedArrowThickness * 0.5f;
+
+            if (offset <= 0.0f)
+            {
+                m_Game->m_DebugOverlay->AddLineOverlay(start, end, colorR, colorG, colorB, true, duration);
+                return;
+            }
+
+            const std::array<Vector, 5> offsets =
+            {
+                Vector(0.0f, 0.0f, 0.0f),
+                Vector(offset, 0.0f, 0.0f),
+                Vector(-offset, 0.0f, 0.0f),
+                Vector(0.0f, offset, 0.0f),
+                Vector(0.0f, -offset, 0.0f)
+            };
+
+            for (const auto& lineOffset : offsets)
+            {
+                m_Game->m_DebugOverlay->AddLineOverlay(start + lineOffset, end + lineOffset, colorR, colorG, colorB, true, duration);
             }
         };
 
@@ -2482,6 +2598,9 @@ bool VR::HasLineOfSightToSpecialInfected(const Vector& infectedOrigin) const
 void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type, int entityIndex, bool isPlayerClass)
 {
     if (m_SpecialInfectedPreWarningDistance <= 0.0f || !m_SpecialInfectedPreWarningAutoAimEnabled)
+        return;
+
+    if (m_CommonInfectedAutoAimInRange)
         return;
 
     const auto now = std::chrono::steady_clock::now();
@@ -2558,6 +2677,51 @@ void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialI
     }
 }
 
+void VR::RefreshCommonInfectedAutoAim(const Vector& infectedOrigin, int entityIndex)
+{
+    if (m_CommonInfectedAutoAimDistance <= 0.0f || !m_SpecialInfectedPreWarningAutoAimEnabled)
+        return;
+
+    (void)entityIndex;
+
+    const auto now = std::chrono::steady_clock::now();
+
+    Vector toInfected = infectedOrigin - m_HmdPosAbs;
+    toInfected.z = 0.0f;
+    if (toInfected.IsZero())
+        return;
+
+    const float distanceSq = toInfected.LengthSqr();
+    const float maxDistanceSq = m_CommonInfectedAutoAimDistance * m_CommonInfectedAutoAimDistance;
+    if (distanceSq > maxDistanceSq)
+        return;
+
+    if (!HasLineOfSightToSpecialInfected(infectedOrigin))
+        return;
+
+    const bool isCloser = distanceSq < m_CommonInfectedAutoAimTargetDistanceSq;
+    if (isCloser || m_CommonInfectedAutoAimTargetDistanceSq == std::numeric_limits<float>::max())
+    {
+        Vector adjustedTarget = infectedOrigin;
+        adjustedTarget += (m_HmdRight * m_CommonInfectedAutoAimOffset.x)
+            + (m_HmdForward * m_CommonInfectedAutoAimOffset.y)
+            + (m_HmdUp * m_CommonInfectedAutoAimOffset.z);
+        m_CommonInfectedAutoAimTarget = adjustedTarget;
+        m_CommonInfectedAutoAimTargetDistanceSq = distanceSq;
+    }
+
+    m_CommonInfectedAutoAimActive = true;
+    m_CommonInfectedAutoAimInRange = true;
+    m_LastCommonInfectedAutoAimSeenTime = now;
+
+    m_SpecialInfectedPreWarningTargetEntityIndex = -1;
+    m_SpecialInfectedPreWarningTargetIsPlayer = false;
+    m_SpecialInfectedPreWarningActive = false;
+    m_SpecialInfectedPreWarningInRange = false;
+    m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
+    m_SpecialInfectedAutoAimDirection = {};
+}
+
 void VR::UpdateSpecialInfectedWarningState()
 {
     if (!m_SpecialInfectedBlindSpotWarningActive)
@@ -2593,6 +2757,16 @@ void VR::UpdateSpecialInfectedPreWarningState()
     }
 
     if (m_SpecialInfectedAutoAimCooldown > 0.0f && now < m_SpecialInfectedAutoAimCooldownEnd)
+    {
+        m_SpecialInfectedPreWarningActive = false;
+        m_SpecialInfectedPreWarningInRange = false;
+        m_SpecialInfectedPreWarningTargetEntityIndex = -1;
+        m_SpecialInfectedPreWarningTargetIsPlayer = false;
+        m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
+        return;
+    }
+
+    if (m_CommonInfectedAutoAimInRange)
     {
         m_SpecialInfectedPreWarningActive = false;
         m_SpecialInfectedPreWarningInRange = false;
@@ -2666,6 +2840,32 @@ void VR::UpdateSpecialInfectedPreWarningState()
         m_SpecialInfectedPreWarningTargetIsPlayer = false;
         m_SpecialInfectedPreWarningTargetDistanceSq = std::numeric_limits<float>::max();
     }
+}
+
+void VR::UpdateCommonInfectedAutoAimState()
+{
+    const auto now = std::chrono::steady_clock::now();
+
+    if (m_CommonInfectedAutoAimDistance <= 0.0f || !m_SpecialInfectedPreWarningAutoAimEnabled)
+    {
+        m_CommonInfectedAutoAimActive = false;
+        m_CommonInfectedAutoAimInRange = false;
+        m_CommonInfectedAutoAimTargetDistanceSq = std::numeric_limits<float>::max();
+        return;
+    }
+
+    m_CommonInfectedAutoAimTargetDistanceSq = std::numeric_limits<float>::max();
+    const float seenTimeout = 0.1f;
+
+    if (m_CommonInfectedAutoAimInRange)
+    {
+        const auto elapsed = std::chrono::duration<float>(now - m_LastCommonInfectedAutoAimSeenTime).count();
+        if (elapsed > seenTimeout)
+            m_CommonInfectedAutoAimInRange = false;
+    }
+
+    if (m_CommonInfectedAutoAimActive && !m_CommonInfectedAutoAimInRange)
+        m_CommonInfectedAutoAimActive = false;
 }
 
 void VR::StartSpecialInfectedWarningAction()
@@ -3435,6 +3635,7 @@ void VR::ParseConfigFile()
     m_RequireSecondaryAttackForItemSwitch = getBool("RequireSecondaryAttackForItemSwitch", m_RequireSecondaryAttackForItemSwitch);
     m_SpecialInfectedWarningActionEnabled = getBool("SpecialInfectedAutoEvade", m_SpecialInfectedWarningActionEnabled);
     m_SpecialInfectedArrowEnabled = getBool("SpecialInfectedArrowEnabled", m_SpecialInfectedArrowEnabled);
+    m_CommonInfectedArrowEnabled = getBool("CommonInfectedArrowEnabled", m_CommonInfectedArrowEnabled);
     m_SpecialInfectedArrowSize = std::max(0.0f, getFloat("SpecialInfectedArrowSize", m_SpecialInfectedArrowSize));
     m_SpecialInfectedArrowHeight = std::max(0.0f, getFloat("SpecialInfectedArrowHeight", m_SpecialInfectedArrowHeight));
     m_SpecialInfectedArrowThickness = std::max(0.0f, getFloat("SpecialInfectedArrowThickness", m_SpecialInfectedArrowThickness));
@@ -3447,6 +3648,8 @@ void VR::ParseConfigFile()
     m_SpecialInfectedPreWarningAimAngle = std::clamp(getFloat("SpecialInfectedPreWarningAimAngle", m_SpecialInfectedPreWarningAimAngle), 0.0f, 180.0f);
     m_SpecialInfectedAutoAimLerp = std::clamp(getFloat("SpecialInfectedAutoAimLerp", m_SpecialInfectedAutoAimLerp), 0.0f, 1.0f);
     m_SpecialInfectedAutoAimCooldown = std::max(0.0f, getFloat("SpecialInfectedAutoAimCooldown", m_SpecialInfectedAutoAimCooldown));
+    m_CommonInfectedAutoAimDistance = std::max(0.0f, getFloat("CommonInfectedAutoAimDistance", m_CommonInfectedAutoAimDistance));
+    m_CommonInfectedAutoAimOffset = getVector3("CommonInfectedAutoAimOffset", m_CommonInfectedAutoAimOffset);
     m_SpecialInfectedWarningSecondaryHoldDuration = std::max(0.0f, getFloat("SpecialInfectedWarningSecondaryHoldDuration", m_SpecialInfectedWarningSecondaryHoldDuration));
     m_SpecialInfectedWarningPostAttackDelay = std::max(0.0f, getFloat("SpecialInfectedWarningPostAttackDelay", m_SpecialInfectedWarningPostAttackDelay));
     m_SpecialInfectedWarningJumpHoldDuration = std::max(0.0f, getFloat("SpecialInfectedWarningJumpHoldDuration", m_SpecialInfectedWarningJumpHoldDuration));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -377,6 +377,7 @@ public:
 	float m_SpecialInfectedWarningPostAttackDelay = 0.1f;
 	float m_SpecialInfectedWarningJumpHoldDuration = 0.2f;
 	bool m_SpecialInfectedWarningActionEnabled = false;
+	bool m_CommonInfectedArrowEnabled = true;
 	float m_SpecialInfectedPreWarningDistance = 450.0f;
 	float m_SpecialInfectedPreWarningTargetUpdateInterval = 0.2f;
 	float m_SpecialInfectedPreWarningAimAngle = 30.0f;
@@ -392,6 +393,13 @@ public:
 	float m_SpecialInfectedAutoAimLerp = 0.2f;
 	float m_SpecialInfectedAutoAimCooldown = 0.0f;
 	std::chrono::steady_clock::time_point m_SpecialInfectedAutoAimCooldownEnd{};
+	float m_CommonInfectedAutoAimDistance = 0.0f;
+	bool m_CommonInfectedAutoAimActive = false;
+	bool m_CommonInfectedAutoAimInRange = false;
+	Vector m_CommonInfectedAutoAimTarget = { 0.0f, 0.0f, 0.0f };
+	float m_CommonInfectedAutoAimTargetDistanceSq = std::numeric_limits<float>::max();
+	std::chrono::steady_clock::time_point m_LastCommonInfectedAutoAimSeenTime{};
+	Vector m_CommonInfectedAutoAimOffset = { 0.0f, 0.0f, 0.0f };
 	std::array<Vector, static_cast<size_t>(SpecialInfectedType::Count)> m_SpecialInfectedPreWarningAimOffsets{
 		Vector{ 0.0f, 0.0f, 0.0f }, // Boomer
 		Vector{ 0.0f, 0.0f, 0.0f }, // Smoker
@@ -484,13 +492,18 @@ public:
 	SpecialInfectedType GetSpecialInfectedType(const C_BaseEntity* entity) const;
 	SpecialInfectedType GetSpecialInfectedTypeFromModel(const std::string& modelName) const;
 	bool IsEntityAlive(const C_BaseEntity* entity) const;
+	bool IsCommonInfectedClass(const char* className) const;
+	bool IsCommonInfectedModelName(const std::string& modelName) const;
 	void DrawSpecialInfectedArrow(const Vector& origin, SpecialInfectedType type);
+	void DrawCommonInfectedArrow(const Vector& origin);
 	void RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialInfectedType type, int entityIndex, bool isPlayerClass);
+	void RefreshCommonInfectedAutoAim(const Vector& infectedOrigin, int entityIndex);
 	void RefreshSpecialInfectedBlindSpotWarning(const Vector& infectedOrigin);
 	bool HasLineOfSightToSpecialInfected(const Vector& infectedOrigin) const;
 	bool IsSpecialInfectedInBlindSpot(const Vector& infectedOrigin) const;
 	void UpdateSpecialInfectedWarningState();
 	void UpdateSpecialInfectedPreWarningState();
+	void UpdateCommonInfectedAutoAimState();
 	void StartSpecialInfectedWarningAction();
 	void UpdateSpecialInfectedWarningAction();
 	void ResetSpecialInfectedWarningAction();


### PR DESCRIPTION
### Motivation
- Prioritize nearby common (non-special) infected as temporary auto-aim targets and suspend/override special-infected pre-warning while commons are actively in range. 
- Avoid common-infected auto-aim pointing at the ground by applying an HMD-relative aim offset. 
- Provide visible feedback (debug arrows) to verify detection during testing and improve detection fallback when class names are missing or inconsistent.

### Description
- Added state and config: new members in `VR` (`m_CommonInfectedAutoAimDistance`, `m_CommonInfectedAutoAimOffset`, `m_CommonInfectedAutoAimTarget`, flags/timestamps, and `m_CommonInfectedArrowEnabled`) and corresponding config keys `CommonInfectedAutoAimDistance`, `CommonInfectedAutoAimOffset`, and `CommonInfectedArrowEnabled` in `VR/config.txt` and parsed via `ParseConfigFile`.
- Detection and selection: implemented `IsCommonInfectedClass` (case-insensitive) and a model-name fallback `IsCommonInfectedModelName`, integrated into `hooks.cpp` draw-model flow to call `RefreshCommonInfectedAutoAim` for common-infected candidates (ignoring ragdolls).
- Auto-aim logic: added `RefreshCommonInfectedAutoAim` and `UpdateCommonInfectedAutoAimState` in `vr.cpp`, applied HMD-axis offset to candidate targets (`m_HmdRight/m_HmdForward/m_HmdUp`), and made the aiming flow prefer `m_CommonInfectedAutoAimTarget` when active by updating `UpdateTracking`/`UpdateAimingLaser` to use the common target; special-infected pre-warning is only suppressed while commons are currently `InRange`.
- Debug visuals and safety fixes: added `DrawCommonInfectedArrow` (yellow arrows, controlled by `CommonInfectedArrowEnabled`) to assist verification and relaxed suppression logic to avoid permanently disabling special-infected auto-aim.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69478a6b92908321ac9d22e2efbd6758)