### PR TITLE
Add scope render-to-texture overlay

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -145,12 +145,18 @@ VR::VR(Game* game)
         m_Overlay->CreateOverlay(bottomOverlayKeys[i], bottomOverlayKeys[i], &m_HUDBottomHandles[i]);
     }
 
+    // Gun-mounted scope lens overlay (render-to-texture)
+    m_Overlay->CreateOverlay("ScopeOverlayKey", "ScopeOverlay", &m_ScopeHandle);
+
     m_Overlay->SetOverlayInputMethod(m_MainMenuHandle, vr::VROverlayInputMethod_Mouse);
     m_Overlay->SetOverlayInputMethod(m_HUDTopHandle, vr::VROverlayInputMethod_Mouse);
     for (vr::VROverlayHandle_t& overlay : m_HUDBottomHandles)
     {
         m_Overlay->SetOverlayInputMethod(overlay, vr::VROverlayInputMethod_Mouse);
     }
+
+    // Scope overlay is purely visual
+    m_Overlay->SetOverlayInputMethod(m_ScopeHandle, vr::VROverlayInputMethod_None);
 
     m_Overlay->SetOverlayFlag(m_MainMenuHandle, vr::VROverlayFlags_SendVRDiscreteScrollEvents, true);
     m_Overlay->SetOverlayFlag(m_HUDTopHandle, vr::VROverlayFlags_SendVRDiscreteScrollEvents, true);
@@ -319,6 +325,17 @@ void VR::CreateVRTextures()
     m_CreatingTextureID = Texture_HUD;
     m_HUDTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("vrHUD", windowWidth, windowHeight, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SHARED, TEXTUREFLAGS_NOMIP);
 
+    // Square RTT for gun-mounted scope lens
+    m_CreatingTextureID = Texture_Scope;
+    m_ScopeTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx(
+        "vrScope",
+        static_cast<int>(m_ScopeRTTSize),
+        static_cast<int>(m_ScopeRTTSize),
+        RT_SIZE_NO_CHANGE,
+        m_Game->m_MaterialSystem->GetBackBufferFormat(),
+        MATERIAL_RT_DEPTH_SHARED,
+        TEXTUREFLAGS_NOMIP);
+
     m_CreatingTextureID = Texture_Blank;
     m_BlankTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("blankTexture", 512, 512, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SHARED, TEXTUREFLAGS_NOMIP);
 
@@ -387,6 +404,13 @@ void VR::SubmitVRTextures()
             vr::VROverlay()->SetOverlayTexture(overlay, &m_VKHUD.m_VRTexture);
         };
 
+    auto applyScopeTexture = [&](vr::VROverlayHandle_t overlay)
+        {
+            static const vr::VRTextureBounds_t full{ 0.0f, 0.0f, 1.0f, 1.0f };
+            vr::VROverlay()->SetOverlayTextureBounds(overlay, &full);
+            vr::VROverlay()->SetOverlayTexture(overlay, &m_VKScope.m_VRTexture);
+        };
+
     //     ֡û       ݣ    ߲˵ /Overlay ·  
     if (!m_RenderedNewFrame)
     {
@@ -399,6 +423,7 @@ void VR::SubmitVRTextures()
         vr::VROverlay()->SetOverlayTexture(m_MainMenuHandle, &m_VKBackBuffer.m_VRTexture);
         vr::VROverlay()->ShowOverlay(m_MainMenuHandle);
         hideHudOverlays();
+        vr::VROverlay()->HideOverlay(m_ScopeHandle);
 
         if (!m_Game->m_EngineClient->IsInGame())
         {
@@ -435,6 +460,30 @@ void VR::SubmitVRTextures()
             vr::VROverlay()->ShowOverlay(m_HUDBottomHandles[i]);
         }
     }
