### PR TITLE
Fix scope RTT depth setup and HUD view alignment

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -435,9 +435,10 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		scopeView.angles.y = scopeAngles.y;
 		scopeView.angles.z = scopeAngles.z;
 
-		CViewSetup hudScope = hudViewSetup;
-		hudScope.origin = scopeView.origin;
-		hudScope.angles = scopeView.angles;
+        // Keep the HUD view setup consistent with the offscreen scope view.
+        // Mismatched viewport/FOV here can confuse some internal render paths and lead to
+        // "only a transparent silhouette" for certain NPCs in the scope RTT.
+        CViewSetup hudScope = scopeView;
 
 		// prevent HUD capture hooks during this pass
 		m_VR->m_SuppressHudCapture = true;

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -333,7 +333,10 @@ void VR::CreateVRTextures()
         static_cast<int>(m_ScopeRTTSize),
         RT_SIZE_NO_CHANGE,
         m_Game->m_MaterialSystem->GetBackBufferFormat(),
-        MATERIAL_RT_DEPTH_SHARED,
+        // IMPORTANT: scope RTT needs its own depth buffer.
+        // Sharing depth with the main view/HUD can cause certain opaque models (notably common infected)
+        // to fail depth/culling in this offscreen pass, showing up as a faint/transparent silhouette.
+        MATERIAL_RT_DEPTH_SEPARATE,
         TEXTUREFLAGS_NOMIP);
 
     m_CreatingTextureID = Texture_Blank;


### PR DESCRIPTION
### Motivation
- The scope offscreen render target was sharing the main depth buffer which caused certain opaque models to fail depth/culling and appear as faint/transparent silhouettes in the scope render.
- A mismatch between the HUD view setup and the scope view (viewport/FOV) can confuse internal render paths and contribute to rendering artifacts in the scope RTT.

### Description
- In `L4D2VR/vr.cpp` change the scope render target `vrScope` to use `MATERIAL_RT_DEPTH_SEPARATE` instead of `MATERIAL_RT_DEPTH_SHARED` and add an explanatory comment.
- In `L4D2VR/hooks.cpp` replace the manual origin/angles copy with `CViewSetup hudScope = scopeView` and add comments to keep HUD view setup consistent with the offscreen scope view.
- These adjustments allocate a dedicated depth buffer for the scope RTT and ensure HUD view parameters match the scope pass to avoid mismatched viewport/FOV issues.

### Testing
- No automated tests were executed for this change.
- Basic build or runtime verification was not run as part of this PR checklist.
- No unit or integration tests were added or updated.
- Manual runtime observation prompted the change but is not recorded here as an automated test result.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e017e762883219a50cda02cf06982)