### PR TITLE
Add proximity cut support for controller HUD overlays

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -309,6 +309,7 @@ public:
 	float m_ControllerHudZOffset = 0.0f;
 	float m_ControllerHudRotation = 0.0f;
 	float m_ControllerHudXOffset = 0.0f;
+	bool m_ControllerHudCut = true;
 	bool m_HudAlwaysVisible = false;
 	bool m_HudToggleState = false;
 	std::chrono::steady_clock::time_point m_HudChatVisibleUntil{};


### PR DESCRIPTION
## Summary
- add configuration handling for ControllerHudCut
- hide controller HUD overlays when they get too close to the HMD when enabled

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956a763094083218e6e07702b1fb07c)