### PR TITLE
Improve third-person camera handling

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -238,19 +238,22 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 
 	// Heuristic: in true third-person, the engine camera origin is noticeably away from eye position
 	const float camDist = (setup.origin - eyeOrigin).Length();
-	const bool engineThirdPerson = (localPlayer && camDist > 5.0f);
+	const bool engineThirdPersonNow = (localPlayer && camDist > 1.0f);
+	// Always capture the view the engine is rendering this frame.
+	// In true third-person, setup.origin is the shoulder camera; in first-person it matches the eye.
+	m_VR->m_ThirdPersonViewOrigin = setup.origin;
+	m_VR->m_ThirdPersonViewAngles.Init(setup.angles.x, setup.angles.y, setup.angles.z);
+
+	// Detect third-person by comparing rendered camera origin to the real eye origin.
+	// Use a small threshold + hysteresis to avoid flicker.
+	if (engineThirdPersonNow)
+		m_VR->m_ThirdPersonHoldFrames = 2;
+	else if (m_VR->m_ThirdPersonHoldFrames > 0)
+		m_VR->m_ThirdPersonHoldFrames--;
+
+	const bool engineThirdPerson = engineThirdPersonNow || (m_VR->m_ThirdPersonHoldFrames > 0);
 	// Expose third-person camera to VR helpers (aim line, overlays, etc.)
 	m_VR->m_IsThirdPersonCamera = engineThirdPerson;
-	if (engineThirdPerson)
-	{
-		m_VR->m_ThirdPersonViewOrigin = setup.origin;
-		m_VR->m_ThirdPersonViewAngles.Init(setup.angles.x, setup.angles.y, setup.angles.z);
-	}
-	else
-	{
-		m_VR->m_ThirdPersonViewOrigin = eyeOrigin;
-		m_VR->m_ThirdPersonViewAngles.Init(setup.angles.x, setup.angles.y, setup.angles.z);
-	}
 	CViewSetup leftEyeView = setup;
 	CViewSetup rightEyeView = setup;
 

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2391,10 +2391,18 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     {
         m_LastAimDirection = direction;
         m_LastAimWasThrowable = isThrowable;
-    }
-    VectorNormalize(direction);
+	}
+	VectorNormalize(direction);
 
-    Vector origin = m_RightControllerPosAbs + direction * 2.0f;
+	// Aim line origin is controller-based. In third-person the rendered camera is offset behind the player,
+	// so we translate the controller position into the rendered-camera frame.
+	// We key off the actual camera delta (not just the boolean) to avoid cases where 3P detection flickers.
+	Vector originBase = m_RightControllerPosAbs;
+	Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+	if (camDelta.LengthSqr() > 1.0f)
+		originBase += camDelta;
+
+	Vector origin = originBase + direction * 2.0f;
 
     if (isThrowable)
     {


### PR DESCRIPTION
## Summary
- Lower the third-person camera detection threshold and add frame-based hysteresis to reduce flicker
- Always record the rendered camera origin/angles for VR helpers
- Offset the aim line origin by the actual camera delta so it stays aligned in third-person views

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695839f85ac48321a8db190ab4362f58)