### PR TITLE
Expose all config.txt settings in config tool

### DIFF
--- a/L4D2VRConfigTool/src/Options.h
+++ b/L4D2VRConfigTool/src/Options.h
@@ -12,7 +12,9 @@ enum class OptionType
     Bool,
     Float,
     Int,
-    Color
+    Color,
+    String,
+    Vec3
 };
 
 struct L10nText
@@ -33,6 +35,7 @@ struct Option
 
     float min = 0.f;
     float max = 0.f;
+    const char* defaultValue = "";
 };
 
 // Option table


### PR DESCRIPTION
## Summary
- add string and vector option support so every config entry can be edited from the tool
- surface all current config.txt parameters with bilingual labels, tips, defaults, and tightened ranges that match in-game clamps
- group HUD, movement, inventory, aim assist, and special infected assist options for easier navigation

## Testing
- not run (UI changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69560dbce3488321a7b41cc48697e859)