### PR TITLE
Add automatic Chinese localization to config tool

### DIFF
--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -1,4 +1,4 @@
-﻿#include "Options.h"
+#include "Options.h"
 #include <cstdio>
 #include <cstring>
 #include <string>

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <cctype>
 #include <cstdlib>
+#include <cfloat>
 
 // Search box text (typed in main.cpp)
 char g_OptionSearch[128] = "";
@@ -154,12 +155,16 @@ static void DrawHelp(const Option& opt)
     // Show detailed help when hovering the control (does not consume layout space)
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
     {
+        // Keep tooltip width stable between different options to avoid size flicker.
+        ImGui::SetNextWindowSizeConstraints(ImVec2(320.0f, 0.0f), ImVec2(480.0f, FLT_MAX));
         ImGui::BeginTooltip();
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 38.0f);
         ImGui::TextDisabled("Key: %s", opt.key);
         const char* desc = L(opt.desc);
         const char* tip = L(opt.tip);
         if (desc && *desc) { ImGui::Separator(); ImGui::TextWrapped("%s", desc); }
         if (tip && *tip) { ImGui::Separator(); ImGui::TextWrapped("%s", tip); }
+        ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
     }
 }

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -8,6 +8,11 @@
 // Search box text (typed in main.cpp)
 char g_OptionSearch[128] = "";
 
+static const char* L(const L10nText& t)
+{
+    return (g_UseChinese && t.zh && *t.zh) ? t.zh : t.en;
+}
+
 // ----------------------------
 // Small helper: ASCII case-insensitive substring search
 // (Chinese text is not case-converted and will still match)
@@ -39,11 +44,20 @@ static bool OptionMatchesFilter(const Option& opt)
     if (g_OptionSearch[0] == '\0')
         return true;
 
+    const char* groupEn = opt.group.en ? opt.group.en : "";
+    const char* groupZh = opt.group.zh ? opt.group.zh : "";
+    const char* titleEn = opt.title.en ? opt.title.en : "";
+    const char* titleZh = opt.title.zh ? opt.title.zh : "";
+    const char* descEn = opt.desc.en ? opt.desc.en : "";
+    const char* descZh = opt.desc.zh ? opt.desc.zh : "";
+    const char* tipEn = opt.tip.en ? opt.tip.en : "";
+    const char* tipZh = opt.tip.zh ? opt.tip.zh : "";
+
     return ContainsI(opt.key, g_OptionSearch) ||
-        ContainsI(opt.group, g_OptionSearch) ||
-        ContainsI(opt.title, g_OptionSearch) ||
-        ContainsI(opt.desc, g_OptionSearch) ||
-        ContainsI(opt.tip, g_OptionSearch);
+        ContainsI(groupEn, g_OptionSearch) || ContainsI(groupZh, g_OptionSearch) ||
+        ContainsI(titleEn, g_OptionSearch) || ContainsI(titleZh, g_OptionSearch) ||
+        ContainsI(descEn, g_OptionSearch) || ContainsI(descZh, g_OptionSearch) ||
+        ContainsI(tipEn, g_OptionSearch) || ContainsI(tipZh, g_OptionSearch);
 }
 
 static std::string GetStr(const std::string& key)
@@ -142,8 +156,10 @@ static void DrawHelp(const Option& opt)
     {
         ImGui::BeginTooltip();
         ImGui::TextDisabled("Key: %s", opt.key);
-        if (opt.desc && *opt.desc) { ImGui::Separator(); ImGui::TextWrapped("%s", opt.desc); }
-        if (opt.tip && *opt.tip) { ImGui::Separator(); ImGui::TextWrapped("%s", opt.tip); }
+        const char* desc = L(opt.desc);
+        const char* tip = L(opt.tip);
+        if (desc && *desc) { ImGui::Separator(); ImGui::TextWrapped("%s", desc); }
+        if (tip && *tip) { ImGui::Separator(); ImGui::TextWrapped("%s", tip); }
         ImGui::EndTooltip();
     }
 }
