### PR TITLE
Handle infected type lookup safely

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -703,7 +703,7 @@ void Hooks::dDrawModelExecute(void* ecx, void* edx, void* state, const ModelRend
 				isAlive = m_VR->IsEntityAlive(entity);
 			}
 			const bool isInfectedModel = modelName.find("models/infected/") != std::string::npos;
-			if (isInfectedModel)
+			if (isInfectedModel && isPlayerClass)
 			{
 				infectedType = m_VR->GetSpecialInfectedType(entity);
 			}

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2365,8 +2365,22 @@ VR::SpecialInfectedType VR::GetSpecialInfectedType(const C_BaseEntity* entity) c
     if (!entity)
         return SpecialInfectedType::None;
 
-    const auto base = reinterpret_cast<const std::uint8_t*>(entity);
-    const int zombieClass = *reinterpret_cast<const int*>(base + kZombieClassOffset);
+    auto SafeReadInt = [](const void* base, int offset, int& out) -> bool
+    {
+        __try
+        {
+            out = *reinterpret_cast<const int*>(reinterpret_cast<const std::uint8_t*>(base) + offset);
+            return true;
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return false;
+        }
+    };
+
+    int zombieClass = 0;
+    if (!SafeReadInt(entity, kZombieClassOffset, zombieClass))
+        return SpecialInfectedType::None;
 
     switch (zombieClass)
     {


### PR DESCRIPTION
## Summary
- restrict special infected identification to player-class infected models
- guard zombie class offset reads to avoid crashes when accessing invalid entities

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69547f82db7883219bca5fc8e614f3bf)