### PR TITLE
Stabilize third-person VR camera and enforce controller bullet origin

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -278,10 +278,12 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		const float ipd = (m_VR->m_Ipd * m_VR->m_IpdScale * m_VR->m_VRScale);
 		const float eyeZ = (m_VR->m_EyeZ * m_VR->m_VRScale);
 
-		// Treat setup.origin as camera "head center", apply SteamVR eye-to-head offsets
+		// Treat setup.origin as camera "head center". For third-person we deliberately collapse IPD
+		// to reduce ghosting/double images of the player model.
 		Vector camCenter = setup.origin + (fwd * (-eyeZ));
-		leftOrigin = camCenter + (right * (-(ipd * 0.5f)));
-		rightOrigin = camCenter + (right * (+(ipd * 0.5f)));
+		leftOrigin = camCenter;
+		rightOrigin = camCenter;
+		viewAngles = Vector(camAng.x, camAng.y, camAng.z);
 	}
 	else
 	{

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -317,6 +317,10 @@ public:
 	std::chrono::steady_clock::time_point m_HudChatVisibleUntil{};
 	float m_ControllerSmoothing = 0.0f;
 	bool m_ControllerSmoothingInitialized = false;
+	float m_HeadSmoothing = 0.0f;
+	bool m_HeadSmoothingInitialized = false;
+	Vector m_HmdPosSmoothed = { 0,0,0 };
+	QAngle m_HmdAngSmoothed = { 0,0,0 };
 	CustomActionBinding m_CustomAction1Binding{};
 	CustomActionBinding m_CustomAction2Binding{};
 	CustomActionBinding m_CustomAction3Binding{};


### PR DESCRIPTION
## Summary
- Stabilize third-person detection to prevent rapid flicker/ghosting, and ensure the camera still follows HMD orientation even when forcing non-VR server movement.
- Fallback to engine angles only when HMD tracking is unavailable to keep third-person aim stable.
- Always drive local bullet origin/angles from the right controller so shots stay anchored to the hand in all modes.

## Testing
- Not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957a7587b3483219bac55e4084ae0f5)