### PR TITLE
Add 'hold:' support for CustomAction key bindings

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -57,6 +57,7 @@ SpecialInfectedPreWarningAimOffsetTank=0,0,0
 SpecialInfectedPreWarningAimOffsetWitch=0,0,0
 # Console commands executed when pressing the custom SteamVR bindings (leave empty to disable)
 # Prefix a value with "key:" to send a keyboard key instead of a console command (e.g. key:space, key:f5, key:k)
+# Prefix with "hold:" to send keydown/keyup on press/release (e.g. hold:key:space)
 CustomAction1Command=
 CustomAction2Command=
 CustomAction3Command=

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -44,6 +44,7 @@ struct CustomActionBinding
 {
 	std::string command;
 	std::optional<WORD> virtualKey;
+	bool holdVirtualKey = false;
 };
 
 
@@ -436,6 +437,8 @@ public:
 	void ProcessMenuInput();
 	void ProcessInput();
 	void SendVirtualKey(WORD virtualKey);
+	void SendVirtualKeyDown(WORD virtualKey);
+	void SendVirtualKeyUp(WORD virtualKey);
 	void SendFunctionKey(WORD virtualKey);
 	VMatrix VMatrixFromHmdMatrix(const vr::HmdMatrix34_t& hmdMat);
 	vr::HmdMatrix34_t VMatrixToHmdMatrix(const VMatrix& vMat);


### PR DESCRIPTION
### Motivation

- Allow SteamVR custom actions to either send an instantaneous key press or emulate holding a key for actions that require press-and-hold.
- The previous implementation always sent a quick keydown+keyup which fails for bindings that expect a sustained press.
- Provide an easy config syntax to opt into hold behavior per binding.
- Improve logging so users can confirm whether a binding is treated as a hold.

### Description

- Added `holdVirtualKey` to `CustomActionBinding` and updated parsing in `ParseConfigFile` to recognize a `hold:` prefix (e.g. `hold:key:space`).
- Reworked custom-action handling in `ProcessInput` to inspect digital action state (`bState`/`bChanged`) and send `keydown`/`keyup` events for hold bindings or a single `SendVirtualKey` for instant bindings.
- Split key-sending helpers into `SendVirtualKeyDown`, `SendVirtualKeyUp`, and updated `SendVirtualKey` to call them.
- Documented the new `hold:` syntax in `config.txt` and enhanced log messages to indicate `(hold)` when applicable.

### Testing

- No automated tests were run for this change.
- (Manual verification steps recommended: set `CustomActionXCommand=hold:key:<k>` and confirm keydown on press and keyup on release; set `CustomActionXCommand=key:<k>` for instant presses.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948c39586cc8321bde222c4d24fff7a)