+
+    // Scope overlay independent of HUD cursor mode
+    if (m_ScopeTexture && m_ScopeEnabled)
+    {
+        applyScopeTexture(m_ScopeHandle);
+        const float alpha = IsScopeActive() ? 1.0f : std::clamp(m_ScopeOverlayIdleAlpha, 0.0f, 1.0f);
+        vr::VROverlay()->SetOverlayAlpha(m_ScopeHandle, alpha);
+
+        vr::TrackedDeviceIndex_t leftControllerIndex = m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_LeftHand);
+        vr::TrackedDeviceIndex_t rightControllerIndex = m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_RightHand);
+        if (m_LeftHanded)
+            std::swap(leftControllerIndex, rightControllerIndex);
+        const vr::TrackedDeviceIndex_t gunControllerIndex = rightControllerIndex;
+
+        if (ShouldRenderScope() && gunControllerIndex != vr::k_unTrackedDeviceIndexInvalid)
+            vr::VROverlay()->ShowOverlay(m_ScopeHandle);
+        else
+            vr::VROverlay()->HideOverlay(m_ScopeHandle);
+    }
+    else
+    {
+        vr::VROverlay()->HideOverlay(m_ScopeHandle);
+    }
+
     submitEye(vr::Eye_Left, &m_VKLeftEye.m_VRTexture, &(m_TextureBounds)[0]);
     submitEye(vr::Eye_Right, &m_VKRightEye.m_VRTexture, &(m_TextureBounds)[1]);
 
@@ -625,6 +674,66 @@ void VR::RepositionOverlays(bool attachToControllers)
             vr::HmdMatrix34_t segmentTransform = buildFacingTransform(segmentPos);
             vr::VROverlay()->SetOverlayTransformAbsolute(overlay, trackingOrigin, &segmentTransform);
             vr::VROverlay()->SetOverlayWidthInMeters(overlay, segmentWidth);
+        }
+    }
+
+    // Reposition scope overlay relative to the gun-hand controller.
+    // Note: gun hand follows the same left-handed swap logic used in GetPoses().
+    {
+        vr::TrackedDeviceIndex_t leftControllerIndex = m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_LeftHand);
+        vr::TrackedDeviceIndex_t rightControllerIndex = m_System->GetTrackedDeviceIndexForControllerRole(vr::TrackedControllerRole_RightHand);
+        if (m_LeftHanded)
+            std::swap(leftControllerIndex, rightControllerIndex);
+
+        const vr::TrackedDeviceIndex_t gunControllerIndex = rightControllerIndex;
+        if (gunControllerIndex != vr::k_unTrackedDeviceIndexInvalid)
+        {
+            const float deg2rad = 3.14159265358979323846f / 180.0f;
+
+            auto mul33 = [](const float a[3][3], const float b[3][3], float out[3][3])
+            {
+                for (int r = 0; r < 3; ++r)
+                    for (int c = 0; c < 3; ++c)
+                        out[r][c] = a[r][0] * b[0][c] + a[r][1] * b[1][c] + a[r][2] * b[2][c];
+            };
+
+            const float pitch = m_ScopeOverlayAngleOffset.x * deg2rad;
+            const float yaw   = m_ScopeOverlayAngleOffset.y * deg2rad;
+            const float roll  = m_ScopeOverlayAngleOffset.z * deg2rad;
+
+            const float cp = cosf(pitch), sp = sinf(pitch);
+            const float cy = cosf(yaw),   sy = sinf(yaw);
+            const float cr = cosf(roll),  sr = sinf(roll);
+
+            const float Rx[3][3] = {
+                {1.0f, 0.0f, 0.0f},
+                {0.0f, cp,   -sp},
+                {0.0f, sp,   cp}
+            };
+            const float Ry[3][3] = {
+                {cy,   0.0f, sy},
+                {0.0f, 1.0f, 0.0f},
+                {-sy,  0.0f, cy}
+            };
+            const float Rz[3][3] = {
+                {cr,   -sr,  0.0f},
+                {sr,   cr,   0.0f},
+                {0.0f, 0.0f, 1.0f}
+            };
+
+            float RyRx[3][3];
+            float R[3][3];
+            mul33(Ry, Rx, RyRx);
+            mul33(Rz, RyRx, R);
+
+            vr::HmdMatrix34_t scopeRelative = {
+                R[0][0], R[0][1], R[0][2], m_ScopeOverlayXOffset,
+                R[1][0], R[1][1], R[1][2], m_ScopeOverlayYOffset,
+                R[2][0], R[2][1], R[2][2], m_ScopeOverlayZOffset
+            };
+
+            vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(m_ScopeHandle, gunControllerIndex, &scopeRelative);
+            vr::VROverlay()->SetOverlayWidthInMeters(m_ScopeHandle, std::max(0.01f, m_ScopeOverlayWidthMeters));
         }
     }
 }
