### PR TITLE
Improve VR camera handling and firing origin

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -241,11 +241,16 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	m_VR->m_SetupOrigin = eyeOrigin;
 	m_VR->m_SetupAngles.Init(setup.angles.x, setup.angles.y, setup.angles.z);
 
-	Vector leftOrigin, rightOrigin, viewAngles;
+	Vector leftOrigin, rightOrigin;
+	Vector viewAngles = m_VR->GetViewAngle();
 	if (engineThirdPerson)
 	{
-		// Render from the engine-provided third-person camera (setup.origin/angles)
-		QAngle camAng(setup.angles.x, setup.angles.y, setup.angles.z);
+		// Render from the engine-provided third-person camera (setup.origin),
+		// but aim the camera with the HMD so head look still works in third-person.
+		QAngle camAng(viewAngles.x, viewAngles.y, viewAngles.z);
+		if (m_VR->m_HmdForward.IsZero())
+			camAng = QAngle(setup.angles.x, setup.angles.y, setup.angles.z);
+
 		Vector fwd, right, up;
 		QAngle::AngleVectors(camAng, &fwd, &right, &up);
 
@@ -256,14 +261,12 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		Vector camCenter = setup.origin + (fwd * (-eyeZ));
 		leftOrigin = camCenter + (right * (-(ipd * 0.5f)));
 		rightOrigin = camCenter + (right * (+(ipd * 0.5f)));
-		viewAngles = setup.angles;
 	}
 	else
 	{
 		// Normal VR first-person
 		leftOrigin = m_VR->GetViewOriginLeft();
 		rightOrigin = m_VR->GetViewOriginRight();
-		viewAngles = m_VR->GetViewAngle();
 	}
 
 	leftEyeView.origin = leftOrigin;
@@ -272,12 +275,7 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	Vector hmdAngle = m_VR->GetViewAngle();
 	QAngle inGameAngle(hmdAngle.x, hmdAngle.y, hmdAngle.z);
 
-
-	const bool treatServerAsNonVR = m_VR->m_ForceNonVRServerMovement;
-	if (!treatServerAsNonVR)
-	{
-		m_Game->m_EngineClient->SetViewAngles(inGameAngle);
-	}
+	m_Game->m_EngineClient->SetViewAngles(inGameAngle);
 
 	rndrContext->SetRenderTarget(m_VR->m_LeftEyeTexture);
 	hkRenderView.fOriginal(ecx, leftEyeView, hudViewSetup, nClearFlags, whatToDraw);
@@ -406,16 +404,9 @@ int Hooks::dClientFireTerrorBullets(int playerId, const Vector& vecOrigin, const
 	// 只有当本局服务器端确实运行了 VR 钩子时，才用控制器射线做本地预测
 	if (m_VR->m_IsVREnabled && playerId == m_Game->m_EngineClient->GetLocalPlayer())
 	{
-		if (!m_VR->m_ForceNonVRServerMovement)
-		{
-			vecNewOrigin = m_VR->GetRightControllerAbsPos();
+		vecNewOrigin = m_VR->GetRightControllerAbsPos();
+		if (!m_VR->m_ForceNonVRServerMovement || m_VR->m_NonVRServerMovementAngleOverride)
 			vecNewAngles = m_VR->GetRightControllerAbsAngle();
-		}
-		else if (m_VR->m_NonVRServerMovementAngleOverride)
-		{
-			// 非 VR 服务器：服务器仍以常规射线起点为准，但视角需要跟随控制器
-			vecNewAngles = m_VR->GetRightControllerAbsAngle();
-		}
 	}
 
 	return hkClientFireTerrorBullets.fOriginal(playerId, vecNewOrigin, vecNewAngles, a4, a5, a6, a7);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -317,6 +317,10 @@ public:
 	std::chrono::steady_clock::time_point m_HudChatVisibleUntil{};
 	float m_ControllerSmoothing = 0.0f;
 	bool m_ControllerSmoothingInitialized = false;
+	float m_HeadSmoothing = 0.0f;
+	bool m_HeadSmoothingInitialized = false;
+	Vector m_HmdPosSmoothed = { 0,0,0 };
+	QAngle m_HmdAngSmoothed = { 0,0,0 };
 	CustomActionBinding m_CustomAction1Binding{};
 	CustomActionBinding m_CustomAction2Binding{};
 	CustomActionBinding m_CustomAction3Binding{};


### PR DESCRIPTION
## Summary
- Aim third-person rendering with the HMD so camera look works even when forcing non-VR server movement, and keep the client view angles in sync.
- Add head pose smoothing (with backward-compatible config parsing) so HMD-driven view changes are less jittery.
- Anchor local bullet traces to the controller even when forcing non-VR server movement so shots originate from the hand.

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957a7587b3483219bac55e4084ae0f5)