### PR TITLE
Add VR pose payload ring buffer and sync DXVK matrices

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -208,6 +208,8 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 
 	CViewSetup leftEyeView = setup;
 	CViewSetup rightEyeView = setup;
+	m_VR->m_LastZNear = setup.zNear;
+	m_VR->m_LastZFar = setup.zFar;
 
 	// Left eye CViewSetup
 	leftEyeView.x = 0;

--- a/L4D2VR/sdk/vector.h
+++ b/L4D2VR/sdk/vector.h
@@ -1,6 +1,7 @@
 //========= Copyright Valve Corporation, All rights reserved. ============//
 #pragma once
 #include <cmath>
+#include <cstring>
 
 #define  FORCEINLINE			__forceinline
 
@@ -668,61 +669,6 @@ public:
 	vec_t		m[4][4];
 };
 
-// Inline implementations for commonly used VMatrix helpers
-inline VMatrix& VMatrix::operator=(const VMatrix& mOther)
-{
-	if (this == &mOther)
-		return *this;
-
-	memcpy(m, mOther.m, sizeof(m));
-	return *this;
-}
-
-inline void VMatrix::Identity()
-{
-	m[0][0] = 1.0f; m[0][1] = 0.0f; m[0][2] = 0.0f; m[0][3] = 0.0f;
-	m[1][0] = 0.0f; m[1][1] = 1.0f; m[1][2] = 0.0f; m[1][3] = 0.0f;
-	m[2][0] = 0.0f; m[2][1] = 0.0f; m[2][2] = 1.0f; m[2][3] = 0.0f;
-	m[3][0] = 0.0f; m[3][1] = 0.0f; m[3][2] = 0.0f; m[3][3] = 1.0f;
-}
-
-inline void VMatrix::SetupMatrixOrgAngles(const Vector& origin, const QAngle& vAngles)
-{
-	Vector forward, right, up;
-	QAngle::AngleVectors(vAngles, &forward, &right, &up);
-
-	m[0][0] = forward.x; m[0][1] = right.x; m[0][2] = up.x;   m[0][3] = origin.x;
-	m[1][0] = forward.y; m[1][1] = right.y; m[1][2] = up.y;   m[1][3] = origin.y;
-	m[2][0] = forward.z; m[2][1] = right.z; m[2][2] = up.z;   m[2][3] = origin.z;
-	m[3][0] = 0.0f;      m[3][1] = 0.0f;    m[3][2] = 0.0f;    m[3][3] = 1.0f;
-}
-
-inline void VMatrix::InverseTR(VMatrix& mRet) const
-{
-	// Assumes rotation + translation only
-	mRet.m[0][0] = m[0][0]; mRet.m[0][1] = m[1][0]; mRet.m[0][2] = m[2][0];
-	mRet.m[1][0] = m[0][1]; mRet.m[1][1] = m[1][1]; mRet.m[1][2] = m[2][1];
-	mRet.m[2][0] = m[0][2]; mRet.m[2][1] = m[1][2]; mRet.m[2][2] = m[2][2];
-	mRet.m[3][0] = 0.0f;    mRet.m[3][1] = 0.0f;    mRet.m[3][2] = 0.0f;
-	mRet.m[3][3] = 1.0f;
-
-	// Translation
-	float tx = -m[0][3];
-	float ty = -m[1][3];
-	float tz = -m[2][3];
-
-	mRet.m[0][3] = tx * mRet.m[0][0] + ty * mRet.m[0][1] + tz * mRet.m[0][2];
-	mRet.m[1][3] = tx * mRet.m[1][0] + ty * mRet.m[1][1] + tz * mRet.m[1][2];
-	mRet.m[2][3] = tx * mRet.m[2][0] + ty * mRet.m[2][1] + tz * mRet.m[2][2];
-}
-
-inline VMatrix VMatrix::InverseTR() const
-{
-	VMatrix result;
-	InverseTR(result);
-	return result;
-}
-
 inline Vector Vector::operator*(float fl) const
 {
 	Vector res;
@@ -1142,4 +1088,59 @@ inline void QAngle::VectorAngles(const Vector &forward, const Vector &pseudoup, 
 		// Assume no roll in this case as one degree of freedom has been lost (i.e. yaw == roll)
 		angles[2] = 0;
 	}
+}
+
+// Inline implementations for commonly used VMatrix helpers
+inline VMatrix& VMatrix::operator=(const VMatrix& mOther)
+{
+	if (this == &mOther)
+		return *this;
+
+	memcpy(m, mOther.m, sizeof(m));
+	return *this;
+}
+
+inline void VMatrix::Identity()
+{
+	m[0][0] = 1.0f; m[0][1] = 0.0f; m[0][2] = 0.0f; m[0][3] = 0.0f;
+	m[1][0] = 0.0f; m[1][1] = 1.0f; m[1][2] = 0.0f; m[1][3] = 0.0f;
+	m[2][0] = 0.0f; m[2][1] = 0.0f; m[2][2] = 1.0f; m[2][3] = 0.0f;
+	m[3][0] = 0.0f; m[3][1] = 0.0f; m[3][2] = 0.0f; m[3][3] = 1.0f;
+}
+
+inline void VMatrix::SetupMatrixOrgAngles(const Vector& origin, const QAngle& vAngles)
+{
+	Vector forward, right, up;
+	QAngle::AngleVectors(vAngles, &forward, &right, &up);
+
+	m[0][0] = forward.x; m[0][1] = right.x; m[0][2] = up.x;   m[0][3] = origin.x;
+	m[1][0] = forward.y; m[1][1] = right.y; m[1][2] = up.y;   m[1][3] = origin.y;
+	m[2][0] = forward.z; m[2][1] = right.z; m[2][2] = up.z;   m[2][3] = origin.z;
+	m[3][0] = 0.0f;      m[3][1] = 0.0f;    m[3][2] = 0.0f;    m[3][3] = 1.0f;
+}
+
+inline void VMatrix::InverseTR(VMatrix& mRet) const
+{
+	// Assumes rotation + translation only
+	mRet.m[0][0] = m[0][0]; mRet.m[0][1] = m[1][0]; mRet.m[0][2] = m[2][0];
+	mRet.m[1][0] = m[0][1]; mRet.m[1][1] = m[1][1]; mRet.m[1][2] = m[2][1];
+	mRet.m[2][0] = m[0][2]; mRet.m[2][1] = m[1][2]; mRet.m[2][2] = m[2][2];
+	mRet.m[3][0] = 0.0f;    mRet.m[3][1] = 0.0f;    mRet.m[3][2] = 0.0f;
+	mRet.m[3][3] = 1.0f;
+
+	// Translation
+	float tx = -m[0][3];
+	float ty = -m[1][3];
+	float tz = -m[2][3];
+
+	mRet.m[0][3] = tx * mRet.m[0][0] + ty * mRet.m[0][1] + tz * mRet.m[0][2];
+	mRet.m[1][3] = tx * mRet.m[1][0] + ty * mRet.m[1][1] + tz * mRet.m[1][2];
+	mRet.m[2][3] = tx * mRet.m[2][0] + ty * mRet.m[2][1] + tz * mRet.m[2][2];
+}
+
+inline VMatrix VMatrix::InverseTR() const
+{
+	VMatrix result;
+	InverseTR(result);
+	return result;
 }

