### PR TITLE
Add configurable minimum hit distance for aim line traces

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2622,7 +2622,13 @@ void VR::UpdateNonVRAimSolution(C_BasePlayer* localPlayer)
     rayP.Init(origin, target);
     m_Game->m_EngineTrace->TraceRay(rayP, STANDARD_TRACE_MASK, &tracefilter, &traceP);
 
-    const Vector P = (traceP.fraction < 1.0f && traceP.fraction > 0.0f) ? traceP.endpos : target;
+    Vector P = target;
+    if (traceP.fraction < 1.0f && traceP.fraction > 0.0f)
+    {
+        const float hitDist = (traceP.endpos - origin).Length();
+        if (hitDist >= m_AimLineMinHitDistance)
+            P = traceP.endpos;
+    }
     m_NonVRAimDesiredPoint = P;
 
     // 2) Eye ray towards P -> H (what the server will actually hit)
@@ -2765,7 +2771,15 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
             ray.Init(origin, target);
             m_Game->m_EngineTrace->TraceRay(ray, STANDARD_TRACE_MASK, &tracefilter, &trace);
 
-            m_AimConvergePoint = (trace.fraction < 1.0f && trace.fraction > 0.0f) ? trace.endpos : target;
+            m_AimConvergePoint = target;
+            if (trace.fraction < 1.0f && trace.fraction > 0.0f)
+            {
+                const float hitDist = (trace.endpos - origin).Length();
+                if (hitDist >= m_AimLineMinHitDistance)
+                    m_AimConvergePoint = trace.endpos;
+                else
+                    m_AimConvergePoint = target;
+            }
             m_HasAimConvergePoint = true;
             target = m_AimConvergePoint; // draw to P
         }
@@ -4368,6 +4382,7 @@ void VR::ParseConfigFile()
     m_AimLineColorA = aimColor[3];
     m_AimLinePersistence = std::max(0.0f, getFloat("AimLinePersistence", m_AimLinePersistence));
     m_AimLineFrameDurationMultiplier = std::max(0.0f, getFloat("AimLineFrameDurationMultiplier", m_AimLineFrameDurationMultiplier));
+    m_AimLineMinHitDistance = std::max(0.0f, getFloat("AimLineMinHitDistance", m_AimLineMinHitDistance));
     m_AimLineMaxHz = std::max(0.0f, getFloat("AimLineMaxHz", m_AimLineMaxHz));
     m_ThrowArcLandingOffset = std::max(-10000.0f, std::min(10000.0f, getFloat("ThrowArcLandingOffset", m_ThrowArcLandingOffset)));
     m_ThrowArcMaxHz = std::max(0.0f, getFloat("ThrowArcMaxHz", m_ThrowArcMaxHz));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -182,6 +182,9 @@ public:
 	bool m_PlayerControlledBySI = false;
 	float m_AimLinePersistence = 0.02f;
 	float m_AimLineFrameDurationMultiplier = 2.0f;
+	// If the aim ray hits something extremely close to its origin (e.g. player hugging a wall),
+	// ignore that hit so the line doesn't "stick" to nearby geometry. 0 = disable.
+	float m_AimLineMinHitDistance = 8.0f;
 	int m_AimLineColorR = 0;
 	int m_AimLineColorG = 255;
 	int m_AimLineColorB = 0;


### PR DESCRIPTION
### Motivation
- Prevent aim lines from "sticking" to geometry that is extremely close to the aim origin (e.g., player hugging a wall). 
- Make the behavior configurable so users can tune or disable the proximity ignore behavior.

### Description
- Added a new member `m_AimLineMinHitDistance` (default `8.0f`) to `vr.h` to store the minimum hit distance setting.
- Updated `UpdateNonVRAimSolution` to ignore controller-trace hits closer than `m_AimLineMinHitDistance` when computing the desired point `P`.
- Updated `UpdateAimingLaser` to apply the same minimum-hit-distance check when computing the third-person aim converge point in `UpdateAimingLaser`.
- Loaded the new setting from configuration via `ParseConfigFile` using the `AimLineMinHitDistance` key.

### Testing
- No automated tests were executed for this change.
- No test failures reported because no tests were run.
- Manual runtime verification was not recorded as part of the automated test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e406484e0832182a847c7a7ab8423)