### PR TITLE
Add rear mirror RTT overlay tied to off-hand controller

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -133,3 +133,16 @@ ScopeLookThroughDistanceMeters=0.6
 ScopeLookThroughAngleDeg=60
 ScopeOverlayAlwaysVisible=false
 ScopeOverlayIdleAlpha=0.5
+
+RearMirrorEnabled=true
+RearMirrorRTTSize=512
+RearMirrorFov=85
+RearMirrorZNear=6
+RearMirrorCameraOffset=0,0,0
+RearMirrorCameraAngleOffset=0,0,0
+RearMirrorOverlayWidthMeters=0.1
+RearMirrorOverlayXOffset=-0.01
+RearMirrorOverlayYOffset=0.02
+RearMirrorOverlayZOffset=0.08
+RearMirrorOverlayAngleOffset=0,180,0
+RearMirrorAlpha=1.0

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -551,6 +551,58 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		m_VR->m_SuppressHudCapture = false;
 	}
 
+	// ----------------------------
+	// Rear mirror RTT pass: render from HMD with 180 yaw into vrRearMirror RTT
+	// ----------------------------
+	if (m_VR->m_CreatedVRTextures && m_VR->ShouldRenderRearMirror() && m_VR->m_RearMirrorTexture)
+	{
+		CViewSetup mirrorView = setup;
+		mirrorView.x = 0;
+		mirrorView.y = 0;
+		mirrorView.m_nUnscaledX = 0;
+		mirrorView.m_nUnscaledY = 0;
+		mirrorView.width = m_VR->m_RearMirrorRTTSize;
+		mirrorView.m_nUnscaledWidth = m_VR->m_RearMirrorRTTSize;
+		mirrorView.height = m_VR->m_RearMirrorRTTSize;
+		mirrorView.m_nUnscaledHeight = m_VR->m_RearMirrorRTTSize;
+		mirrorView.fov = m_VR->m_RearMirrorFov;
+		mirrorView.m_flAspectRatio = 1.0f;
+		mirrorView.fovViewmodel = mirrorView.fov;
+		mirrorView.zNear = m_VR->m_RearMirrorZNear;
+		mirrorView.zNearViewmodel = 99999.0f;
+
+		QAngle mirrorAngles = m_VR->GetRearMirrorCameraAbsAngle();
+		mirrorView.origin = m_VR->GetRearMirrorCameraAbsPos();
+		mirrorView.angles.x = mirrorAngles.x;
+		mirrorView.angles.y = mirrorAngles.y;
+		mirrorView.angles.z = mirrorAngles.z;
+
+		CViewSetup hudMirror = hudViewSetup;
+		hudMirror.origin = mirrorView.origin;
+		hudMirror.angles = mirrorView.angles;
+
+		m_VR->m_SuppressHudCapture = true;
+
+		IMatRenderContext* renderContext = m_Game->m_MaterialSystem->GetRenderContext();
+		if (renderContext)
+		{
+			hkPushRenderTargetAndViewport.fOriginal(renderContext, m_VR->m_RearMirrorTexture, nullptr, 0, 0, m_VR->m_RearMirrorRTTSize, m_VR->m_RearMirrorRTTSize);
+			renderContext->ClearColor4ub(0, 0, 0, 255);
+			renderContext->ClearBuffers(true, true, true);
+
+			QAngle oldEngineAngles;
+			m_Game->m_EngineClient->GetViewAngles(oldEngineAngles);
+			m_Game->m_EngineClient->SetViewAngles(mirrorAngles);
+
+			hkRenderView.fOriginal(ecx, mirrorView, hudMirror, nClearFlags, whatToDraw);
+
+			m_Game->m_EngineClient->SetViewAngles(oldEngineAngles);
+			hkPopRenderTargetAndViewport.fOriginal(renderContext);
+		}
+
+		m_VR->m_SuppressHudCapture = false;
+	}
+
 	// Restore engine angles immediately after our stereo render.
 	m_Game->m_EngineClient->SetViewAngles(prevEngineAngles);
 	m_VR->m_RenderedNewFrame = true;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -67,6 +67,8 @@ public:
 	std::array<vr::VROverlayHandle_t, 4> m_HUDBottomHandles{};
 	// Gun-mounted scope overlay (render-to-texture lens)
 	vr::VROverlayHandle_t m_ScopeHandle = vr::k_ulOverlayHandleInvalid;
+	// Rear mirror overlay (off-hand)
+	vr::VROverlayHandle_t m_RearMirrorHandle = vr::k_ulOverlayHandleInvalid;
 
 	float m_HorizontalOffsetLeft;
 	float m_VerticalOffsetLeft;
