### PR TITLE
Add SpecialInfectedDebug flag to opt out of aim clamps

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -40,6 +40,7 @@ ViewmodelAdjustCombo=Reload+SecondaryAttack
 # Any combo can be disabled by setting it to "false".
 ViewmodelAdjustEnabled=true
 SpecialInfectedBlindSpotDistance=300.0
+SpecialInfectedDebug=false
 SpecialInfectedPreWarningAutoAimEnabled=false
 SpecialInfectedPreWarningDistance=450.0
 SpecialInfectedPreWarningAimAngle=30.0

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1826,7 +1826,9 @@ void VR::UpdateTracking()
         if (!toTarget.IsZero())
         {
             VectorNormalize(toTarget);
-            const float lerpFactor = std::clamp(m_SpecialInfectedAutoAimLerp, 0.0f, 1.0f);
+            const float lerpFactor = m_SpecialInfectedDebug
+                ? std::max(0.0f, m_SpecialInfectedAutoAimLerp)
+                : std::clamp(m_SpecialInfectedAutoAimLerp, 0.0f, 0.4f);
             if (m_SpecialInfectedAutoAimDirection.IsZero())
                 m_SpecialInfectedAutoAimDirection = toTarget;
             else
@@ -2501,7 +2503,9 @@ void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialI
     const bool inRange = distanceSq <= maxDistanceSq;
     if (inRange)
     {
-        const float maxAimAngle = std::clamp(m_SpecialInfectedPreWarningAimAngle, 0.0f, 180.0f);
+        const float maxAimAngle = m_SpecialInfectedDebug
+            ? std::max(0.0f, m_SpecialInfectedPreWarningAimAngle)
+            : std::clamp(m_SpecialInfectedPreWarningAimAngle, 0.0f, 5.0f);
         if (maxAimAngle > 0.0f)
         {
             Vector aimDirection = m_RightControllerForward;
@@ -3423,6 +3427,7 @@ void VR::ParseConfigFile()
     m_RequireSecondaryAttackForItemSwitch = getBool("RequireSecondaryAttackForItemSwitch", m_RequireSecondaryAttackForItemSwitch);
     m_SpecialInfectedWarningActionEnabled = getBool("SpecialInfectedAutoEvade", m_SpecialInfectedWarningActionEnabled);
     m_SpecialInfectedArrowEnabled = getBool("SpecialInfectedArrowEnabled", m_SpecialInfectedArrowEnabled);
+    m_SpecialInfectedDebug = getBool("SpecialInfectedDebug", m_SpecialInfectedDebug);
     m_SpecialInfectedArrowSize = std::max(0.0f, getFloat("SpecialInfectedArrowSize", m_SpecialInfectedArrowSize));
     m_SpecialInfectedArrowHeight = std::max(0.0f, getFloat("SpecialInfectedArrowHeight", m_SpecialInfectedArrowHeight));
     m_SpecialInfectedArrowThickness = std::max(0.0f, getFloat("SpecialInfectedArrowThickness", m_SpecialInfectedArrowThickness));
@@ -3432,8 +3437,14 @@ void VR::ParseConfigFile()
         m_SpecialInfectedPreWarningAutoAimEnabled = false;
     m_SpecialInfectedPreWarningDistance = std::max(0.0f, getFloat("SpecialInfectedPreWarningDistance", m_SpecialInfectedPreWarningDistance));
     m_SpecialInfectedPreWarningTargetUpdateInterval = std::max(0.0f, getFloat("SpecialInfectedPreWarningTargetUpdateInterval", m_SpecialInfectedPreWarningTargetUpdateInterval));
-    m_SpecialInfectedPreWarningAimAngle = std::clamp(getFloat("SpecialInfectedPreWarningAimAngle", m_SpecialInfectedPreWarningAimAngle), 0.0f, 180.0f);
-    m_SpecialInfectedAutoAimLerp = std::clamp(getFloat("SpecialInfectedAutoAimLerp", m_SpecialInfectedAutoAimLerp), 0.0f, 1.0f);
+    const float preWarningAimAngle = getFloat("SpecialInfectedPreWarningAimAngle", m_SpecialInfectedPreWarningAimAngle);
+    m_SpecialInfectedPreWarningAimAngle = m_SpecialInfectedDebug
+        ? std::max(0.0f, preWarningAimAngle)
+        : std::clamp(preWarningAimAngle, 0.0f, 5.0f);
+    const float autoAimLerp = getFloat("SpecialInfectedAutoAimLerp", m_SpecialInfectedAutoAimLerp);
+    m_SpecialInfectedAutoAimLerp = m_SpecialInfectedDebug
+        ? std::max(0.0f, autoAimLerp)
+        : std::clamp(autoAimLerp, 0.0f, 0.4f);
     m_SpecialInfectedAutoAimCooldown = std::max(0.0f, getFloat("SpecialInfectedAutoAimCooldown", m_SpecialInfectedAutoAimCooldown));
     m_SpecialInfectedWarningSecondaryHoldDuration = std::max(0.0f, getFloat("SpecialInfectedWarningSecondaryHoldDuration", m_SpecialInfectedWarningSecondaryHoldDuration));
     m_SpecialInfectedWarningPostAttackDelay = std::max(0.0f, getFloat("SpecialInfectedWarningPostAttackDelay", m_SpecialInfectedWarningPostAttackDelay));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -353,6 +353,7 @@ public:
 	static constexpr int kLifeStateOffset = 0x147;
 
 	bool m_SpecialInfectedArrowEnabled = false;
+	bool m_SpecialInfectedDebug = false;
 	float m_SpecialInfectedArrowSize = 12.0f;
 	float m_SpecialInfectedArrowHeight = 36.0f;
 	float m_SpecialInfectedArrowThickness = 0.0f;


### PR DESCRIPTION
### Motivation
- Enforce sane upper bounds on special-infected auto-aim and pre-warning angle while allowing an opt-out for debugging and tuning.
- Prevent runtime aiming behavior from being driven by out-of-range config values unless explicitly requested.
- Provide a config toggle so developers can temporarily disable the caps without changing code.

### Description
- Added a new `bool m_SpecialInfectedDebug` member and a `SpecialInfectedDebug=false` default entry in `L4D2VR/config.txt` to control clamp behavior.
- Parse `SpecialInfectedDebug` with `getBool` in `ParseConfigFile` and use it to conditionally apply limits when loading `SpecialInfectedPreWarningAimAngle` and `SpecialInfectedAutoAimLerp`.
- Make runtime checks debug-aware by using `m_SpecialInfectedDebug` when computing `lerpFactor` in `UpdateTracking` and `maxAimAngle` in `RefreshSpecialInfectedPreWarning` so caps are bypassed when debug is enabled.
- Changes are localized to `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, and `L4D2VR/config.txt` and use `std::clamp`/`std::max` to keep values non-negative.

### Testing
- No automated tests were run for this change.
- No CI build or unit tests were executed as part of this update.
- Changes were kept minimal and limited to config parsing and conditional clamp logic to reduce risk of regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948c34e0e388321ab7cc53a356130cf)