### PR TITLE
Fix third-person compatibility mode view and controller bullets

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -245,7 +245,8 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	Vector viewAngles = m_VR->GetViewAngle();
 	// In non-VR server compatibility mode, rely on the engine-provided third-person camera
 	// orientation so both eyes share the same view pivot as the shoulder camera.
-	if (engineThirdPerson && m_VR->m_ForceNonVRServerMovement)
+	const bool monoThirdPerson = (engineThirdPerson && m_VR->m_ForceNonVRServerMovement);
+	if (monoThirdPerson)
 	{
 		viewAngles = Vector(setup.angles.x, setup.angles.y, setup.angles.z);
 	}
@@ -260,7 +261,7 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		Vector fwd, right, up;
 		QAngle::AngleVectors(camAng, &fwd, &right, &up);
 
-		const float ipd = (m_VR->m_Ipd * m_VR->m_IpdScale * m_VR->m_VRScale);
+		const float ipd = monoThirdPerson ? 0.0f : (m_VR->m_Ipd * m_VR->m_IpdScale * m_VR->m_VRScale);
 		const float eyeZ = (m_VR->m_EyeZ * m_VR->m_VRScale);
 
 		// Treat setup.origin as camera "head center", apply SteamVR eye-to-head offsets

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -243,6 +243,12 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 
 	Vector leftOrigin, rightOrigin;
 	Vector viewAngles = m_VR->GetViewAngle();
+	// In non-VR server compatibility mode, rely on the engine-provided third-person camera
+	// orientation so both eyes share the same view pivot as the shoulder camera.
+	if (engineThirdPerson && m_VR->m_ForceNonVRServerMovement)
+	{
+		viewAngles = Vector(setup.angles.x, setup.angles.y, setup.angles.z);
+	}
 	if (engineThirdPerson)
 	{
 		// Render from the engine-provided third-person camera (setup.origin),
@@ -405,8 +411,7 @@ int Hooks::dClientFireTerrorBullets(int playerId, const Vector& vecOrigin, const
 	if (m_VR->m_IsVREnabled && playerId == m_Game->m_EngineClient->GetLocalPlayer())
 	{
 		vecNewOrigin = m_VR->GetRightControllerAbsPos();
-		if (!m_VR->m_ForceNonVRServerMovement || m_VR->m_NonVRServerMovementAngleOverride)
-			vecNewAngles = m_VR->GetRightControllerAbsAngle();
+		vecNewAngles = m_VR->GetRightControllerAbsAngle();
 	}
 
 	return hkClientFireTerrorBullets.fOriginal(playerId, vecNewOrigin, vecNewAngles, a4, a5, a6, a7);

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -281,7 +281,6 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 			{
 				// Force both eyes to the exact same transform so the entire scene is monoscopic.
 				rightOrigin = leftOrigin;
-				rightEyeView.angles = QAngle(camAng.x, camAng.y, camAng.z);
 			}
 		}
 		else


### PR DESCRIPTION
## Summary
- align VR third-person rendering with the engine camera when Non-VR Server Compatibility Mode is enabled to prevent double images
- always use controller aim angles for local bullet prediction so projectiles originate from the hand in VR

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957c800affc8321a4460d55fde84c0c)