### PR TITLE
Add engine third-person detection and configurability

### DIFF
--- a/L4D2VR/game.cpp
+++ b/L4D2VR/game.cpp
@@ -260,10 +260,14 @@ ConVar* Game::FindConVar(const char* name) const
     return m_Cvar->FindVar(name);
 }
 
-bool Game::IsEngineThirdPersonActive()
+bool Game::IsEngineThirdPersonActive(bool* outHasFlag)
 {
     if (!m_Cvar)
+    {
+        if (outHasFlag)
+            *outHasFlag = false;
         return false;
+    }
 
     // Cache the lookup to avoid repeated string hashing.
     if (!m_ThirdPersonConVarChecked)
@@ -289,7 +293,11 @@ bool Game::IsEngineThirdPersonActive()
         }
     }
 
-    if (!m_ThirdPersonShoulderConVar)
+    const bool hasFlag = (m_ThirdPersonShoulderConVar != nullptr);
+    if (outHasFlag)
+        *outHasFlag = hasFlag;
+
+    if (!hasFlag)
         return false;
 
     return m_ThirdPersonShoulderConVar->GetBool();

--- a/L4D2VR/game.h
+++ b/L4D2VR/game.h
@@ -118,7 +118,7 @@ public:
     static void errorMsg(const char* msg);
 
     // === Engine State ===
-    bool IsEngineThirdPersonActive();
+    bool IsEngineThirdPersonActive(bool* outHasFlag = nullptr);
 
     // === Player Utilities ===
     bool IsValidPlayerIndex(int index) const;

--- a/L4D2VR/game.h
+++ b/L4D2VR/game.h
@@ -7,6 +7,7 @@
 #include <Windows.h>
 
 #include "vector.h"
+#include "cvar.h"
 
 // === Forward Declarations for Engine Interfaces ===
 class IClientEntityList;
@@ -23,6 +24,7 @@ class C_BaseEntity;
 class C_BasePlayer;
 struct model_t;
 class IVDebugOverlay;
+class ConVar;
 
 // === Forward Declarations for Internal Systems ===
 class Game;
@@ -62,6 +64,7 @@ public:
     IInput* m_VguiInput = nullptr;
     ISurface* m_VguiSurface = nullptr;
     IVDebugOverlay* m_DebugOverlay = nullptr;
+    ICvar* m_Cvar = nullptr;
 
     // === Module Base Addresses ===
     uintptr_t m_BaseEngine = 0;
@@ -92,6 +95,10 @@ public:
     IMaterial* m_ArmsMaterial = nullptr;
     bool m_CachedArmsModel = false;
 
+    // === ConVar Cache ===
+    ConVar* m_ThirdPersonShoulderConVar = nullptr;
+    bool m_ThirdPersonConVarChecked = false;
+
     // === Constructor ===
     Game();
 
@@ -100,6 +107,7 @@ public:
     C_BaseEntity* GetClientEntity(int entityIndex);
     char* getNetworkName(uintptr_t* entity);
     const char* GetNetworkClassName(uintptr_t* entity) const;
+    ConVar* FindConVar(const char* name) const;
 
     // === Command Execution ===
     void ClientCmd(const char* szCmdString);
@@ -108,6 +116,9 @@ public:
     // === Logging ===
     static void logMsg(const char* fmt, ...);
     static void errorMsg(const char* msg);
+
+    // === Engine State ===
+    bool IsEngineThirdPersonActive();
 
     // === Player Utilities ===
     bool IsValidPlayerIndex(int index) const;

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -241,9 +241,10 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	const float camDist = (setup.origin - eyeOrigin).Length();
 	bool engineFlagAvailable = false;
 	const bool engineThirdPersonFlag = m_Game->IsEngineThirdPersonActive(&engineFlagAvailable);
