### PR TITLE
Add third-person aim convergence

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -157,7 +157,10 @@ public:
 	Vector m_AimLineStart = { 0,0,0 };
 	Vector m_AimLineEnd = { 0,0,0 };
 
-	// Third-person convergence: "rendered aim line" hit point that bullets should converge to.
+	// Third-person convergence: point hit by the *rendered* aim ray (camera/reticle ray).
+	// Bullets may be steered to aim at this point so the rendered line and bullet direction
+	// intersect at P. If something blocks the bullet path, it will hit earlier — we do NOT
+	// move P to the blocking surface.
 	Vector m_AimConvergePoint = { 0,0,0 };
 	bool m_HasAimConvergePoint = false;
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -156,6 +156,11 @@ public:
 
 	Vector m_AimLineStart = { 0,0,0 };
 	Vector m_AimLineEnd = { 0,0,0 };
+
+	// Third-person convergence: "rendered aim line" hit point that bullets should converge to.
+	Vector m_AimConvergePoint = { 0,0,0 };
+	bool m_HasAimConvergePoint = false;
+
 	Vector m_LastAimDirection = { 0,0,0 };
 	Vector m_LastUnforcedAimDirection = { 0,0,0 };
 	bool m_HasAimLine = false;


### PR DESCRIPTION
## Summary
- track a third-person aim convergence point alongside the rendered aim line
- trace the rendered aim line and controller ray so third-person bullet hits match the drawn impact point
- aim server and client bullet firing toward the convergence point when available
- normalize and clamp third-person convergence angles using a shared helper to avoid wraparound artifacts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958299533608321ad0cb56052e303f9)