@@ -158,74 +174,90 @@ Option g_Options[] =
     {
         "ForceNonVRServerMovement",
         OptionType::Bool,
-        u8"Multiplayer / Server Compatibility",
-        u8"Non-VR Server Compatibility Mode",
-        u8"When playing on a non-VR server, convert VR movement and interaction into forms that are more acceptable to standard servers.",
-        u8"Recommended for multiplayer. Usually unnecessary for single-player or VR-enabled servers.",
+        { u8"Multiplayer / Server Compatibility", u8"多人 / 服务器兼容" },
+        { u8"Non-VR Server Compatibility Mode", u8"非VR服务器兼容模式" },
+        { u8"When playing on a non-VR server, convert VR movement and interaction into forms that are more acceptable to standard servers.",
+          u8"在非VR服务器上游玩时，将VR移动和交互转换为更适合传统服务器的形式。" },
+        { u8"Recommended for multiplayer. Usually unnecessary for single-player or VR-enabled servers.",
+          u8"多人游戏推荐启用。单人或支持VR的服务器通常不需要。" },
     },
 
     // Aim Line
     {
         "AimLineEnabled",
         OptionType::Bool,
-        u8"Aim Assist",
-        u8"Enable Aim Line",
-        u8"Whether to render the VR aiming line.",
-        u8"Disabling slightly reduces rendering and logic overhead."
+        { u8"Aim Assist", u8"辅助瞄准" },
+        { u8"Enable Aim Line", u8"启用瞄准线" },
+        { u8"Whether to render the VR aiming line.",
+          u8"是否渲染VR瞄准线。" },
+        { u8"Disabling slightly reduces rendering and logic overhead.",
+          u8"关闭可略微减少渲染和逻辑开销。" }
     },
     {
         "AimLineFrameDurationMultiplier",
         OptionType::Float,
-        u8"Aim Assist",
-        u8"Aim Line Persistence",
-        u8"Controls how long the aim line lingers (trail effect). Higher values keep historical frames longer.",
-        u8"Recommended 1.0 ~ 1.5. Too high may look cluttered.",
+        { u8"Aim Assist", u8"辅助瞄准" },
+        { u8"Aim Line Persistence", u8"瞄准线保留时间" },
+        { u8"Controls how long the aim line lingers (trail effect). Higher values keep historical frames longer.",
+          u8"控制瞄准线停留时间（拖尾效果）。值越高，历史帧保留越久。" },
+        { u8"Recommended 1.0 ~ 1.5. Too high may look cluttered.",
+          u8"推荐 1.0 ~ 1.5，过高可能显得杂乱。" },
         0.1f, 5.0f
     },
     {
         "AimLineMaxHz",
         OptionType::Int,
-        u8"Aim Assist",
-        u8"Aim Line Update Rate Limit",
-        u8"Limits the maximum aim-line updates per second to control trace and CPU usage.",
-        u8"Recommended 60~120. Lower to 45/30 on weaker machines.",
+        { u8"Aim Assist", u8"辅助瞄准" },
+        { u8"Aim Line Update Rate Limit", u8"瞄准线刷新率上限" },
+        { u8"Limits the maximum aim-line updates per second to control trace and CPU usage.",
+          u8"限制瞄准线每秒更新次数，以控制追踪和CPU开销。" },
+        { u8"Recommended 60~120. Lower to 45/30 on weaker machines.",
+          u8"推荐 60~120。性能不足时可降到 45/30。" },
         10.f, 240.f
     },
     {
         "AimLineThickness",
         OptionType::Float,
-        u8"Aim Assist",
-        u8"Aim Line Thickness",
-        u8"Affects visual thickness only; does not affect hit detection.",
-        u8"Recommended 1.0 ~ 2.0",
+        { u8"Aim Assist", u8"辅助瞄准" },
+        { u8"Aim Line Thickness", u8"瞄准线粗细" },
+        { u8"Affects visual thickness only; does not affect hit detection.",
+          u8"仅影响视觉粗细，不影响判定。" },
+        { u8"Recommended 1.0 ~ 2.0",
+          u8"推荐 1.0 ~ 2.0" },
         0.1f, 5.0f
     },
     {
         "AimLineColor",
         OptionType::Color,
-        u8"Aim Assist",
-        u8"Aim Line Color",
-        u8"Sets the aim line color (RGBA). Supports values in 0~1 or 0~255.",
-        u8"Example: 1,1,1,1 or 255,255,255,255"
+        { u8"Aim Assist", u8"辅助瞄准" },
+        { u8"Aim Line Color", u8"瞄准线颜色" },
+        { u8"Sets the aim line color (RGBA). Supports values in 0~1 or 0~255.",
+          u8"设置瞄准线颜色（RGBA）。支持 0~1 或 0~255。" },
+        { u8"Example: 1,1,1,1 or 255,255,255,255",
+          u8"示例：1,1,1,1 或 255,255,255,255" }
     },
 
     // Head / View
     {
         "HeadSmoothing",
         OptionType::Float,
-        u8"View / Head",
-        u8"Head Tracking Smoothing",
-        u8"Applies smoothing to head tracking to reduce jitter at the cost of slight latency.",
-        u8"Motion-sickness-prone players may increase this slightly.",
+        { u8"View / Head", u8"视角 / 头部" },
+        { u8"Head Tracking Smoothing", u8"头部追踪平滑" },
+        { u8"Applies smoothing to head tracking to reduce jitter at the cost of slight latency.",
+          u8"为头部追踪添加平滑以减少抖动，但会略微增加延迟。" },
+        { u8"Motion-sickness-prone players may increase this slightly.",
+          u8"易晕玩家可适当提高该值。" },
         0.0f, 1.0f
     },
     {
         "VRScale",
         OptionType::Float,
-        u8"View / Head",
-        u8"VR World Scale",
-        u8"Adjusts overall world scale (distance and sense of size).",
-        u8"Default is 1.0. Large changes may affect distance perception.",
+        { u8"View / Head", u8"视角 / 头部" },
+        { u8"VR World Scale", u8"VR 世界缩放" },
+        { u8"Adjusts overall world scale (distance and sense of size).",
+          u8"调整整体世界尺度（距离感与尺寸感）。" },
+        { u8"Default is 1.0. Large changes may affect distance perception.",
+          u8"默认 1.0，过大调整会影响距离感知。" },
         0.5f, 2.0f
     },
 
