### PR TITLE
Handle third-person camera state in VR

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2389,7 +2389,18 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     }
     VectorNormalize(direction);
 
-    Vector origin = m_RightControllerPosAbs + direction * 2.0f;
+    Vector originBase = m_RightControllerPosAbs;
+
+    // In third-person, the engine camera is offset from the player's eye. Translate the
+    // controller-origin into the third-person camera space so the aim line appears near
+    // your current view instead of stuck on the character.
+    if (m_IsThirdPersonCamera)
+    {
+        Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+        originBase += camDelta;
+    }
+
+    Vector origin = originBase + direction * 2.0f;
 
     if (isThrowable)
     {

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -190,6 +190,7 @@ public:
 	float m_SpecialInfectedTraceMaxHz = 15.0f;   // caps TraceRay per entity
 
 	std::chrono::steady_clock::time_point m_LastAimLineDrawTime{};
+	std::chrono::steady_clock::time_point m_LastAimLineTraceTime{};
 	std::chrono::steady_clock::time_point m_LastThrowArcDrawTime{};
 	mutable std::unordered_map<int, std::chrono::steady_clock::time_point> m_LastSpecialInfectedOverlayTime{};
 	mutable std::unordered_map<int, std::chrono::steady_clock::time_point> m_LastSpecialInfectedTraceTime{};


### PR DESCRIPTION
## Summary
- expose third-person camera origin/angles to VR helpers for overlays
- align engine view angles with render view angles during VR rendering
- offset aiming laser origin for third-person camera to match view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69580d7618748321a721c51eccfea0b3)