### PR TITLE
Handle third-person VR yaw

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -269,7 +269,8 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	leftEyeView.origin = leftOrigin;
 	leftEyeView.angles = viewAngles;
 
-	Vector hmdAngle = m_VR->GetViewAngle();
+	Vector hmdAngleVec = m_VR->GetViewAngle();
+	QAngle hmdAngle(hmdAngleVec.x, hmdAngleVec.y, hmdAngleVec.z);
 
 	// ----------------------------------------
 	// Third-person VR rule:

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -270,7 +270,25 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	leftEyeView.angles = viewAngles;
 
 	Vector hmdAngle = m_VR->GetViewAngle();
-	QAngle inGameAngle(hmdAngle.x, hmdAngle.y, hmdAngle.z);
+
+	// ----------------------------------------
+	// Third-person VR rule:
+	// Do NOT feed HMD yaw back into engine view angles,
+	// or the third-person camera will fight VR tracking
+	// and cause severe jitter / nausea.
+	// ----------------------------------------
+	QAngle inGameAngle;
+	if (engineThirdPerson)
+	{
+		inGameAngle = setup.angles;
+		inGameAngle.x += hmdAngle.x;   // pitch only
+		// inGameAngle.y += hmdAngle.y; // ❌ lock yaw in third-person
+		inGameAngle.z = 0.f;
+	}
+	else
+	{
+		inGameAngle.Init(hmdAngle.x, hmdAngle.y, hmdAngle.z);
+	}
 
 
 	const bool treatServerAsNonVR = m_VR->m_ForceNonVRServerMovement;

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -280,10 +280,10 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	QAngle inGameAngle;
 	if (engineThirdPerson)
 	{
-		inGameAngle = setup.angles;
-		inGameAngle.x += hmdAngle.x;   // pitch only
-		// inGameAngle.y += hmdAngle.y; // ❌ lock yaw in third-person
-		inGameAngle.z = 0.f;
+		inGameAngle.Init(
+			setup.angles.x + hmdAngle.x, // pitch only
+			setup.angles.y,              // lock yaw in third-person
+			0.f);
 	}
 	else
 	{


### PR DESCRIPTION
## Summary
- prevent HMD yaw from being applied to engine view angles in third-person VR
- keep third-person camera stable by only applying pitch offset and locking yaw while in that mode

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69573a2681848321bd340204ec98a04b)