### PR TITLE
Restore HMD-driven view angles in third-person

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -243,7 +243,7 @@ ITexture* __fastcall Hooks::dGetRenderTarget(void* ecx, void* edx)
 		QAngle renderAngles(renderAnglesVec.x, renderAnglesVec.y, renderAnglesVec.z);
 		QAngle serverAngles(renderAnglesVec.x, renderAnglesVec.y, renderAnglesVec.z);
 		if (thirdPersonActive || m_VR->m_ThirdPersonHoldFrames > 0)
-			serverAngles = setup.angles;
+			serverAngles.Init(setup.angles.x, setup.angles.y, setup.angles.z);
 
 		// Left eye CViewSetup
 		leftEyeView.x = 0;

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -254,7 +254,7 @@ ITexture* __fastcall Hooks::dGetRenderTarget(void* ecx, void* edx)
 		leftEyeView.m_flAspectRatio = m_VR->m_Aspect;
 		leftEyeView.zNear = 6;
 		leftEyeView.zNearViewmodel = 6;
-		leftEyeView.origin = m_VR->GetViewOriginLeft();
+		leftEyeView.origin = m_VR->GetViewOriginLeft(renderAngles);
 		leftEyeView.angles = renderAnglesVec;
 
 		m_VR->m_SetupOrigin = setup.origin;
@@ -279,7 +279,7 @@ ITexture* __fastcall Hooks::dGetRenderTarget(void* ecx, void* edx)
 		rightEyeView.m_flAspectRatio = m_VR->m_Aspect;
 		rightEyeView.zNear = 6;
 		rightEyeView.zNearViewmodel = 6;