-	const bool distanceThirdPersonNow = (localPlayer && camDist > m_VR->m_ThirdPersonDistanceThreshold);
+	const bool allowDistanceFallback = (m_VR->m_ThirdPersonDetectionMode == VR::ThirdPersonDetectionMode::DistanceOnly) || m_VR->m_ThirdPersonDistanceFallbackEnabled;
+	const bool distanceThirdPersonNow = allowDistanceFallback && localPlayer && (camDist > m_VR->m_ThirdPersonDistanceThreshold);
 	if (distanceThirdPersonNow)
-		m_VR->m_ThirdPersonHoldFrames = 2;
+		m_VR->m_ThirdPersonHoldFrames = std::max(m_VR->m_ThirdPersonHoldFrames, m_VR->m_ThirdPersonDistanceHoldFrames);
 	else if (m_VR->m_ThirdPersonHoldFrames > 0)
 		m_VR->m_ThirdPersonHoldFrames--;
 

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -1,4 +1,4 @@
-﻿#include "hooks.h"
+#include "hooks.h"
 #include "game.h"
 #include "texture.h"
 #include "sdk.h"

--- a/L4D2VR/sdk/cvar.h
+++ b/L4D2VR/sdk/cvar.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <cstdint>
+
+// Minimal Source engine ICvar/ConVar interfaces for querying client ConVars.
+
+using CreateInterfaceFn = void* (*)(const char* name, int* returnCode);
+
+enum InitReturnVal_t
+{
+	INIT_FAILED = 0,
+	INIT_OK,
+};
+
+struct AppSystemInfo_t
+{
+	const char* pSystemName;
+	const char* pInterfaceName;
+};
+
+enum AppSystemTier_t
+{
+	APP_SYSTEM_TIER0 = 0,
+	APP_SYSTEM_TIER1,
+	APP_SYSTEM_TIER2,
+	APP_SYSTEM_TIER3,
+};
+
+class IAppSystem
+{
+public:
+	virtual bool Connect(CreateInterfaceFn factory) = 0;
+	virtual void Disconnect() = 0;
+	virtual void* QueryInterface(const char* pInterfaceName) = 0;
+	virtual InitReturnVal_t Init() = 0;
+	virtual void Shutdown() = 0;
+	virtual const AppSystemInfo_t* GetDependencies() = 0;
+	virtual AppSystemTier_t GetTier() = 0;
+	virtual void Reconnect(CreateInterfaceFn factory, const char* pInterfaceName) = 0;
+	virtual bool IsSingleton() = 0;
+};
+
+struct Color
+{
+	uint8_t r, g, b, a;
+};
+
+class ConCommandBase;
+
+class IConVar
+{
+public:
+	virtual void SetValue(const char* pValue) = 0;
+	virtual void SetValue(float flValue) = 0;
+	virtual void SetValue(int nValue) = 0;
+	virtual void SetValue(Color value) = 0;
+};
+
+class ConVar : public IConVar
+{
+public:
+	virtual bool IsFlagSet(int flag) const = 0;
+	virtual const char* GetHelpText(void) const = 0;
+	virtual bool IsRegistered(void) const = 0;
+	virtual const char* GetName(void) const = 0;
+	virtual const char* GetBaseName(void) const = 0;
+	virtual int GetSplitScreenPlayerSlot() const = 0;
+	virtual void AddFlags(int flags) = 0;
+	virtual int GetFlags() const = 0;
+	virtual bool IsCommand(void) const = 0;
+	virtual void SetValue(const char* value) = 0;
+	virtual void SetValue(float value) = 0;
+	virtual void SetValue(int value) = 0;
+	virtual void SetValue(Color value) = 0;
+	virtual void InternalSetValue(const char* value) = 0;
+	virtual void InternalSetFloatValue(float fNewValue) = 0;
+	virtual void InternalSetIntValue(int nValue) = 0;
+	virtual void ChangeStringValue(const char* tempVal, float flOldValue) = 0;
+	virtual void Create(const char* pszName, const char* pszHelpString = 0, int flags = 0, const char* pszDefaultValue = 0, bool bHasMin = false, float fMinVal = 0.0, bool bHasMax = false, float fMaxVal = 0.0, void* callback = 0) = 0;
+	virtual void Init() = 0;
+	virtual const char* GetDefault(void) const = 0;
+	virtual void SetDefault(const char* pszDefault) = 0;
+	virtual float GetFloat(void) const = 0;
+	virtual int GetInt(void) const = 0;
+	virtual bool GetBool(void) const = 0;
+	virtual const char* GetString(void) const = 0;
+};
+
+class IConsoleDisplayFunc;
+
+class ICvar : public IAppSystem
+{
+public:
+	using CVarDLLIdentifier_t = int;
+
+	virtual CVarDLLIdentifier_t AllocateDLLIdentifier() = 0;
+	virtual void RegisterConCommand(ConCommandBase* pCommandBase) = 0;
+	virtual void UnregisterConCommand(ConCommandBase* pCommandBase) = 0;
+	virtual void UnregisterConCommands(CVarDLLIdentifier_t id) = 0;
+	virtual const char* GetCommandLineValue(const char* pVariableName) = 0;
+	virtual ConCommandBase* FindCommandBase(const char* name) = 0;
+	virtual const ConCommandBase* FindCommandBase(const char* name) const = 0;
+	virtual ConVar* FindVar(const char* var_name) = 0;
+	virtual const ConVar* FindVar(const char* var_name) const = 0;
+	virtual void CallGlobalChangeCallbacks(ConVar* var, const char* pOldString, float flOldValue) = 0;
+	virtual void InstallConsoleDisplayFunc(IConsoleDisplayFunc* pDisplayFunc) = 0;
+	virtual void RemoveConsoleDisplayFunc(IConsoleDisplayFunc* pDisplayFunc) = 0;
+	virtual void ConsoleColorPrintf(const Color& clr, const char* pFormat, ...) const = 0;
+	virtual void ConsolePrintf(const char* pFormat, ...) const = 0;
+	virtual void ConsoleDPrintf(const char* pFormat, ...) const = 0;
+	virtual void RevertFlaggedConVars(int nFlag) = 0;
+	virtual void InstallGlobalChangeCallback(void (*callback)(ConVar*, const char*, float)) = 0;
+	virtual void RemoveGlobalChangeCallback(void (*callback)(ConVar*, const char*, float)) = 0;
+	virtual void CallGlobalChangeCallbacks(ConVar* var, const char* pOldString, float flOldValue, bool invokeCallback) = 0;
+	virtual void InstallConsoleCommandBase(ConCommandBase* pCommandBase) = 0;
+	virtual void AssignConCommandBase(CVarDLLIdentifier_t id, ConCommandBase* pCommandBase) = 0;
+};

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -85,7 +85,7 @@ void VR::ReportThirdPersonDecision(bool isThirdPerson, bool usedEngine, bool use
         (usedEngine != m_LastThirdPersonUsedEngine) ||
         (usedDistance != m_LastThirdPersonUsedDistance);
     const bool sourceChanged = (engineFlag != m_LastThirdPersonEngineFlag) ||
-        (usedDistance != m_LastThirdPersonUsedDistance);
+        (distanceFlag != m_LastThirdPersonDistanceFlag);
 
     if (!stateChanged && !sourceChanged)
         return;
@@ -4369,6 +4369,8 @@ void VR::ParseConfigFile()
 
     m_ThirdPersonDistanceThreshold = std::max(0.0f, getFloat("ThirdPersonDistanceThreshold", m_ThirdPersonDistanceThreshold));
     m_ThirdPersonEngineSlack = std::max(0.0f, getFloat("ThirdPersonEngineSlack", m_ThirdPersonEngineSlack));
+    m_ThirdPersonDistanceFallbackEnabled = getBool("ThirdPersonDistanceFallbackEnabled", m_ThirdPersonDistanceFallbackEnabled);
+    m_ThirdPersonDistanceHoldFrames = std::max(0, getInt("ThirdPersonDistanceHoldFrames", m_ThirdPersonDistanceHoldFrames));
 
     // Non-VR server melee feel tuning (ForceNonVRServerMovement=true only)
     m_NonVRMeleeSwingThreshold = std::max(0.0f, getFloat("NonVRMeleeSwingThreshold", m_NonVRMeleeSwingThreshold));

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -1,4 +1,4 @@
-﻿
+
 #include "vr.h"
 #include <Windows.h>
 #include "sdk.h"

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -54,6 +54,13 @@ struct CustomActionBinding
 class VR
 {
 public:
+	enum class ThirdPersonDetectionMode
+	{
+		Hybrid = 0,
+		EngineOnly,
+		DistanceOnly
+	};
+
 	Game* m_Game = nullptr;
 
 	vr::IVRSystem* m_System = nullptr;
@@ -129,6 +136,14 @@ public:
 	QAngle m_ThirdPersonViewAngles = { 0,0,0 };
 	bool m_ThirdPersonPoseInitialized = false;
 	float m_ThirdPersonCameraSmoothing = 0.5f;
+	ThirdPersonDetectionMode m_ThirdPersonDetectionMode = ThirdPersonDetectionMode::Hybrid;
+	float m_ThirdPersonDistanceThreshold = 5.0f;
+	float m_ThirdPersonEngineSlack = 2.0f;
+	bool m_LastThirdPersonState = false;
+	bool m_LastThirdPersonEngineFlag = false;
+	bool m_LastThirdPersonDistanceFlag = false;
+	bool m_LastThirdPersonUsedEngine = false;
+	bool m_LastThirdPersonUsedDistance = false;
 
 	Vector m_LeftControllerPosAbs;
 	QAngle m_LeftControllerAngAbs;
@@ -581,6 +596,8 @@ public:
 	Vector GetThirdPersonViewOrigin() const { return m_ThirdPersonViewOrigin; }
 	QAngle GetThirdPersonViewAngles() const { return m_ThirdPersonViewAngles; }
 	bool IsThirdPersonCameraActive() const { return m_IsThirdPersonCamera; }
+	const char* GetThirdPersonDetectionModeName() const;
+	void ReportThirdPersonDecision(bool isThirdPerson, bool usedEngine, bool usedDistance, bool engineFlag, bool distanceFlag, float camDist);
 	bool PressedDigitalAction(vr::VRActionHandle_t& actionHandle, bool checkIfActionChanged = false);
 	bool GetDigitalActionData(vr::VRActionHandle_t& actionHandle, vr::InputDigitalActionData_t& digitalDataOut);
 	bool GetAnalogActionData(vr::VRActionHandle_t& actionHandle, vr::InputAnalogActionData_t& analogDataOut);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -132,13 +132,15 @@ public:
 	bool m_IsThirdPersonCamera = false;
 	bool m_ObserverThirdPerson = false;
 	int m_ThirdPersonHoldFrames = 0;
+	int m_ThirdPersonDistanceHoldFrames = 2;
 	Vector m_ThirdPersonViewOrigin = { 0,0,0 };
 	QAngle m_ThirdPersonViewAngles = { 0,0,0 };
 	bool m_ThirdPersonPoseInitialized = false;
 	float m_ThirdPersonCameraSmoothing = 0.5f;
-	ThirdPersonDetectionMode m_ThirdPersonDetectionMode = ThirdPersonDetectionMode::Hybrid;
+	ThirdPersonDetectionMode m_ThirdPersonDetectionMode = ThirdPersonDetectionMode::EngineOnly;
 	float m_ThirdPersonDistanceThreshold = 5.0f;
 	float m_ThirdPersonEngineSlack = 2.0f;
+	bool m_ThirdPersonDistanceFallbackEnabled = false;
 	bool m_LastThirdPersonState = false;
 	bool m_LastThirdPersonEngineFlag = false;
 	bool m_LastThirdPersonDistanceFlag = false;


### PR DESCRIPTION
## Summary
- add minimal ICvar interface to read engine third-person ConVars and cache the thirdpersonshoulder flag
- prioritize engine-declared third-person in dRenderView while keeping distance heuristics as fallback with slack and detailed logging
- expose config knobs for third-person detection mode and thresholds to tune behavior for mods

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695be88b898c83219bfc24bccd0b2cca)