### PR TITLE
Add user-controlled third-person lock and cam_collision management

### DIFF
--- a/L4D2VR/hooks.h
+++ b/L4D2VR/hooks.h
@@ -83,6 +83,8 @@ typedef void(__thiscall* tPopRenderTargetAndViewport)(void* thisptr);
 typedef void(__thiscall* tVgui_Paint)(void* thisptr, int mode);
 typedef int(__cdecl* tIsSplitScreen)();
 typedef DWORD* (__thiscall* tPrePushRenderTarget)(void* thisptr, int a2);
+typedef void* (__thiscall* tClientCmd)(void* thisptr, const char* szCmdString);
+typedef void* (__thiscall* tClientCmdUnrestricted)(void* thisptr, const char* szCmdString);
 
 
 class Hooks
@@ -119,6 +121,8 @@ public:
 	static inline Hook<tVgui_Paint> hkVgui_Paint;
 	static inline Hook<tIsSplitScreen> hkIsSplitScreen;
 	static inline Hook<tPrePushRenderTarget> hkPrePushRenderTarget;
+	static inline Hook<tClientCmd> hkClientCmd;
+	static inline Hook<tClientCmdUnrestricted> hkClientCmdUnrestricted;
 	static bool s_ServerUnderstandsVR;
 
 	Hooks() {};
@@ -157,6 +161,8 @@ public:
 	static void __fastcall dVGui_Paint(void* ecx, void* edx, int mode);
 	static int __fastcall dIsSplitScreen();
 	static DWORD* __fastcall dPrePushRenderTarget(void* ecx, void* edx, int a2);
+	static void* __fastcall dClientCmd(void* ecx, void* edx, const char* szCmdString);
+	static void* __fastcall dClientCmdUnrestricted(void* ecx, void* edx, const char* szCmdString);
 
 	static inline int m_PushHUDStep;
 	static inline bool m_PushedHud;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -54,6 +54,12 @@ struct CustomActionBinding
 class VR
 {
 public:
+	enum class CameraMode
+	{
+		FirstPerson,
+		ThirdPerson
+	};
+
 	Game* m_Game = nullptr;
 
 	vr::IVRSystem* m_System = nullptr;
@@ -129,6 +135,9 @@ public:
 	QAngle m_ThirdPersonViewAngles = { 0,0,0 };
 	bool m_ThirdPersonPoseInitialized = false;
 	float m_ThirdPersonCameraSmoothing = 0.5f;
+	bool m_ThirdPersonModeLocked = false;
+	CameraMode m_CameraMode = CameraMode::FirstPerson;
+	bool m_CamCollisionEnabled = false;
 
 	Vector m_LeftControllerPosAbs;
 	QAngle m_LeftControllerAngAbs;
@@ -623,4 +632,12 @@ public:
 	void GetAimLineColor(int& r, int& g, int& b, int& a) const;
 	void FinishFrame();
 	void ConfigureExplicitTiming();
+	void InitializeCameraMode();
+	void RequestThirdPersonShoulder();
+	void RequestFirstPerson();
+	bool ShouldForceThirdPersonCamera() const;
+	bool IsThirdPersonModeLocked() const { return m_ThirdPersonModeLocked; }
+	bool IsThirdPersonUserMode() const { return m_CameraMode == CameraMode::ThirdPerson; }
+	void SetCameraMode(CameraMode mode, bool lockThirdPerson);
+	void ApplyCameraCollision(bool enable);
 };


### PR DESCRIPTION
### Motivation
- Provide a user-driven way to lock the VR camera into third-person shoulder mode and avoid flicker caused by the engine's automatic third-person detection.
- Ensure `cam_collision` is set correctly for the chosen camera mode and only when the mode actually changes to avoid per-frame writes.
- Keep automatic third-person heuristics from overriding an explicit user lock so shoulder view stays stable.
- Expose a small API in `VR` to request/initialize camera mode and toggle camera collision programmatically.

### Description
- Added camera mode state and APIs in `vr.h`/`vr.cpp`: `CameraMode`, `InitializeCameraMode`, `SetCameraMode`, `RequestThirdPersonShoulder`, `RequestFirstPerson`, and `ApplyCameraCollision` which runs `ClientCmd_Unrestricted("cam_collision 1"/"0")` only when the state actually changes.
- Hooked engine command calls by adding detours for `ClientCmd` and `ClientCmd_Unrestricted` (vtable indices used) in `hooks.h`/`hooks.cpp` and detect the `thirdpersonshoulder` and `firstperson` tokens to call the new `VR` APIs.
- Short-circuited the existing automatic third-person detection in `Hooks::dRenderView` when the user has requested/locked third-person to prevent the hold-frame hysteresis flipping the mode.
- Added helper `CommandMatchesToken` and `HandleCameraCommand` to robustly parse and match the console token and guarded hook installation so command hooks enable only if vtable pointers are present.

### Testing
- No automated tests were run for this change.
- Changes were compiled/committed locally during development (source diffs updated: `L4D2VR/hooks.cpp`, `L4D2VR/hooks.h`, `L4D2VR/vr.cpp`, `L4D2VR/vr.h`).
- Runtime behavior to validate manually: issue `thirdpersonshoulder` to lock third-person (should set `cam_collision 1` and stop flicker), and `firstperson` to return to first-person (should set `cam_collision 0`).
- Hook installation is guarded; if engine vtable lookups fail the command hooks are not enabled and an error is logged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c98f9c8108321aa634830ef293f37)