@@ -2199,6 +2308,58 @@ void VR::UpdateTracking()
     else
     {
         m_SpecialInfectedAutoAimDirection = m_RightControllerForward;
+    }
+
+    // Update scope camera pose + look-through activation
+    if (m_ScopeEnabled)
+    {
+        m_ScopeCameraPosAbs = m_RightControllerPosAbs
+            + m_RightControllerForward * m_ScopeCameraOffset.x
+            + m_RightControllerRight  * m_ScopeCameraOffset.y
+            + m_RightControllerUp     * m_ScopeCameraOffset.z;
+
+        QAngle scopeAng;
+        QAngle::VectorAngles(m_RightControllerForward, m_RightControllerUp, scopeAng);
+        scopeAng.x += m_ScopeCameraAngleOffset.x;
+        scopeAng.y += m_ScopeCameraAngleOffset.y;
+        scopeAng.z += m_ScopeCameraAngleOffset.z;
+        scopeAng.x = wrapAngle(scopeAng.x);
+        scopeAng.y = wrapAngle(scopeAng.y);
+        scopeAng.z = wrapAngle(scopeAng.z);
+        m_ScopeCameraAngAbs = scopeAng;
+
+        if (m_ScopeRequireLookThrough)
+        {
+            const float maxDist = std::max(0.0f, m_ScopeLookThroughDistanceMeters) * m_VRScale;
+            Vector toScope = m_ScopeCameraPosAbs - m_HmdPosAbs;
+            const float dist = VectorLength(toScope);
+            if (dist > 0.0f && dist <= maxDist)
+            {
+                toScope /= dist;
+                Vector scopeForward;
+                QAngle::AngleVectors(m_ScopeCameraAngAbs, &scopeForward);
+                if (!scopeForward.IsZero()) VectorNormalize(scopeForward);
+
+                const float maxAngleRad = std::clamp(m_ScopeLookThroughAngleDeg, 0.0f, 89.0f) * (3.14159265358979323846f / 180.0f);
+                const float minDot = cosf(maxAngleRad);
+
+                const float inFrontDot = DotProduct(m_HmdForward, toScope);
+                const float alignDot   = DotProduct(m_HmdForward, scopeForward);
+                m_ScopeActive = (inFrontDot > 0.2f) && (alignDot >= minDot);
+            }
+            else
+            {
+                m_ScopeActive = false;
+            }
+        }
+        else
+        {
+            m_ScopeActive = true;
+        }
+    }
+    else
+    {
+        m_ScopeActive = false;
     }
 
     // Non-VR servers only understand cmd->viewangles. When ForceNonVRServerMovement is enabled,
@@ -4081,6 +4242,27 @@ void VR::ParseConfigFile()
     m_AimLineMaxHz = std::max(0.0f, getFloat("AimLineMaxHz", m_AimLineMaxHz));
     m_ThrowArcLandingOffset = std::max(-10000.0f, std::min(10000.0f, getFloat("ThrowArcLandingOffset", m_ThrowArcLandingOffset)));
     m_ThrowArcMaxHz = std::max(0.0f, getFloat("ThrowArcMaxHz", m_ThrowArcMaxHz));
