### PR TITLE
Make third-person camera detection configurable

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -23,6 +23,16 @@ ControllerSmoothing=0.0
 
 HideArms=false
 
+ThirdPersonDistanceThreshold=5.0
+ThirdPersonHorizontalThreshold=2.5
+ThirdPersonVerticalThreshold=1.25
+ThirdPersonAngleDeltaThreshold=50.0
+ThirdPersonHoldTimeMs=75
+ThirdPersonSignalsRequired=1
+ThirdPersonShoulderHint=false
+ThirdPersonDebugOverlay=false
+ThirdPersonDebugOverlayDuration=0.18
+
 RequireSecondaryAttackForItemSwitch=true
 VoiceRecordCombo=Crouch+Reload
 QuickTurnCombo=SecondaryAttack+Crouch
@@ -131,4 +141,3 @@ ScopeLookThroughDistanceMeters=0.6
 ScopeLookThroughAngleDeg=60
 ScopeOverlayAlwaysVisible=false
 ScopeOverlayIdleAlpha=0.5
-

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -5,6 +5,7 @@
 #include "sdk_server.h"
 #include "vr.h"
 #include "offsets.h"
+#include "sdk/ivdebugoverlay.h"
 #include <iostream>
 #include <cstdint>
 #include <string>
@@ -269,7 +270,10 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	const float holdSeconds = std::max(0.0f, m_VR->m_ThirdPersonHoldTimeMs * 0.001f);
 	bool engineThirdPersonNow = (signalCount >= m_VR->m_ThirdPersonSignalsRequired);
 	if (engineThirdPersonNow && holdSeconds > 0.0f)
-		m_VR->m_ThirdPersonHoldUntil = now + std::chrono::duration<float>(holdSeconds);
+	{
+		const auto holdDuration = std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<float>(holdSeconds));
+		m_VR->m_ThirdPersonHoldUntil = now + holdDuration;
+	}
 
 	const bool holdActive = holdSeconds > 0.0f && now < m_VR->m_ThirdPersonHoldUntil;
 	if (!engineThirdPersonNow && holdActive)

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2596,7 +2596,8 @@ void VR::UpdateNonVRAimSolution(C_BasePlayer* localPlayer)
 
     Vector originBase = m_RightControllerPosAbs;
     Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
-    if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
+    const float camDeltaThresholdSq = m_ThirdPersonDistanceThreshold * m_ThirdPersonDistanceThreshold;
+    if (m_IsThirdPersonCamera && camDelta.LengthSqr() > camDeltaThresholdSq)
         originBase += camDelta;
 
     Vector origin = originBase + direction * 2.0f;
@@ -2713,7 +2714,8 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     // We key off the actual camera delta (not just the boolean) to avoid cases where 3P detection flickers.
     Vector originBase = m_RightControllerPosAbs;
     Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
-    if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
+    const float camDeltaThresholdSq = m_ThirdPersonDistanceThreshold * m_ThirdPersonDistanceThreshold;
+    if (m_IsThirdPersonCamera && camDelta.LengthSqr() > camDeltaThresholdSq)
         originBase += camDelta;
 
     Vector origin = originBase + direction * 2.0f;
@@ -4263,6 +4265,16 @@ void VR::ParseConfigFile()
     else
         headSmoothingValue = controllerSmoothingValue; // Match controller smoothing by default
     m_HeadSmoothing = std::clamp(headSmoothingValue, 0.0f, 0.99f);
+
+    m_ThirdPersonDistanceThreshold = std::max(0.0f, getFloat("ThirdPersonDistanceThreshold", m_ThirdPersonDistanceThreshold));
+    m_ThirdPersonHorizontalThreshold = std::max(0.0f, getFloat("ThirdPersonHorizontalThreshold", m_ThirdPersonHorizontalThreshold));
+    m_ThirdPersonVerticalThreshold = std::max(0.0f, getFloat("ThirdPersonVerticalThreshold", m_ThirdPersonVerticalThreshold));
+    m_ThirdPersonAngleDeltaThreshold = std::max(0.0f, getFloat("ThirdPersonAngleDeltaThreshold", m_ThirdPersonAngleDeltaThreshold));
+    m_ThirdPersonHoldTimeMs = std::clamp(getFloat("ThirdPersonHoldTimeMs", m_ThirdPersonHoldTimeMs), 0.0f, 1000.0f);
+    m_ThirdPersonSignalsRequired = std::max(1, getInt("ThirdPersonSignalsRequired", m_ThirdPersonSignalsRequired));
+    m_ThirdPersonShoulderHint = getBool("ThirdPersonShoulderHint", m_ThirdPersonShoulderHint);
+    m_ThirdPersonDebugOverlayEnabled = getBool("ThirdPersonDebugOverlay", m_ThirdPersonDebugOverlayEnabled);
+    m_ThirdPersonDebugOverlayDuration = std::max(0.01f, getFloat("ThirdPersonDebugOverlayDuration", m_ThirdPersonDebugOverlayDuration));
     m_MotionGestureSwingThreshold = std::max(0.0f, getFloat("MotionGestureSwingThreshold", m_MotionGestureSwingThreshold));
     m_MotionGestureDownSwingThreshold = std::max(0.0f, getFloat("MotionGestureDownSwingThreshold", m_MotionGestureDownSwingThreshold));
     m_MotionGestureJumpThreshold = std::max(0.0f, getFloat("MotionGestureJumpThreshold", m_MotionGestureJumpThreshold));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -129,6 +129,21 @@ public:
 	QAngle m_ThirdPersonViewAngles = { 0,0,0 };
 	bool m_ThirdPersonPoseInitialized = false;
 	float m_ThirdPersonCameraSmoothing = 0.5f;
+	float m_ThirdPersonDistanceThreshold = 5.0f;
+	float m_ThirdPersonHorizontalThreshold = 2.5f;
+	float m_ThirdPersonVerticalThreshold = 1.25f;
+	float m_ThirdPersonAngleDeltaThreshold = 50.0f;
+	float m_ThirdPersonHoldTimeMs = 75.0f;
+	int m_ThirdPersonSignalsRequired = 1;
+	bool m_ThirdPersonShoulderHint = false;
+	bool m_ThirdPersonDebugOverlayEnabled = false;
+	float m_ThirdPersonDebugOverlayDuration = 0.18f;
+	std::chrono::steady_clock::time_point m_ThirdPersonHoldUntil{};
+	float m_ThirdPersonLastCamDistance = 0.0f;
+	float m_ThirdPersonLastHorizontalDistance = 0.0f;
+	float m_ThirdPersonLastVerticalDistance = 0.0f;
+	float m_ThirdPersonLastAngleDelta = 0.0f;
+	int m_ThirdPersonLastSignalCount = 0;
 
 	Vector m_LeftControllerPosAbs;
 	QAngle m_LeftControllerAngAbs;


### PR DESCRIPTION
## Summary
- add configurable third-person detection thresholds, signal count, and adaptive hold timing sourced from config
- incorporate additional detection signals (HMD angle delta, per-axis offsets, optional shoulder hint) plus debug logging/overlay hooks
- reuse the configurable threshold when offsetting third-person aim helpers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c00f9d2c883219ce29d71d9cb2061)