### PR TITLE
Add scope magnification toggle and sync aim line behavior

### DIFF
--- a/L4D2VR/SteamVRActionManifest/action_manifest.json
+++ b/L4D2VR/SteamVRActionManifest/action_manifest.json
@@ -144,6 +144,11 @@
 			"name": "/actions/main/in/CustomAction2",
 			"type": "boolean",
 			"requirement": "optional"
+		},
+		{
+			"name": "/actions/main/in/ScopeMagnificationToggle",
+			"type": "boolean",
+			"requirement": "optional"
 		}
 	],
 
@@ -186,7 +191,8 @@
 			"/actions/main/in/ShowHUD": "Show HUD",
 			"/actions/main/in/Pause": "Pause",
 			"/actions/main/in/CustomAction1": "Custom Action 1",
-			"/actions/main/in/CustomAction2": "Custom Action 2"
+			"/actions/main/in/CustomAction2": "Custom Action 2",
+			"/actions/main/in/ScopeMagnificationToggle": "Toggle Scope Magnification"
 		}
 	]
 }

--- a/L4D2VR/SteamVRActionManifest/bindings_knuckles.json
+++ b/L4D2VR/SteamVRActionManifest/bindings_knuckles.json
@@ -123,7 +123,16 @@
                "mode" : "button",
                "path" : "/user/hand/right/input/b"
             },
-			{
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/main/in/ScopeMagnificationToggle"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/a"
+            },
+            {
                "inputs" : {
                   "click" : {
                      "output" : "/actions/main/in/ActivateVR"
@@ -233,4 +242,3 @@
    "options" : {},
    "simulated_actions" : []
 }
-

--- a/L4D2VR/SteamVRActionManifest/bindings_oculus_touch.json
+++ b/L4D2VR/SteamVRActionManifest/bindings_oculus_touch.json
@@ -118,7 +118,16 @@
                "mode" : "button",
                "path" : "/user/hand/right/input/b"
             },
-			{
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/main/in/ScopeMagnificationToggle"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/a"
+            },
+            {
                "inputs" : {
                   "click" : {
                      "output" : "/actions/main/in/ActivateVR"
@@ -223,4 +232,3 @@
    "options" : {},
    "simulated_actions" : []
 }
-

--- a/L4D2VR/SteamVRActionManifest/bindings_vive_cosmos_controller.json
+++ b/L4D2VR/SteamVRActionManifest/bindings_vive_cosmos_controller.json
@@ -118,7 +118,16 @@
                "mode" : "button",
                "path" : "/user/hand/right/input/b"
             },
-			{
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/main/in/ScopeMagnificationToggle"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/a"
+            },
+            {
                "inputs" : {
                   "click" : {
                      "output" : "/actions/main/in/ActivateVR"
@@ -223,4 +232,3 @@
    "options" : {},
    "simulated_actions" : []
 }
-

--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -115,7 +115,8 @@ SpecialInfectedTraceMaxHz=90
 
 ScopeEnabled=true
 ScopeRTTSize=512
-ScopeFov=8
+ScopeFov=20
+ScopeMagnification=20,15,10,5
 ScopeZNear=2
 
 ScopeCameraOffset=12,0,3
@@ -132,4 +133,3 @@ ScopeLookThroughDistanceMeters=0.6
 ScopeLookThroughAngleDeg=60
 ScopeOverlayAlwaysVisible=false
 ScopeOverlayIdleAlpha=0.5
-

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 #define MAX_STR_LEN 256
 
 class Game;
@@ -172,6 +173,8 @@ public:
 	bool m_HasAimLine = false;
 	float m_AimLineThickness = 2.0f;
 	bool m_AimLineEnabled = true;
+	bool m_AimLineConfigEnabled = true;
+	bool m_ScopeForcingAimLine = false;
 	bool m_MeleeAimLineEnabled = true;
 	float m_AimLinePersistence = 0.02f;
 	float m_AimLineFrameDurationMultiplier = 2.0f;
@@ -303,6 +306,7 @@ public:
 	vr::VRActionHandle_t m_CustomAction3;
 	vr::VRActionHandle_t m_CustomAction4;
 	vr::VRActionHandle_t m_CustomAction5;
+	vr::VRActionHandle_t m_ActionScopeMagnificationToggle;
 
 	TrackedDevicePoseData m_HmdPose;
 	TrackedDevicePoseData m_LeftControllerPose;
@@ -515,6 +519,8 @@ public:
 	int   m_ScopeRTTSize = 1024;               // square RTT size in pixels
 	float m_ScopeFov = 20.0f;                  // smaller = more zoom
 	float m_ScopeZNear = 2.0f;                 // game units
+	std::vector<float> m_ScopeMagnificationOptions{ 20.0f, 15.0f, 10.0f, 5.0f };
+	size_t m_ScopeMagnificationIndex = 0;
 
 	// Scope camera pose relative to gun hand (game units, in controller basis fwd/right/up)
 	Vector m_ScopeCameraOffset = { 10.0f, 0.0f, 2.0f };
@@ -543,6 +549,8 @@ public:
 	QAngle GetScopeCameraAbsAngle() const { return m_ScopeCameraAngAbs; }
 	bool   IsScopeActive() const { return m_ScopeEnabled && m_ScopeActive; }
 	bool   ShouldRenderScope() const { return m_ScopeEnabled && (m_ScopeOverlayAlwaysVisible || IsScopeActive()); }
+	void   CycleScopeMagnification();
+	void   UpdateScopeAimLineState();
 
 	VR() {};
 	VR(Game* game);


### PR DESCRIPTION
### Motivation
- Provide a SteamVR button to cycle scope zoom levels so users can switch scope FOV in-VR without editing files.
- Allow scope magnification choices to be managed from the config via a single parameter list so multiple presets are easy to set with `ScopeMagnification`.
- Ensure aiming helpers behave sensibly when scoping by temporarily enabling the aim line while scoped if the user had disabled it in config, and restoring state after scope closes.

### Description
- Added a new SteamVR action `ScopeMagnificationToggle` and default controller bindings in `L4D2VR/SteamVRActionManifest/*` to map a controller button to cycle magnification.
- Introduced `ScopeMagnification` parsing and storage (`m_ScopeMagnificationOptions`, `m_ScopeMagnificationIndex`) and updated `ParseConfigFile` and `config.txt` to support a comma-separated list (default `20,15,10,5`).
- Implemented `CycleScopeMagnification()` to advance the selected FOV and `UpdateScopeAimLineState()` plus flags `m_AimLineConfigEnabled` and `m_ScopeForcingAimLine` to temporarily enable/disable the aim line when scoping.
- Hooked the new action into input processing (`ProcessInput`) and added the action handle `m_ActionScopeMagnificationToggle` acquisition in `SetActionManifest`.

### Testing
- No automated tests were executed in this environment (changes committed but no CI/build/tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d270a09fc8321a3942796d8dd1bf5)