@@ -233,19 +265,23 @@ Option g_Options[] =
     {
         "TurnSpeed",
         OptionType::Float,
-        u8"Turning / Input",
-        u8"Turn Speed",
-        u8"Controls smooth turning speed.",
-        u8"Too fast may cause motion sickness; too slow makes turning awkward.",
+        { u8"Turning / Input", u8"转向 / 输入" },
+        { u8"Turn Speed", u8"平滑转向速度" },
+        { u8"Controls smooth turning speed.",
+          u8"控制平滑转向速度。" },
+        { u8"Too fast may cause motion sickness; too slow makes turning awkward.",
+          u8"过快可能引起眩晕，过慢会影响操作。" },
         0.1f, 10.0f
     },
     {
         "ControllerSmoothing",
         OptionType::Float,
-        u8"Turning / Input",
-        u8"Controller Input Smoothing",
-        u8"Smooths controller input to reduce hand jitter.",
-        u8"Excessive values may introduce input latency.",
+        { u8"Turning / Input", u8"转向 / 输入" },
+        { u8"Controller Input Smoothing", u8"手柄输入平滑" },
+        { u8"Smooths controller input to reduce hand jitter.",
+          u8"平滑手柄输入以减少抖动。" },
+        { u8"Excessive values may introduce input latency.",
+          u8"过高会增加输入延迟。" },
         0.0f, 1.0f
     },
 
