### PR TITLE
Add third-person aim convergence

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -422,7 +422,31 @@ int Hooks::dServerFireTerrorBullets(int playerId, const Vector& vecOrigin, const
 	if (m_VR->m_IsVREnabled && playerId == m_Game->m_EngineClient->GetLocalPlayer())
 	{
 		vecNewOrigin = m_VR->GetRightControllerAbsPos();
-		vecNewAngles = m_VR->GetRightControllerAbsAngle();
+
+		// Third-person convergence: aim bullets to the converge point so "bullet line" intersects
+		// the rendered aim line at the actual hit point.
+		if (m_VR->IsThirdPersonCameraActive() && m_VR->m_HasAimConvergePoint)
+		{
+			Vector to = m_VR->m_AimConvergePoint - vecNewOrigin;
+			if (!to.IsZero())
+			{
+				VectorNormalize(to);
+				QAngle ang;
+				QAngle::VectorAngles(to, ang);
+				ang.z = 0.f;
+				if (ang.x > 89.f) ang.x = 89.f;
+				if (ang.x < -89.f) ang.x = -89.f;
+				vecNewAngles = ang;
+			}
+			else
+			{
+				vecNewAngles = m_VR->GetRightControllerAbsAngle();
+			}
+		}
+		else
+		{
+			vecNewAngles = m_VR->GetRightControllerAbsAngle();
+		}
 	}
 	// Clients
 	else if (m_Game->IsValidPlayerIndex(playerId) && m_Game->m_PlayersVRInfo[playerId].isUsingVR)
@@ -443,7 +467,29 @@ int Hooks::dClientFireTerrorBullets(int playerId, const Vector& vecOrigin, const
 	if (m_VR->m_IsVREnabled && playerId == m_Game->m_EngineClient->GetLocalPlayer())
 	{
 		vecNewOrigin = m_VR->GetRightControllerAbsPos();
-		vecNewAngles = m_VR->GetRightControllerAbsAngle();
+
+		if (m_VR->IsThirdPersonCameraActive() && m_VR->m_HasAimConvergePoint)
+		{
+			Vector to = m_VR->m_AimConvergePoint - vecNewOrigin;
+			if (!to.IsZero())
+			{
+				VectorNormalize(to);
+				QAngle ang;
+				QAngle::VectorAngles(to, ang);
+				ang.z = 0.f;
+				if (ang.x > 89.f) ang.x = 89.f;
+				if (ang.x < -89.f) ang.x = -89.f;
+				vecNewAngles = ang;
+			}
+			else
+			{
+				vecNewAngles = m_VR->GetRightControllerAbsAngle();
+			}
+		}
+		else
+		{
+			vecNewAngles = m_VR->GetRightControllerAbsAngle();
+		}
 	}
 
 	return hkClientFireTerrorBullets.fOriginal(playerId, vecNewOrigin, vecNewAngles, a4, a5, a6, a7);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2390,16 +2390,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     }
     VectorNormalize(direction);
 
-    // Aim line origin used for rendering. In third-person you may be shifting things toward the camera;
-    // keep that consistent here so convergence matches what you actually draw.
-    Vector originBase = m_RightControllerPosAbs;
-    if (m_IsThirdPersonCamera)
-    {
-        // Move controller-origin into the third-person camera space (same idea as your earlier fix)
-        Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
-        originBase += camDelta;
-    }
-    Vector origin = originBase + direction * 2.0f;
+    Vector origin = m_RightControllerPosAbs + direction * 2.0f; // 仍然贴手柄（不要第三人称平移）
 
     if (isThrowable)
     {
@@ -2412,45 +2403,31 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     }
 
     const float maxDistance = 8192.0f;
-    Vector targetMax = origin + direction * maxDistance;
+    Vector target = origin + direction * maxDistance;
 
-    // Default: no convergence
-    Vector finalHit = targetMax;
+    // Third-person convergence point = hit point on controller ray
     m_HasAimConvergePoint = false;
-
-    // Third-person convergence:
-    // 1) Trace from the rendered aim-line (origin -> targetMax) to get desired point P
-    // 2) Trace from bullet origin (controller) to P to get the true bullet hit point
+    Vector hitPoint = target;
     if (m_IsThirdPersonCamera && localPlayer && m_Game->m_EngineTrace)
     {
         CTraceFilterSkipSelf filter((IHandleEntity*)localPlayer, 0);
         Ray_t ray;
         CGameTrace tr;
-
-        ray.Init(origin, targetMax);
+        ray.Init(origin, target);
         m_Game->m_EngineTrace->TraceRay(ray, STANDARD_TRACE_MASK, &filter, &tr);
+        if (tr.fraction > 0.0f && tr.fraction < 1.0f)
+            hitPoint = tr.endpos;
 
-        Vector desiredPoint = (tr.fraction < 1.0f && tr.fraction > 0.0f) ? tr.endpos : targetMax;
-
-        // Now get the actual bullet hit if we shoot from controller toward desiredPoint
-        Vector bulletOrigin = m_RightControllerPosAbs; // matches your FireTerrorBullets origin override
-        Ray_t ray2;
-        CGameTrace tr2;
-        ray2.Init(bulletOrigin, desiredPoint);
-        m_Game->m_EngineTrace->TraceRay(ray2, STANDARD_TRACE_MASK, &filter, &tr2);
-
-        finalHit = (tr2.fraction < 1.0f && tr2.fraction > 0.0f) ? tr2.endpos : desiredPoint;
-
-        m_AimConvergePoint = finalHit;
+        m_AimConvergePoint = hitPoint;
         m_HasAimConvergePoint = true;
     }
 
     m_AimLineStart = origin;
-    m_AimLineEnd = finalHit;
+    m_AimLineEnd = hitPoint;
     m_HasAimLine = true;
     m_HasThrowArc = false;
 
-    DrawAimLine(origin, finalHit);
+    DrawAimLine(origin, hitPoint);
 }
 
 bool VR::ShouldShowAimLine(C_WeaponCSBase* weapon) const

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2353,6 +2353,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     {
         m_LastAimDirection = Vector{ 0.0f, 0.0f, 0.0f };
         m_HasAimLine = false;
+        m_HasAimConvergePoint = false;
         m_HasThrowArc = false;
         m_LastAimWasThrowable = false;
         return;
@@ -2389,17 +2390,15 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     }
     VectorNormalize(direction);
 
