### PR TITLE
Add config toggle to control controller HUD cutting

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -24,6 +24,7 @@ ControllerHudYOffset=0.1
 ControllerHudZOffset=-0.3
 ControllerHudRotation=-60
 ControllerHudXOffset=0.1
+ControllerHudCut=false
 MotionGestureSwingThreshold=1.1
 MotionGestureDownSwingThreshold=1.0
 MotionGestureJumpThreshold=1.0

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -331,10 +331,10 @@ void VR::SubmitVRTextures()
 
     const vr::VRTextureBounds_t topBounds{ 0.0f, 0.0f, 1.0f, 0.5f };
     const std::array<vr::VRTextureBounds_t, 4> bottomBounds{
-        vr::VRTextureBounds_t{ 0.0f, 0.5f, 0.25f, 1.0f },
-        vr::VRTextureBounds_t{ 0.25f, 0.5f, 0.5f, 1.0f },
-        vr::VRTextureBounds_t{ 0.5f, 0.5f, 0.75f, 1.0f },
-        vr::VRTextureBounds_t{ 0.75f, 0.5f, 1.0f, 1.0f }
+        vr::VRTextureBounds_t{ 0.0f, m_ControllerHudCut ? 0.5f : 0.0f, 0.25f, 1.0f },
+        vr::VRTextureBounds_t{ 0.25f, m_ControllerHudCut ? 0.5f : 0.0f, 0.5f, 1.0f },
+        vr::VRTextureBounds_t{ 0.5f, m_ControllerHudCut ? 0.5f : 0.0f, 0.75f, 1.0f },
+        vr::VRTextureBounds_t{ 0.75f, m_ControllerHudCut ? 0.5f : 0.0f, 1.0f, 1.0f }
     };
 
     auto applyHudTexture = [&](vr::VROverlayHandle_t overlay, const vr::VRTextureBounds_t& bounds)
@@ -3507,6 +3507,7 @@ void VR::ParseConfigFile()
     m_ControllerHudZOffset = getFloat("ControllerHudZOffset", m_ControllerHudZOffset);
     m_ControllerHudRotation = getFloat("ControllerHudRotation", m_ControllerHudRotation);
     m_ControllerHudXOffset = getFloat("ControllerHudXOffset", m_ControllerHudXOffset);
+    m_ControllerHudCut = getBool("ControllerHudCut", m_ControllerHudCut);
     m_HudAlwaysVisible = getBool("HudAlwaysVisible", m_HudAlwaysVisible);
     m_HudToggleState = m_HudAlwaysVisible;
     m_FixedHudYOffset = getFloat("FixedHudYOffset", m_FixedHudYOffset);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -294,6 +294,7 @@ public:
 	float m_ControllerHudZOffset = 0.0f;
 	float m_ControllerHudRotation = 0.0f;
 	float m_ControllerHudXOffset = 0.0f;
+	bool m_ControllerHudCut = false;
 	bool m_HudAlwaysVisible = false;
 	bool m_HudToggleState = false;
 	std::chrono::steady_clock::time_point m_HudChatVisibleUntil{};


### PR DESCRIPTION
## Summary
- add ControllerHudCut option to config.txt to control whether controller HUD segments use the cut overlay
- default to showing the full HUD on controllers while still allowing optional cutting via config
- plumb the new flag through parsing and overlay bounds when drawing the controller HUD

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd1a07380832195235c897bc6f7a9)