### PR TITLE
Allow canceling pre-warning auto aim via controller movement

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1837,6 +1837,10 @@ void VR::UpdateTracking()
     m_RightControllerForward = VectorRotate(m_RightControllerForward, m_RightControllerRight, -45.0);
     m_RightControllerUp = VectorRotate(m_RightControllerUp, m_RightControllerRight, -45.0);
 
+    m_RightControllerForwardUnforced = m_RightControllerForward;
+    if (!m_RightControllerForwardUnforced.IsZero())
+        m_LastUnforcedAimDirection = m_RightControllerForwardUnforced;
+
     const bool shouldForceAim = m_SpecialInfectedPreWarningActive;
     const Vector forcedTarget = m_SpecialInfectedPreWarningTarget;
 
@@ -2532,9 +2536,9 @@ void VR::RefreshSpecialInfectedPreWarning(const Vector& infectedOrigin, SpecialI
             : std::clamp(m_SpecialInfectedPreWarningAimAngle, 0.0f, 5.0f);
         if (maxAimAngle > 0.0f)
         {
-            Vector aimDirection = m_RightControllerForward;
+            Vector aimDirection = m_RightControllerForwardUnforced;
             if (aimDirection.IsZero())
-                aimDirection = m_LastAimDirection;
+                aimDirection = m_LastUnforcedAimDirection;
 
             Vector toTarget = infectedOrigin - m_RightControllerPosAbs;
             if (!aimDirection.IsZero() && !toTarget.IsZero())

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -88,6 +88,7 @@ public:
 	Vector m_LeftControllerRight;
 	Vector m_LeftControllerUp;
 
+	Vector m_RightControllerForwardUnforced = { 0,0,0 };
 	Vector m_RightControllerForward;
 	Vector m_RightControllerRight;
 	Vector m_RightControllerUp;
@@ -153,6 +154,7 @@ public:
 	Vector m_AimLineStart = { 0,0,0 };
 	Vector m_AimLineEnd = { 0,0,0 };
 	Vector m_LastAimDirection = { 0,0,0 };
+	Vector m_LastUnforcedAimDirection = { 0,0,0 };
 	bool m_HasAimLine = false;
 	float m_AimLineThickness = 2.0f;
 	bool m_AimLineEnabled = true;


### PR DESCRIPTION
## Summary
- track the controller's unforced forward direction before pre-warning auto-aim adjusts it
- use the unforced aim direction when evaluating the pre-warning aim angle so moving the controller can break the lock

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cef70c5188321be9c2b86ed1fabc7)