-		rightEyeView.origin = m_VR->GetViewOriginRight();
+		rightEyeView.origin = m_VR->GetViewOriginRight(renderAngles);
 		rightEyeView.angles = renderAnglesVec;
 
 		rndrContext->SetRenderTarget(m_VR->m_RightEyeTexture);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -3083,7 +3083,7 @@ Vector VR::GetViewOriginLeft(const QAngle& renderAngles)
 	if (m_IsThirdPersonCamera || m_ThirdPersonHoldFrames > 0)
 	{
 		Vector forward, right, up;
-		QAngle::AngleVectors(m_ThirdPersonViewAngles, &forward, &right, &up);
+		QAngle::AngleVectors(renderAngles, &forward, &right, &up);
 
 		viewOriginLeft = m_ThirdPersonViewOrigin + (forward * (-(m_EyeZ * m_VRScale)));
 		viewOriginLeft = viewOriginLeft + (right * (-((m_Ipd * m_IpdScale * m_VRScale) / 2)));
@@ -3107,7 +3107,7 @@ Vector VR::GetViewOriginRight(const QAngle& renderAngles)
 	if (m_IsThirdPersonCamera || m_ThirdPersonHoldFrames > 0)
 	{
 		Vector forward, right, up;
-		QAngle::AngleVectors(m_ThirdPersonViewAngles, &forward, &right, &up);
+		QAngle::AngleVectors(renderAngles, &forward, &right, &up);
 
 		viewOriginRight = m_ThirdPersonViewOrigin + (forward * (-(m_EyeZ * m_VRScale)));
 		viewOriginRight = viewOriginRight + (right * (m_Ipd * m_IpdScale * m_VRScale) / 2);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -3083,7 +3083,7 @@ Vector VR::GetViewOriginLeft(const QAngle& renderAngles)
 	if (m_IsThirdPersonCamera || m_ThirdPersonHoldFrames > 0)
 	{
 		Vector forward, right, up;
-		QAngle::AngleVectors(renderAngles, &forward, &right, &up);
+		QAngle::AngleVectors(m_ThirdPersonViewAngles, &forward, &right, &up);
 
 		viewOriginLeft = m_ThirdPersonViewOrigin + (forward * (-(m_EyeZ * m_VRScale)));
 		viewOriginLeft = viewOriginLeft + (right * (-((m_Ipd * m_IpdScale * m_VRScale) / 2)));
@@ -3107,7 +3107,7 @@ Vector VR::GetViewOriginRight(const QAngle& renderAngles)
 	if (m_IsThirdPersonCamera || m_ThirdPersonHoldFrames > 0)
 	{
 		Vector forward, right, up;
-		QAngle::AngleVectors(renderAngles, &forward, &right, &up);
+		QAngle::AngleVectors(m_ThirdPersonViewAngles, &forward, &right, &up);
 
 		viewOriginRight = m_ThirdPersonViewOrigin + (forward * (-(m_EyeZ * m_VRScale)));
 		viewOriginRight = viewOriginRight + (right * (m_Ipd * m_IpdScale * m_VRScale) / 2);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -3076,46 +3076,52 @@ bool VR::UpdateThirdPersonViewState(const Vector& cameraOrigin, const Vector& ca
     return true;
 }
 
-Vector VR::GetViewOriginLeft()
+Vector VR::GetViewOriginLeft(const QAngle& renderAngles)
 {
-    Vector viewOriginLeft;
+	Vector viewOriginLeft;
 
-    if (m_IsThirdPersonCamera || m_ThirdPersonHoldFrames > 0)
-    {
-        Vector forward, right, up;
-        QAngle::AngleVectors(m_ThirdPersonViewAngles, &forward, &right, &up);
+	if (m_IsThirdPersonCamera || m_ThirdPersonHoldFrames > 0)
+	{
+		Vector forward, right, up;
+		QAngle::AngleVectors(renderAngles, &forward, &right, &up);
 
-        viewOriginLeft = m_ThirdPersonViewOrigin + (forward * (-(m_EyeZ * m_VRScale)));
-        viewOriginLeft = viewOriginLeft + (right * (-((m_Ipd * m_IpdScale * m_VRScale) / 2)));
-    }
-    else
-    {
-        viewOriginLeft = m_HmdPosAbs + (m_HmdForward * (-(m_EyeZ * m_VRScale)));
-        viewOriginLeft = viewOriginLeft + (m_HmdRight * (-((m_Ipd * m_IpdScale * m_VRScale) / 2)));
-    }
+		viewOriginLeft = m_ThirdPersonViewOrigin + (forward * (-(m_EyeZ * m_VRScale)));
+		viewOriginLeft = viewOriginLeft + (right * (-((m_Ipd * m_IpdScale * m_VRScale) / 2)));
+	}
+	else
+	{
+		Vector forward, right, up;
+		QAngle::AngleVectors(renderAngles, &forward, &right, &up);
 
-    return viewOriginLeft;
+		viewOriginLeft = m_HmdPosAbs + (forward * (-(m_EyeZ * m_VRScale)));
+		viewOriginLeft = viewOriginLeft + (right * (-((m_Ipd * m_IpdScale * m_VRScale) / 2)));
+	}
+
+	return viewOriginLeft;
 }
 
-Vector VR::GetViewOriginRight()
+Vector VR::GetViewOriginRight(const QAngle& renderAngles)
 {
-    Vector viewOriginRight;
+	Vector viewOriginRight;
 
-    if (m_IsThirdPersonCamera || m_ThirdPersonHoldFrames > 0)
-    {
-        Vector forward, right, up;
-        QAngle::AngleVectors(m_ThirdPersonViewAngles, &forward, &right, &up);
+	if (m_IsThirdPersonCamera || m_ThirdPersonHoldFrames > 0)
+	{
+		Vector forward, right, up;
+		QAngle::AngleVectors(renderAngles, &forward, &right, &up);
 
-        viewOriginRight = m_ThirdPersonViewOrigin + (forward * (-(m_EyeZ * m_VRScale)));
-        viewOriginRight = viewOriginRight + (right * (m_Ipd * m_IpdScale * m_VRScale) / 2);
-    }
-    else
-    {
-        viewOriginRight = m_HmdPosAbs + (m_HmdForward * (-(m_EyeZ * m_VRScale)));
-        viewOriginRight = viewOriginRight + (m_HmdRight * (m_Ipd * m_IpdScale * m_VRScale) / 2);
-    }
+		viewOriginRight = m_ThirdPersonViewOrigin + (forward * (-(m_EyeZ * m_VRScale)));
+		viewOriginRight = viewOriginRight + (right * (m_Ipd * m_IpdScale * m_VRScale) / 2);
+	}
+	else
+	{
+		Vector forward, right, up;
+		QAngle::AngleVectors(renderAngles, &forward, &right, &up);
 
-    return viewOriginRight;
+		viewOriginRight = m_HmdPosAbs + (forward * (-(m_EyeZ * m_VRScale)));
+		viewOriginRight = viewOriginRight + (right * (m_Ipd * m_IpdScale * m_VRScale) / 2);
+	}
+
+	return viewOriginRight;
 }
 
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -486,8 +486,8 @@ public:
 	void UpdateMotionGestures(C_BasePlayer* localPlayer);
 	bool UpdateThirdPersonViewState(const Vector& cameraOrigin, const Vector& cameraAngles);
 	Vector GetViewAngle();
-	Vector GetViewOriginLeft();
-	Vector GetViewOriginRight();
+	Vector GetViewOriginLeft(const QAngle& renderAngles);
+	Vector GetViewOriginRight(const QAngle& renderAngles);
 	Vector GetThirdPersonViewOrigin() const { return m_ThirdPersonViewOrigin; }
 	QAngle GetThirdPersonViewAngles() const { return m_ThirdPersonViewAngles; }
 	bool IsThirdPersonCameraActive() const { return m_IsThirdPersonCamera; }


### PR DESCRIPTION
## Summary
- render third-person camera with HMD orientation while keeping engine/server view angles from the game’s third-person camera
- allow head look-around again by removing third-person override from VR view angles
- preserve third-person camera origin and smoothing while falling back cleanly to first person

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695706b88ab88321a3eb0c1b51be0167)