+
+    // Gun-mounted scope
+    m_ScopeEnabled = getBool("ScopeEnabled", m_ScopeEnabled);
+    m_ScopeRTTSize = std::clamp(getInt("ScopeRTTSize", m_ScopeRTTSize), 128, 4096);
+    m_ScopeFov = std::clamp(getFloat("ScopeFov", m_ScopeFov), 1.0f, 179.0f);
+    m_ScopeZNear = std::clamp(getFloat("ScopeZNear", m_ScopeZNear), 0.1f, 64.0f);
+    m_ScopeCameraOffset = getVector3("ScopeCameraOffset", m_ScopeCameraOffset);
+    { Vector tmp = getVector3("ScopeCameraAngleOffset", Vector{ m_ScopeCameraAngleOffset.x, m_ScopeCameraAngleOffset.y, m_ScopeCameraAngleOffset.z }); m_ScopeCameraAngleOffset = QAngle{ tmp.x, tmp.y, tmp.z }; }
+
+    m_ScopeOverlayWidthMeters = std::max(0.001f, getFloat("ScopeOverlayWidthMeters", m_ScopeOverlayWidthMeters));
+    m_ScopeOverlayXOffset = getFloat("ScopeOverlayXOffset", m_ScopeOverlayXOffset);
+    m_ScopeOverlayYOffset = getFloat("ScopeOverlayYOffset", m_ScopeOverlayYOffset);
+    m_ScopeOverlayZOffset = getFloat("ScopeOverlayZOffset", m_ScopeOverlayZOffset);
+    { Vector tmp = getVector3("ScopeOverlayAngleOffset", Vector{ m_ScopeOverlayAngleOffset.x, m_ScopeOverlayAngleOffset.y, m_ScopeOverlayAngleOffset.z }); m_ScopeOverlayAngleOffset = QAngle{ tmp.x, tmp.y, tmp.z }; }
+
+    m_ScopeOverlayAlwaysVisible = getBool("ScopeOverlayAlwaysVisible", m_ScopeOverlayAlwaysVisible);
+    m_ScopeOverlayIdleAlpha = std::clamp(getFloat("ScopeOverlayIdleAlpha", m_ScopeOverlayIdleAlpha), 0.0f, 1.0f);
+    m_ScopeRequireLookThrough = getBool("ScopeRequireLookThrough", m_ScopeRequireLookThrough);
+    m_ScopeLookThroughDistanceMeters = std::clamp(getFloat("ScopeLookThroughDistanceMeters", m_ScopeLookThroughDistanceMeters), 0.01f, 2.0f);
+    m_ScopeLookThroughAngleDeg = std::clamp(getFloat("ScopeLookThroughAngleDeg", m_ScopeLookThroughAngleDeg), 1.0f, 89.0f);
+
     m_ForceNonVRServerMovement = getBool("ForceNonVRServerMovement", m_ForceNonVRServerMovement);
 
 // Non-VR server melee feel tuning (ForceNonVRServerMovement=true only)

--- a/dxvk_local/src/d3d9/d3d9_device.cpp
+++ b/dxvk_local/src/d3d9/d3d9_device.cpp
@@ -517,6 +517,12 @@ namespace dxvk {
               texture.ref()->GetSurfaceLevel(0, &g_Game->m_VR->m_D9HUDSurface);
               g_D3DVR9->GetVRDesc(g_Game->m_VR->m_D9HUDSurface, &texDesc);
           }
+          else if (texID == VR::Texture_Scope)
+          {
+              textureTarget = &g_Game->m_VR->m_VKScope;
+              texture.ref()->GetSurfaceLevel(0, &g_Game->m_VR->m_D9ScopeSurface);
+              g_D3DVR9->GetVRDesc(g_Game->m_VR->m_D9ScopeSurface, &texDesc);
+          }
           else if (texID == VR::Texture_Blank)
           {
               textureTarget = &g_Game->m_VR->m_VKBlankTexture;


### PR DESCRIPTION
## Summary
- add gun-mounted scope overlay handle, textures, and runtime state
- render a scoped camera pass to a dedicated RTT and place it on the controller
- route bullet origins and HUD capture logic to respect scope activation and overlays

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a6a68fc708321834f3abc358dc2ee)