@@ -253,37 +289,41 @@ Option g_Options[] =
     {
         "ControllerHudSize",
         OptionType::Float,
-        u8"HUD / Controller HUD",
-        u8"Controller HUD Size",
-        u8"Adjusts the size of the HUD attached to the controller.",
-        u8"",
+        { u8"HUD / Controller HUD", u8"HUD / 手柄HUD" },
+        { u8"Controller HUD Size", u8"手柄HUD大小" },
+        { u8"Adjusts the size of the HUD attached to the controller.",
+          u8"调整附着在手柄上的HUD尺寸。" },
+        { u8"", u8"" },
         0.1f, 3.0f
     },
     {
         "ControllerHudXOffset",
         OptionType::Float,
-        u8"HUD / Controller HUD",
-        u8"Controller HUD X Offset",
-        u8"Fine-tunes the left/right position of the controller HUD.",
-        u8"",
+        { u8"HUD / Controller HUD", u8"HUD / 手柄HUD" },
+        { u8"Controller HUD X Offset", u8"手柄HUD X偏移" },
+        { u8"Fine-tunes the left/right position of the controller HUD.",
+          u8"微调手柄HUD的左右位置。" },
+        { u8"", u8"" },
         -50.f, 50.f
     },
     {
         "ControllerHudYOffset",
         OptionType::Float,
-        u8"HUD / Controller HUD",
-        u8"Controller HUD Y Offset",
-        u8"Fine-tunes the up/down position of the controller HUD.",
-        u8"",
+        { u8"HUD / Controller HUD", u8"HUD / 手柄HUD" },
+        { u8"Controller HUD Y Offset", u8"手柄HUD Y偏移" },
+        { u8"Fine-tunes the up/down position of the controller HUD.",
+          u8"微调手柄HUD的上下位置。" },
+        { u8"", u8"" },
         -50.f, 50.f
     },
     {
         "ControllerHudZOffset",
         OptionType::Float,
-        u8"HUD / Controller HUD",
-        u8"Controller HUD Z Offset",
-        u8"Fine-tunes the forward/backward distance of the controller HUD.",
-        u8"",
+        { u8"HUD / Controller HUD", u8"HUD / 手柄HUD" },
+        { u8"Controller HUD Z Offset", u8"手柄HUD Z偏移" },
+        { u8"Fine-tunes the forward/backward distance of the controller HUD.",
+          u8"微调手柄HUD的前后距离。" },
+        { u8"", u8"" },
         -50.f, 50.f
     },
 
@@ -291,27 +331,33 @@ Option g_Options[] =
     {
         "SpecialInfectedPreWarningAutoAimEnabled",
         OptionType::Bool,
-        u8"Special Infected Assist",
-        u8"Enable Special Infected Warning / Assist",
-        u8"Enables special infected pre-warning and related assist logic.",
-        u8"Note: This is an assist feature. Use responsibly."
+        { u8"Special Infected Assist", u8"特感辅助" },
+        { u8"Enable Special Infected Warning / Assist", u8"启用特感预警 / 辅助" },
+        { u8"Enables special infected pre-warning and related assist logic.",
+          u8"启用特感预警及相关辅助逻辑。" },
+        { u8"Note: This is an assist feature. Use responsibly.",
+          u8"注意：此为辅助功能，请合理使用。" }
     },
     {
         "SpecialInfectedPreWarningDistance",
         OptionType::Float,
-        u8"Special Infected Assist",
-        u8"Special Infected Warning Distance",
-        u8"Triggers a warning when special infected enter this distance.",
-        u8"Recommended 400 ~ 600",
+        { u8"Special Infected Assist", u8"特感辅助" },
+        { u8"Special Infected Warning Distance", u8"特感预警距离" },
+        { u8"Triggers a warning when special infected enter this distance.",
+          u8"当特感进入该距离时触发预警。" },
+        { u8"Recommended 400 ~ 600",
+          u8"推荐 400 ~ 600" },
         0.f, 3000.f
     },
     {
         "SpecialInfectedTraceMaxHz",
         OptionType::Int,
-        u8"Special Infected Assist",
-        u8"Special Infected Detection Rate Limit",
-        u8"Limits how often special infected detection traces/logic run per second to reduce CPU cost.",
-        u8"Recommended 60~120. Lower if performance issues occur.",
+        { u8"Special Infected Assist", u8"特感辅助" },
+        { u8"Special Infected Detection Rate Limit", u8"特感检测频率上限" },
+        { u8"Limits how often special infected detection traces/logic run per second to reduce CPU cost.",
+          u8"限制特感检测/逻辑每秒运行次数以降低CPU开销。" },
+        { u8"Recommended 60~120. Lower if performance issues occur.",
+          u8"推荐 60~120。如有性能问题可再降低。" },
         10.f, 240.f
     },
 