@@ -225,6 +227,7 @@ public:
 		Texture_RightEye,
 		Texture_HUD,
 		Texture_Scope,
+		Texture_RearMirror,
 		Texture_Blank
 	};
 
@@ -232,12 +235,14 @@ public:
 	ITexture* m_RightEyeTexture;
 	ITexture* m_HUDTexture;
 	ITexture* m_ScopeTexture = nullptr;
+	ITexture* m_RearMirrorTexture = nullptr;
 	ITexture* m_BlankTexture = nullptr;
 
 	IDirect3DSurface9* m_D9LeftEyeSurface;
 	IDirect3DSurface9* m_D9RightEyeSurface;
 	IDirect3DSurface9* m_D9HUDSurface;
 	IDirect3DSurface9* m_D9ScopeSurface;
+	IDirect3DSurface9* m_D9RearMirrorSurface = nullptr;
 	IDirect3DSurface9* m_D9BlankSurface;
 
 	SharedTextureHolder m_VKLeftEye;
@@ -245,6 +250,7 @@ public:
 	SharedTextureHolder m_VKBackBuffer;
 	SharedTextureHolder m_VKHUD;
 	SharedTextureHolder m_VKScope;
+	SharedTextureHolder m_VKRearMirror;
 	SharedTextureHolder m_VKBlankTexture;
 
 	bool m_IsVREnabled = false;
@@ -555,6 +561,31 @@ public:
 	bool   ShouldRenderScope() const { return m_ScopeEnabled && (m_ScopeOverlayAlwaysVisible || IsScopeActive()); }
 	void   CycleScopeMagnification();
 	void   UpdateScopeAimLineState();
+
+	// ----------------------------
+	// Rear mirror (off-hand)
+	// ----------------------------
+	bool  m_RearMirrorEnabled = false;
+	int   m_RearMirrorRTTSize = 512;
+	float m_RearMirrorFov = 85.0f;
+	float m_RearMirrorZNear = 6.0f;
+
+	Vector m_RearMirrorCameraOffset = { 0.0f, 0.0f, 0.0f };
+	QAngle m_RearMirrorCameraAngleOffset = { 0.0f, 0.0f, 0.0f };
+
+	float  m_RearMirrorOverlayWidthMeters = 0.10f;
+	float  m_RearMirrorOverlayXOffset = -0.01f;
+	float  m_RearMirrorOverlayYOffset = 0.02f;
+	float  m_RearMirrorOverlayZOffset = 0.08f;
+	QAngle m_RearMirrorOverlayAngleOffset = { 0.0f, 180.0f, 0.0f };
+	float  m_RearMirrorAlpha = 1.0f;
+
+	Vector m_RearMirrorCameraPosAbs = { 0.0f, 0.0f, 0.0f };
+	QAngle m_RearMirrorCameraAngAbs = { 0.0f, 0.0f, 0.0f };
+
+	Vector GetRearMirrorCameraAbsPos() const { return m_RearMirrorCameraPosAbs; }
+	QAngle GetRearMirrorCameraAbsAngle() const { return m_RearMirrorCameraAngAbs; }
+	bool   ShouldRenderRearMirror() const { return m_RearMirrorEnabled; }
 
 	VR() {};
 	VR(Game* game);


### PR DESCRIPTION
### Motivation

- Provide a rear-view mirror as an RTT SteamVR overlay attached to the off-hand controller for situational awareness.
- Reuse the existing scope render-to-texture and overlay architecture to implement the mirror feature consistently.
- Allow runtime configuration of mirror behavior and placement via the existing `config.txt` settings.

### Description

- Added `Texture_RearMirror` and mirror-related members (`m_RearMirrorHandle`, `m_RearMirrorTexture`, `m_VKRearMirror`, surfaces, state and config fields) to `VR` in `vr.h` and exposed accessors `GetRearMirrorCameraAbsPos/Angle` and `ShouldRenderRearMirror`.
- Created the overlay handle and input method for the rear mirror in `VR::VR()`, allocated the mirror RTT in `VR::CreateVRTextures()`, and wired overlay texture submission in `VR::SubmitVRTextures()` with alpha handling.
- Attached the overlay to the off-hand controller in `VR::RepositionOverlays()` using the same tracked-device-relative transform math as the scope overlay, and added `UpdateTracking()` logic to compute the mirror camera pose as HMD orientation plus a 180° yaw and configured offsets.
- Added an off-screen render pass in `hooks.cpp` that renders the scene from the mirror camera into the rear mirror RTT (push/pop render target and view angle swap), and added configurable defaults to `config.txt` plus parsing in `VR::ParseConfigFile()`.

### Testing

- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eac3e0db48321b45e1a02222ad9cd)