### PR TITLE
Exclude blind spot warning for Tank, Witch, and Charger

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -722,7 +722,12 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 			if (!isRagdoll)
 			{
 				m_VR->RefreshSpecialInfectedPreWarning(info.origin, infectedType, info.entity_index, isPlayerClass);
-				m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
+				if (infectedType != VR::SpecialInfectedType::Tank
+					&& infectedType != VR::SpecialInfectedType::Witch
+					&& infectedType != VR::SpecialInfectedType::Charger)
+				{
+					m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
+				}
 				m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
 			}
 		}

--- a/thirdparty/hooks.cpp
+++ b/thirdparty/hooks.cpp
@@ -697,7 +697,12 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 			if (!isRagdoll)
 			{
 				m_VR->RefreshSpecialInfectedPreWarning(info.origin, infectedType);
-				m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
+				if (infectedType != VR::SpecialInfectedType::Tank
+					&& infectedType != VR::SpecialInfectedType::Witch
+					&& infectedType != VR::SpecialInfectedType::Charger)
+				{
+					m_VR->RefreshSpecialInfectedBlindSpotWarning(info.origin);
+				}
 				m_VR->DrawSpecialInfectedArrow(info.origin, infectedType);
 			}
 		}


### PR DESCRIPTION
### Motivation
- The blind-spot proximity warning triggered by `SpecialInfectedBlindSpotDistance` should not apply to certain large/unique special infected types (Tank, Witch, Charger) to avoid inappropriate warnings.
- The hooks that call into the VR warning logic currently invoke the blind-spot check for all special infected models.

### Description
- Add conditional checks in `L4D2VR/hooks.cpp` to skip calling `RefreshSpecialInfectedBlindSpotWarning` when `infectedType` is `Tank`, `Witch`, or `Charger`.
- Apply the same conditional change in `thirdparty/hooks.cpp` to keep behavior consistent across both hook implementations.
- Preserve existing calls to `RefreshSpecialInfectedPreWarning` and `DrawSpecialInfectedArrow` for all special infected types.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483bc979fc8321855b2b864ec7d53e)