@@ -319,19 +365,22 @@ Option g_Options[] =
     {
         "ThrowArcMaxHz",
         OptionType::Int,
-        u8"Throw Prediction",
-        u8"Throw Trajectory Update Rate",
-        u8"Limits how frequently the throw trajectory is updated.",
-        u8"Lowering this can reduce performance cost.",
+        { u8"Throw Prediction", u8"投掷预测" },
+        { u8"Throw Trajectory Update Rate", u8"投掷轨迹刷新率" },
+        { u8"Limits how frequently the throw trajectory is updated.",
+          u8"限制投掷轨迹更新频率。" },
+        { u8"Lowering this can reduce performance cost.",
+          u8"降低该值可减少性能开销。" },
         10.f, 240.f
     },
     {
         "ThrowArcLandingOffset",
         OptionType::Float,
-        u8"Throw Prediction",
-        u8"Throw Landing Offset",
-        u8"Applies positional compensation to the predicted landing point to account for network or engine error.",
-        u8"",
+        { u8"Throw Prediction", u8"投掷预测" },
+        { u8"Throw Landing Offset", u8"投掷落点补偿" },
+        { u8"Applies positional compensation to the predicted landing point to account for network or engine error.",
+          u8"为预测落点添加位置补偿，以应对网络或引擎误差。" },
+        { u8"", u8"" },
         -50.f, 50.f
     },
 
@@ -339,10 +388,12 @@ Option g_Options[] =
     {
         "ViewmodelAdjustEnabled",
         OptionType::Bool,
-        u8"View Model",
-        u8"Enable View Model Adjustment",
-        u8"Allows manual adjustment and saving of weapon/view models.",
-        u8"Typically used to fine-tune weapon grip positioning."
+        { u8"View Model", u8"武器视模" },
+        { u8"Enable View Model Adjustment", u8"启用视模调整" },
+        { u8"Allows manual adjustment and saving of weapon/view models.",
+          u8"允许手动调整并保存武器/视模位置。" },
+        { u8"Typically used to fine-tune weapon grip positioning.",
+          u8"通常用于微调武器握持位置。" }
     },
 };
 
@@ -365,9 +416,11 @@ void DrawOptionsUI()
         std::string key = opt.key;
 
         // Group header
-        if (!currentGroup || std::strcmp(currentGroup, opt.group) != 0)
+        const char* group = L(opt.group);
+
+        if (!currentGroup || std::strcmp(currentGroup, group) != 0)
         {
-            currentGroup = opt.group;
+            currentGroup = group;
             ImGui::SeparatorText(currentGroup);
         }
 
