### PR TITLE
Add custom action alias support

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -55,6 +55,9 @@ CustomAction2Command=thirdpersonshoulder
 CustomAction3Command=say /drop
 CustomAction4Command=+alt2
 CustomAction5Command=
+// 示例：自定义动作5定义别名并触发一次慢走点按（等待大约0.5秒=30帧后松开）
+// Source 里的“走路”命令是 +speed / -speed（不是 +walk）
+// CustomAction5Command=alias:vr_walktap:+speed|wait 30|-speed
 
 SpecialInfectedArrowEnabled=false
 SpecialInfectedArrowSize=20.0

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -44,8 +44,10 @@ struct SharedTextureHolder
 struct CustomActionBinding
 {
 	std::string command;
+	std::string releaseCommand;
 	std::optional<WORD> virtualKey;
 	bool holdVirtualKey = false;
+	bool usePressReleaseCommands = false;
 };
 
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@
 4. Load into a campaign.
 5. To recenter the camera height, press down on the left stick. To see the HUD, aim the controller up or down.
 
+### Custom action aliases
+You can define a Source `alias` directly from `VR/config.txt` for the five custom actions. Use the format:
+
+```
+CustomActionXCommand=alias:aliasName:command|command|command
+```
+
+`|` is converted to `;` to avoid the config parser treating semicolons as comments. Example: tap-walk for roughly 0.5s (30 `wait` frames). Note: the Source engine “walk” key is `+speed` / `-speed` (not `+walk`):
+
+```
+CustomAction5Command=alias:vr_walktap:+speed|wait 30|-speed
+```
+
+Bind Custom Action 5 in SteamVR, and triggering it will run the alias.
+
+Tip: If you set a custom action command that starts with `+` (e.g., `+speed`, `+walk`, `+use`), the mod will now automatically send the matching `-` command when you release the action, so hold-style commands work as expected.
+
 
 ## How to play multiplayer
 * The host must have the mod installed and the server must be set to local. Other players can play in VR too (if they also installed the mod).


### PR DESCRIPTION
## Summary
- add alias syntax for custom VR action commands so config can define multi-step aliases
- log alias creation and document usage with example tap-walk alias
- clarify that Source walk uses +speed/-speed and update the example accordingly
- send matching release commands when a custom action uses a leading +command so hold/release mods (e.g., +walk) behave correctly in VR

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695700fdd6ac8321ad70dcf831f1bdcc)