+    // Aim line origin used for rendering. In third-person you may be shifting things toward the camera;
+    // keep that consistent here so convergence matches what you actually draw.
     Vector originBase = m_RightControllerPosAbs;
-
-    // In third-person, the engine camera is offset from the player's eye. Translate the
-    // controller-origin into the third-person camera space so the aim line appears near
-    // your current view instead of stuck on the character.
     if (m_IsThirdPersonCamera)
     {
+        // Move controller-origin into the third-person camera space (same idea as your earlier fix)
         Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
         originBase += camDelta;
     }
-
     Vector origin = originBase + direction * 2.0f;
 
     if (isThrowable)
@@ -2413,14 +2412,45 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     }
 
     const float maxDistance = 8192.0f;
-    Vector target = origin + direction * maxDistance;
+    Vector targetMax = origin + direction * maxDistance;
+
+    // Default: no convergence
+    Vector finalHit = targetMax;
+    m_HasAimConvergePoint = false;
+
+    // Third-person convergence:
+    // 1) Trace from the rendered aim-line (origin -> targetMax) to get desired point P
+    // 2) Trace from bullet origin (controller) to P to get the true bullet hit point
+    if (m_IsThirdPersonCamera && localPlayer && m_Game->m_EngineTrace)
+    {
+        CTraceFilterSkipSelf filter((IHandleEntity*)localPlayer, 0);
+        Ray_t ray;
+        CGameTrace tr;
+
+        ray.Init(origin, targetMax);
+        m_Game->m_EngineTrace->TraceRay(ray, STANDARD_TRACE_MASK, &filter, &tr);
+
+        Vector desiredPoint = (tr.fraction < 1.0f && tr.fraction > 0.0f) ? tr.endpos : targetMax;
+
+        // Now get the actual bullet hit if we shoot from controller toward desiredPoint
+        Vector bulletOrigin = m_RightControllerPosAbs; // matches your FireTerrorBullets origin override
+        Ray_t ray2;
+        CGameTrace tr2;
+        ray2.Init(bulletOrigin, desiredPoint);
+        m_Game->m_EngineTrace->TraceRay(ray2, STANDARD_TRACE_MASK, &filter, &tr2);
+
+        finalHit = (tr2.fraction < 1.0f && tr2.fraction > 0.0f) ? tr2.endpos : desiredPoint;
+
+        m_AimConvergePoint = finalHit;
+        m_HasAimConvergePoint = true;
+    }
 
     m_AimLineStart = origin;
-    m_AimLineEnd = target;
+    m_AimLineEnd = finalHit;
     m_HasAimLine = true;
     m_HasThrowArc = false;
 
-    DrawAimLine(origin, target);
+    DrawAimLine(origin, finalHit);
 }
 
 bool VR::ShouldShowAimLine(C_WeaponCSBase* weapon) const

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -156,9 +156,9 @@ public:
 
 	Vector m_AimLineStart = { 0,0,0 };
 	Vector m_AimLineEnd = { 0,0,0 };
-	// Third-person convergence: "rendered aim line" hit point that bullets should converge to.
+	// Third-person convergence target (point on the controller aim ray).
 	Vector m_AimConvergePoint = { 0,0,0 };
-	bool m_HasAimConvergePoint = false;
+	bool   m_HasAimConvergePoint = false;
 	Vector m_LastAimDirection = { 0,0,0 };
 	Vector m_LastUnforcedAimDirection = { 0,0,0 };
 	bool m_HasAimLine = false;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -156,6 +156,9 @@ public:
 
 	Vector m_AimLineStart = { 0,0,0 };
 	Vector m_AimLineEnd = { 0,0,0 };
+	// Third-person convergence: "rendered aim line" hit point that bullets should converge to.
+	Vector m_AimConvergePoint = { 0,0,0 };
+	bool m_HasAimConvergePoint = false;
 	Vector m_LastAimDirection = { 0,0,0 };
 	Vector m_LastUnforcedAimDirection = { 0,0,0 };
 	bool m_HasAimLine = false;


### PR DESCRIPTION
## Summary
- add an aim convergence point for third-person so the rendered aim line aligns with bullet traces
- shift the aim-line origin consistently with third-person camera offsets and compute a converged hit point
- aim server and client bullet angles toward the convergence point when available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958267743048321b47c575011a15b25)