--- a/L4D2VR/sdk/vector.h
+++ b/L4D2VR/sdk/vector.h
@@ -668,6 +668,60 @@ public:
 	vec_t		m[4][4];
 };
 
+// Inline implementations for commonly used VMatrix helpers
+inline VMatrix& VMatrix::operator=(const VMatrix& mOther)
+{
+	if (this == &mOther)
+		return *this;
+
+	memcpy(m, mOther.m, sizeof(m));
+	return *this;
+}
+
+inline void VMatrix::Identity()
+{
+	m[0][0] = 1.0f; m[0][1] = 0.0f; m[0][2] = 0.0f; m[0][3] = 0.0f;
+	m[1][0] = 0.0f; m[1][1] = 1.0f; m[1][2] = 0.0f; m[1][3] = 0.0f;
+	m[2][0] = 0.0f; m[2][1] = 0.0f; m[2][2] = 1.0f; m[2][3] = 0.0f;
+	m[3][0] = 0.0f; m[3][1] = 0.0f; m[3][2] = 0.0f; m[3][3] = 1.0f;
+}
+
+inline void VMatrix::SetupMatrixOrgAngles(const Vector& origin, const QAngle& vAngles)
+{
+	Vector forward, right, up;
+	QAngle::AngleVectors(vAngles, &forward, &right, &up);
+
+	m[0][0] = forward.x; m[0][1] = right.x; m[0][2] = up.x;   m[0][3] = origin.x;
+	m[1][0] = forward.y; m[1][1] = right.y; m[1][2] = up.y;   m[1][3] = origin.y;
+	m[2][0] = forward.z; m[2][1] = right.z; m[2][2] = up.z;   m[2][3] = origin.z;
+	m[3][0] = 0.0f;      m[3][1] = 0.0f;    m[3][2] = 0.0f;    m[3][3] = 1.0f;
+}
+
+inline void VMatrix::InverseTR(VMatrix& mRet) const
+{
+	// Assumes rotation + translation only
+	mRet.m[0][0] = m[0][0]; mRet.m[0][1] = m[1][0]; mRet.m[0][2] = m[2][0];
+	mRet.m[1][0] = m[0][1]; mRet.m[1][1] = m[1][1]; mRet.m[1][2] = m[2][1];
+	mRet.m[2][0] = m[0][2]; mRet.m[2][1] = m[1][2]; mRet.m[2][2] = m[2][2];
+	mRet.m[3][0] = 0.0f;    mRet.m[3][1] = 0.0f;    mRet.m[3][2] = 0.0f;
+	mRet.m[3][3] = 1.0f;
+
+	// Translation
+	float tx = -m[0][3];
+	float ty = -m[1][3];
+	float tz = -m[2][3];
+
+	mRet.m[0][3] = tx * mRet.m[0][0] + ty * mRet.m[0][1] + tz * mRet.m[0][2];
+	mRet.m[1][3] = tx * mRet.m[1][0] + ty * mRet.m[1][1] + tz * mRet.m[1][2];
+	mRet.m[2][3] = tx * mRet.m[2][0] + ty * mRet.m[2][1] + tz * mRet.m[2][2];
+}
+
+inline VMatrix VMatrix::InverseTR() const
+{
+	VMatrix result;
+	InverseTR(result);
+	return result;
+}
 
 inline Vector Vector::operator*(float fl) const
 {

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -177,6 +177,8 @@ public:
 	float m_ThrowArcLandingOffset = -90.0f;
 	// Tracks the duration of the previous frame so the aim line can persist when the framerate dips.
 	float m_LastFrameDuration = 1.0f / 90.0f;
+	float m_LastZNear = 6.0f;
+	float m_LastZFar = 10000.0f;
 
 	float m_Ipd;
 	float m_EyeZ;
@@ -464,6 +466,9 @@ public:
 	Vector GetViewAngle();
 	Vector GetViewOriginLeft();
 	Vector GetViewOriginRight();
+	void PublishViewPayload();
+	VMatrix BuildEyeViewMatrix(const Vector& origin, const QAngle& angles) const;
+	VMatrix BuildEyeProjectionMatrix(vr::EVREye eye) const;
 	Vector GetThirdPersonViewOrigin() const { return m_ThirdPersonViewOrigin; }
 	QAngle GetThirdPersonViewAngles() const { return m_ThirdPersonViewAngles; }
 	bool IsThirdPersonCameraActive() const { return m_IsThirdPersonCamera; }

--- a/L4D2VR/vr_payload.h
+++ b/L4D2VR/vr_payload.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+
+#include "sdk/vector.h"
+
+struct VrViewPayload
+{
+    uint64_t sequence = 0;
+
+    Vector hmdPositionAbs = { 0.0f, 0.0f, 0.0f };
+    QAngle hmdAnglesAbs = { 0.0f, 0.0f, 0.0f };
+
+    Vector leftEyePosition = { 0.0f, 0.0f, 0.0f };
+    Vector rightEyePosition = { 0.0f, 0.0f, 0.0f };
+
+    VMatrix leftViewMatrix{};
+    VMatrix rightViewMatrix{};
+
+    VMatrix leftProjectionMatrix{};
+    VMatrix rightProjectionMatrix{};
+
+    std::chrono::steady_clock::time_point capturedAt{};
+};
+
+class VrPayloadRingBuffer
+{
+public:
+    static constexpr size_t kCapacity = 32;
+
+    void Push(const VrViewPayload& payload)
+    {
+        uint64_t nextSequence = m_publishedSequence.load(std::memory_order_relaxed) + 1;
+
+        VrViewPayload copy = payload;
+        copy.sequence = nextSequence;
+
+        const size_t slot = (nextSequence - 1) % kCapacity;
+        m_buffer[slot] = copy;
+
+        std::atomic_thread_fence(std::memory_order_release);
+        m_publishedSequence.store(nextSequence, std::memory_order_release);
+    }
+
+    bool TryReadLatest(VrViewPayload& payloadOut, uint64_t& sequenceOut) const
+    {
+        const uint64_t sequence = m_publishedSequence.load(std::memory_order_acquire);
+
+        if (sequence == 0)
+            return false;
+
+        const size_t slot = (sequence - 1) % kCapacity;
+        const VrViewPayload& payload = m_buffer[slot];
+
+        if (payload.sequence != sequence)
+            return false;
+
+        payloadOut = payload;
+        sequenceOut = sequence;
+        return true;
+    }
+
+    uint64_t LatestSequence() const
+    {
+        return m_publishedSequence.load(std::memory_order_acquire);
+    }
+
+private:
+    std::array<VrViewPayload, kCapacity> m_buffer{};
+    std::atomic<uint64_t> m_publishedSequence{ 0 };
+};
+
+inline VrPayloadRingBuffer g_VrViewPayloadQueue{};

--- a/dxvk_local/src/d3d9/d3d9_device.cpp
+++ b/dxvk_local/src/d3d9/d3d9_device.cpp
@@ -7499,13 +7499,24 @@ namespace dxvk {
     if (!surface || !g_Game || !g_Game->m_VR)
       return false;
 
-    if (surface == static_cast<D3D9Surface*>(g_Game->m_VR->m_D9LeftEyeSurface))
+    auto matchesSurface = [&](IDirect3DSurface9* vrSurface)->bool
+    {
+      return vrSurface && surface == static_cast<D3D9Surface*>(vrSurface);
+    };
+
+    auto matchesImage = [&](const SharedTextureHolder& holder)->bool
+    {
+      auto* image = surface->GetCommonTexture()->GetImage();
+      return holder.m_VulkanData.m_nImage != 0 && image && uint64_t(image->handle()) == holder.m_VulkanData.m_nImage;
+    };
+
+    if (matchesSurface(g_Game->m_VR->m_D9LeftEyeSurface) || matchesImage(g_Game->m_VR->m_VKLeftEye))
     {
       eyeOut = VrEye::Left;
       return true;
     }
 
-    if (surface == static_cast<D3D9Surface*>(g_Game->m_VR->m_D9RightEyeSurface))
+    if (matchesSurface(g_Game->m_VR->m_D9RightEyeSurface) || matchesImage(g_Game->m_VR->m_VKRightEye))
     {
       eyeOut = VrEye::Right;
       return true;

--- a/dxvk_local/src/d3d9/d3d9_device.cpp
+++ b/dxvk_local/src/d3d9/d3d9_device.cpp
@@ -7500,7 +7500,7 @@ namespace dxvk {
       return false;
 
     D3D9CommonTexture* texInfo = surface->GetCommonTexture();
-    auto* image = texInfo ? texInfo->GetImage() : nullptr;
+    Rc<DxvkImage> image = texInfo ? texInfo->GetImage() : Rc<DxvkImage>{};
 
     auto matchesSurface = [&](IDirect3DSurface9* vrSurface)->bool
     {

--- a/dxvk_local/src/d3d9/d3d9_device.cpp
+++ b/dxvk_local/src/d3d9/d3d9_device.cpp
@@ -7492,12 +7492,15 @@ namespace dxvk {
     }
   }
 
-  bool D3D9DeviceEx::IsVrRenderTarget(const D3D9Surface* surface, VrEye& eyeOut) const
+  bool D3D9DeviceEx::IsVrRenderTarget(D3D9Surface* surface, VrEye& eyeOut) const
   {
     eyeOut = VrEye::None;
 
     if (!surface || !g_Game || !g_Game->m_VR)
       return false;
+
+    D3D9CommonTexture* texInfo = surface->GetCommonTexture();
+    auto* image = texInfo ? texInfo->GetImage() : nullptr;
 
     auto matchesSurface = [&](IDirect3DSurface9* vrSurface)->bool
     {
@@ -7506,7 +7509,6 @@ namespace dxvk {
 
     auto matchesImage = [&](const SharedTextureHolder& holder)->bool
     {
-      auto* image = surface->GetCommonTexture()->GetImage();
       return holder.m_VulkanData.m_nImage != 0 && image && uint64_t(image->handle()) == holder.m_VulkanData.m_nImage;
     };
 

--- a/dxvk_local/src/d3d9/d3d9_device.cpp
+++ b/dxvk_local/src/d3d9/d3d9_device.cpp
@@ -7509,7 +7509,10 @@ namespace dxvk {
 
     auto matchesImage = [&](const SharedTextureHolder& holder)->bool
     {
-      return holder.m_VulkanData.m_nImage != 0 && image && uint64_t(image->handle()) == holder.m_VulkanData.m_nImage;
+      if (holder.m_VulkanData.m_nImage == 0 || !image)
+        return false;
+
+      return uint64_t(image->handle()) == holder.m_VulkanData.m_nImage;
     };
 
     if (matchesSurface(g_Game->m_VR->m_D9LeftEyeSurface) || matchesImage(g_Game->m_VR->m_VKLeftEye))

--- a/dxvk_local/src/d3d9/d3d9_device.h
+++ b/dxvk_local/src/d3d9/d3d9_device.h
@@ -13,6 +13,7 @@
 #include "d3d9_state.h"
 
 #include "d3d9_options.h"
+#include "L4D2VR/vr_payload.h"
 
 #include "../dxso/dxso_module.h"
 #include "../dxso/dxso_util.h"
@@ -28,6 +29,7 @@
 #include <vector>
 #include <type_traits>
 #include <unordered_map>
+#include <chrono>
 
 namespace dxvk {
 
@@ -1141,6 +1143,18 @@ namespace dxvk {
 
     uint64_t GetCurrentSequenceNumber();
 
+    enum class VrEye
+    {
+      None,
+      Left,
+      Right,
+    };
+
+    bool IsVrRenderTarget(const D3D9Surface* surface, VrEye& eyeOut) const;
+    void TryLatchVrPayload(VrEye eye);
+    void UploadVrConstants(VrEye eye);
+    void UpdateVrStatsAfterPresent();
+
     Com<D3D9InterfaceEx>            m_parent;
     D3DDEVTYPE                      m_deviceType;
     HWND                            m_window;
@@ -1270,6 +1284,13 @@ namespace dxvk {
 
     std::atomic<int64_t>            m_availableMemory = { 0 };
     std::atomic<int32_t>            m_samplerCount    = { 0 };
+
+    VrViewPayload                   m_vrLatchedPayload{};
+    uint64_t                        m_vrLatchedSequence = 0;
+    uint64_t                        m_vrLastPresentedSequence = 0;
+    uint64_t                        m_vrDroppedFrames = 0;
+    uint32_t                        m_vrEyeMask = 0;
+    std::chrono::steady_clock::time_point m_vrLastStatsLog{};
 
     Direct3DState9                  m_state;
 

--- a/dxvk_local/src/d3d9/d3d9_device.h
+++ b/dxvk_local/src/d3d9/d3d9_device.h
@@ -1150,7 +1150,7 @@ namespace dxvk {
       Right,
     };
 
-    bool IsVrRenderTarget(const D3D9Surface* surface, VrEye& eyeOut) const;
+    bool IsVrRenderTarget(D3D9Surface* surface, VrEye& eyeOut) const;
     void TryLatchVrPayload(VrEye eye);
     void UploadVrConstants(VrEye eye);
     void UpdateVrStatsAfterPresent();


### PR DESCRIPTION
## Summary
- capture view and projection data each VR update via a lock-free payload ring buffer
- latch a single payload per stereo frame in DXVK, push view/projection matrices into high registers, and gate reuse with sequence metadata
- add payload sequencing logs and store the latest view z-near/z-far to monitor timing issues such as mat_queue_mode=2 drops

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694feab036fc8321bc60e4e78ad86910)