@@ -379,7 +432,7 @@ void DrawOptionsUI()
         case OptionType::Bool:
         {
             bool v = ParseBool(GetStr(key), false);
-            if (ImGui::Checkbox(opt.title, &v))
+            if (ImGui::Checkbox(L(opt.title), &v))
                 g_Values[key] = v ? "true" : "false";
             DrawHelp(opt);
             break;
@@ -388,7 +441,7 @@ void DrawOptionsUI()
         {
             float defV = (opt.min != 0.f || opt.max != 0.f) ? (opt.min + opt.max) * 0.5f : 0.f;
             float v = GetFloat(key, defV);
-            if (ImGui::SliderFloat(opt.title, &v, opt.min, opt.max, "%.3f"))
+            if (ImGui::SliderFloat(L(opt.title), &v, opt.min, opt.max, "%.3f"))
                 g_Values[key] = std::to_string(v);
             DrawHelp(opt);
             break;
@@ -397,7 +450,7 @@ void DrawOptionsUI()
         {
             int defV = 0;
             int v = GetInt(key, defV);
-            if (ImGui::SliderInt(opt.title, &v, (int)opt.min, (int)opt.max))
+            if (ImGui::SliderInt(L(opt.title), &v, (int)opt.min, (int)opt.max))
                 g_Values[key] = std::to_string(v);
             DrawHelp(opt);
             break;
@@ -405,7 +458,7 @@ void DrawOptionsUI()
         case OptionType::Color:
         {
             ImVec4 c = GetColor(key, ImVec4(1, 1, 1, 1));
-            if (ImGui::ColorEdit4(opt.title, (float*)&c))
+            if (ImGui::ColorEdit4(L(opt.title), (float*)&c))
                 SetColor(key, c);
             DrawHelp(opt);
             break;

--- a/L4D2VRConfigTool/src/Options.h
+++ b/L4D2VRConfigTool/src/Options.h
@@ -15,15 +15,21 @@ enum class OptionType
     Color
 };
 
+struct L10nText
+{
+    const char* en;     // English text
+    const char* zh;     // Simplified Chinese text
+};
+
 struct Option
 {
     const char* key;        // config.txt key
     OptionType type;
 
-    const char* group;      // UI group
-    const char* title;      // UI title
-    const char* desc;       // description
-    const char* tip;        // tip / recommendation
+    L10nText group;         // UI group
+    L10nText title;         // UI title
+    L10nText desc;          // description
+    L10nText tip;           // tip / recommendation
 
     float min = 0.f;
     float max = 0.f;
@@ -35,6 +41,9 @@ extern const int g_OptionCount;
 
 // Global config values (defined in main.cpp)
 extern std::unordered_map<std::string, std::string> g_Values;
+
+// Whether UI should show Simplified Chinese, defined in main.cpp
+extern bool g_UseChinese;
 
 // Search text
 extern char g_OptionSearch[128];

--- a/L4D2VRConfigTool/src/Options.h
+++ b/L4D2VRConfigTool/src/Options.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include <string>
 #include <unordered_map>
 #include "imgui.h"

--- a/L4D2VRConfigTool/src/main.cpp
+++ b/L4D2VRConfigTool/src/main.cpp
@@ -218,8 +218,17 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 
     const TCHAR* windowTitle = g_UseChinese ? _T("L4D2VR 配置工具") : _T("L4D2VR Config Tool");
 
+    int screenW = GetSystemMetrics(SM_CXSCREEN);
+    int screenH = GetSystemMetrics(SM_CYSCREEN);
+    int windowW = static_cast<int>(screenW * 0.75f);
+    int windowH = static_cast<int>(screenH * 0.75f);
+
+    // Center the window while sizing it to 75% of the current resolution.
+    int posX = (screenW - windowW) / 2;
+    int posY = (screenH - windowH) / 2;
+
     HWND hwnd = CreateWindow(wc.lpszClassName, windowTitle,
-        WS_OVERLAPPEDWINDOW, 100, 100, 700, 500,
+        WS_OVERLAPPEDWINDOW, posX, posY, windowW, windowH,
         nullptr, nullptr, wc.hInstance, nullptr);
 
     if (!CreateDeviceD3D(hwnd))

--- a/L4D2VRConfigTool/src/main.cpp
+++ b/L4D2VRConfigTool/src/main.cpp
@@ -21,6 +21,7 @@
 
 
 std::unordered_map<std::string, std::string> g_Values;
+bool g_UseChinese = false;
 // ============================================================
 // Win32 + DX11 boilerplate (ImGui official example, simplified)
 // ============================================================
@@ -120,6 +121,19 @@ std::string GetConfigPath()
     return GetExeDir() + "\\vr\\config.txt";
 }
 
+static bool IsChineseUILanguage()
+{
+    auto is_zh = [](LANGID lang) {
+        return PRIMARYLANGID(lang) == LANG_CHINESE;
+    };
+
+    LANGID userLang = GetUserDefaultUILanguage();
+    if (is_zh(userLang)) return true;
+    LANGID sysLang = GetSystemDefaultUILanguage();
+    if (is_zh(sysLang)) return true;
+    return false;
+}
+
 void LoadConfig(const std::string& path)
 {
     g_Lines.clear();
@@ -194,12 +208,17 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
     std::string configPath = GetConfigPath();
     LoadConfig(configPath);
 
+    // Decide UI language before creating any windows/UI
+    g_UseChinese = IsChineseUILanguage();
+
     WNDCLASSEX wc = { sizeof(WNDCLASSEX), CS_CLASSDC, WndProc, 0L, 0L,
         GetModuleHandle(nullptr), nullptr, nullptr, nullptr, nullptr,
         _T("L4D2VRConfigTool"), nullptr };
     RegisterClassEx(&wc);
 
-    HWND hwnd = CreateWindow(wc.lpszClassName, _T("L4D2VR Config Tool"),
+    const TCHAR* windowTitle = g_UseChinese ? _T("L4D2VR 配置工具") : _T("L4D2VR Config Tool");
+
+    HWND hwnd = CreateWindow(wc.lpszClassName, windowTitle,
         WS_OVERLAPPEDWINDOW, 100, 100, 700, 500,
         nullptr, nullptr, wc.hInstance, nullptr);
 
@@ -238,20 +257,43 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
         return io.Fonts->AddFontFromFileTTF(path.c_str(), 18.0f, nullptr, io.Fonts->GetGlyphRangesChineseFull());
     };
 
-    // Prefer Microsoft YaHei
-    font = TryFont(L"msyh.ttc");
-    if (!font) font = TryFont(L"msyhbd.ttc");
+    // Prefer Microsoft YaHei when showing Chinese. Always ensure we have Chinese glyphs even in English UI.
+    if (g_UseChinese)
+    {
+        font = TryFont(L"msyh.ttc");
+        if (!font) font = TryFont(L"msyhbd.ttc");
+        if (!font) font = TryFont(L"simhei.ttf");
+        if (!font) font = TryFont(L"simsun.ttc");
+        if (!font) font = io.Fonts->AddFontDefault();
+    }
+    else
+    {
+        font = io.Fonts->AddFontDefault(); // English UI
 
-    // Fallbacks
-    if (!font) font = TryFont(L"simhei.ttf");
-    if (!font) font = TryFont(L"simsun.ttc");
+        // Merge a Chinese font so Chinese option text/tooltips render correctly
+        ImFontConfig cfg;
+        cfg.MergeMode = true;
+        cfg.PixelSnapH = true;
+        cfg.GlyphMinAdvanceX = 12.0f;
+        auto merge = [&](const wchar_t* name) {
+            std::wstring wpath = fontsDir + name;
+            if (GetFileAttributesW(wpath.c_str()) == INVALID_FILE_ATTRIBUTES)
+                return false;
+            std::string path = WideToUtf8(wpath);
+            return io.Fonts->AddFontFromFileTTF(path.c_str(), 16.0f, &cfg, io.Fonts->GetGlyphRangesChineseFull()) != nullptr;
+        };
+        if (!merge(L"msyh.ttc"))
+            if (!merge(L"msyhbd.ttc"))
+                if (!merge(L"simhei.ttf"))
+                    merge(L"simsun.ttc");
 
-    // Last resort
-    if (!font) font = io.Fonts->AddFontDefault();
+        // Ensure we still have a font
+        if (!font) font = io.Fonts->AddFontDefault();
+    }
 
     io.FontDefault = font;
 
-ImGui::StyleColorsDark();
+    ImGui::StyleColorsDark();
 
     ImGui_ImplWin32_Init(hwnd);
     ImGui_ImplDX11_Init(g_pd3dDevice, g_pd3dDeviceContext);
@@ -273,6 +315,8 @@ ImGui::StyleColorsDark();
         ImGui_ImplWin32_NewFrame();
         ImGui::NewFrame();
 
+        auto L = [](const char* en, const char* zh) { return (g_UseChinese && zh && *zh) ? zh : en; };
+
         ImGuiViewport* vp = ImGui::GetMainViewport();
         ImGui::SetNextWindowPos(vp->WorkPos, ImGuiCond_Always);
         ImGui::SetNextWindowSize(vp->WorkSize, ImGuiCond_Always);
@@ -284,27 +328,27 @@ ImGui::StyleColorsDark();
             ImGuiWindowFlags_NoBringToFrontOnFocus |
             ImGuiWindowFlags_NoTitleBar;
 
-        
-ImGui::Begin("L4D2VR Config Tool", nullptr, winFlags);
+        const char* uiTitle = L("L4D2VR Config Tool", u8"L4D2VR 配置工具");
+        ImGui::Begin(uiTitle, nullptr, winFlags);
 
-    // Header
-    ImGui::Text("Config: %s", configPath.c_str());
-    ImGui::SameLine();
-    if (ImGui::Button("Save"))
-        SaveConfig(configPath);
+        // Header
+        ImGui::Text("%s %s", L("Config:", u8"配置:"), configPath.c_str());
+        ImGui::SameLine();
+        if (ImGui::Button(L("Save", u8"保存")))
+            SaveConfig(configPath);
 
-    // Search
-    ImGui::SetNextItemWidth(420.0f);
-    ImGui::InputTextWithHint("##OptionSearch", u8"Search", g_OptionSearch, sizeof(g_OptionSearch));
+        // Search
+        ImGui::SetNextItemWidth(420.0f);
+        ImGui::InputTextWithHint("##OptionSearch", L("Search", u8"搜索"), g_OptionSearch, sizeof(g_OptionSearch));
 
-    ImGui::Separator();
+        ImGui::Separator();
 
-    // Scrollable options area
-    ImGui::BeginChild("##OptionsScroll", ImVec2(0, 0), false, ImGuiWindowFlags_AlwaysVerticalScrollbar);
-    DrawOptionsUI();
-    ImGui::EndChild();
+        // Scrollable options area
+        ImGui::BeginChild("##OptionsScroll", ImVec2(0, 0), false, ImGuiWindowFlags_AlwaysVerticalScrollbar);
+        DrawOptionsUI();
+        ImGui::EndChild();
 
-    ImGui::End();
+        ImGui::End();
 
         ImGui::Render();
         const float clear[4] = { 0.1f,0.1f,0.1f,1.0f };

--- a/L4D2VRConfigTool/src/main.cpp
+++ b/L4D2VRConfigTool/src/main.cpp
@@ -1,4 +1,4 @@
-﻿// main.cpp
+// main.cpp
 // L4D2VR Config Tool
 // Reads/writes <exe>/vr/config.txt directly
 


### PR DESCRIPTION
## Summary
- add bilingual text definitions for all options and show Chinese text when the system UI language is Chinese
- detect Windows UI language to switch window titles, labels, and search hints automatically
- load fonts with Chinese glyph coverage, including merging CJK glyphs when running in English UI mode

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956054411288321920a03c1a7ff3a94)