### PR TITLE
Add bottom mask overlays for scope and rear mirror

### DIFF
--- a/L4D2VR/d3d9_device.cpp
+++ b/L4D2VR/d3d9_device.cpp
@@ -521,7 +521,7 @@ namespace dxvk {
           vr::VRVulkanTextureData_t vulkanData;
           memset(&vulkanData, 0, sizeof(vr::VRVulkanTextureData_t));
 
-          SharedTextureHolder *textureTarget;
+          SharedTextureHolder* textureTarget = nullptr;
           D3D9_TEXTURE_VR_DESC texDesc;
           VR::TextureID texID = g_Game->m_VR->m_CreatingTextureID;
 
@@ -555,12 +555,27 @@ namespace dxvk {
               texture.ref()->GetSurfaceLevel(0, &g_Game->m_VR->m_D9RearMirrorSurface);
               g_D3DVR9->GetVRDesc(g_Game->m_VR->m_D9RearMirrorSurface, &texDesc);
           }
+          else if (texID == VR::Texture_ScopeMask)
+          {
+              textureTarget = &g_Game->m_VR->m_VKScopeMask;
+              texture.ref()->GetSurfaceLevel(0, &g_Game->m_VR->m_D9ScopeMaskSurface);
+              g_D3DVR9->GetVRDesc(g_Game->m_VR->m_D9ScopeMaskSurface, &texDesc);
+          }
+          else if (texID == VR::Texture_RearMirrorMask)
+          {
+              textureTarget = &g_Game->m_VR->m_VKRearMirrorMask;
+              texture.ref()->GetSurfaceLevel(0, &g_Game->m_VR->m_D9RearMirrorMaskSurface);
+              g_D3DVR9->GetVRDesc(g_Game->m_VR->m_D9RearMirrorMaskSurface, &texDesc);
+          }
           else if (texID == VR::Texture_Blank)
           {
               textureTarget = &g_Game->m_VR->m_VKBlankTexture;
               texture.ref()->GetSurfaceLevel(0, &g_Game->m_VR->m_D9BlankSurface);
               g_D3DVR9->GetVRDesc(g_Game->m_VR->m_D9BlankSurface, &texDesc);
           }
+
+          if (!textureTarget)
+              return D3D_OK;
 
           memcpy(&textureTarget->m_VulkanData, &texDesc, sizeof(vr::VRVulkanTextureData_t));
           textureTarget->m_VRTexture.handle = &textureTarget->m_VulkanData;

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2659,6 +2659,31 @@ void VR::UpdateTracking()
         m_ScopeActive = false;
     }
 
+    // Update rear mirror camera pose
+    if (m_RearMirrorEnabled)
+    {
+        const bool useRight = m_LeftHanded;
+        const Vector& basePos = useRight ? m_RightControllerPosAbs : m_LeftControllerPosAbs;
+        const Vector& baseForward = useRight ? m_RightControllerForward : m_LeftControllerForward;
+        const Vector& baseRight = useRight ? m_RightControllerRight : m_LeftControllerRight;
+        const Vector& baseUp = useRight ? m_RightControllerUp : m_LeftControllerUp;
+
+        m_RearMirrorCameraPosAbs = basePos
+            + baseForward * m_RearMirrorCameraOffset.x
+            + baseRight * m_RearMirrorCameraOffset.y
+            + baseUp * m_RearMirrorCameraOffset.z;
+
+        QAngle mirrorAng;
+        QAngle::VectorAngles(baseForward, baseUp, mirrorAng);
+        mirrorAng.x += m_RearMirrorCameraAngleOffset.x;
+        mirrorAng.y += m_RearMirrorCameraAngleOffset.y;
+        mirrorAng.z += m_RearMirrorCameraAngleOffset.z;
+        mirrorAng.x = wrapAngle(mirrorAng.x);
+        mirrorAng.y = wrapAngle(mirrorAng.y);
+        mirrorAng.z = wrapAngle(mirrorAng.z);
+        m_RearMirrorCameraAngAbs = mirrorAng;
+    }
+
     UpdateScopeAimLineState();
 
     // Non-VR servers only understand cmd->viewangles. When ForceNonVRServerMovement is enabled,
@@ -4688,6 +4713,10 @@ void VR::ParseConfigFile()
     // Rear mirror
     m_RearMirrorEnabled = getBool("RearMirrorEnabled", m_RearMirrorEnabled);
     m_RearMirrorRTTSize = std::clamp(getInt("RearMirrorRTTSize", m_RearMirrorRTTSize), 128, 4096);
+    m_RearMirrorFov = std::clamp(getFloat("RearMirrorFov", m_RearMirrorFov), 1.0f, 179.0f);
+    m_RearMirrorZNear = std::clamp(getFloat("RearMirrorZNear", m_RearMirrorZNear), 0.1f, 64.0f);
+    m_RearMirrorCameraOffset = getVector3("RearMirrorCameraOffset", m_RearMirrorCameraOffset);
+    { Vector tmp = getVector3("RearMirrorCameraAngleOffset", Vector{ m_RearMirrorCameraAngleOffset.x, m_RearMirrorCameraAngleOffset.y, m_RearMirrorCameraAngleOffset.z }); m_RearMirrorCameraAngleOffset = QAngle{ tmp.x, tmp.y, tmp.z }; }
     m_RearMirrorOverlayWidthMeters = std::max(0.001f, getFloat("RearMirrorOverlayWidthMeters", m_RearMirrorOverlayWidthMeters));
     m_RearMirrorOverlayXOffset = getFloat("RearMirrorOverlayXOffset", m_RearMirrorOverlayXOffset);
     m_RearMirrorOverlayYOffset = getFloat("RearMirrorOverlayYOffset", m_RearMirrorOverlayYOffset);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -410,7 +410,7 @@ void VR::CreateVRTextures()
                 ctx->ClearBuffers(true, true, true);
             }
 
-            ctx->PopRenderTargetAndViewport();
+            Hooks::hkPopRenderTargetAndViewport.fOriginal(ctx);
         }
     }
 

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -394,7 +394,13 @@ void VR::CreateVRTextures()
         auto* ctx = m_Game->m_MaterialSystem->GetRenderContext();
         if (ctx)
         {
-            ctx->PushRenderTargetAndViewport();
+            ITexture* initialTarget = m_ScopeMaskTexture ? m_ScopeMaskTexture : m_RearMirrorMaskTexture;
+            if (initialTarget)
+            {
+                const int width = std::max(1, initialTarget->GetActualWidth());
+                const int height = std::max(1, initialTarget->GetActualHeight());
+                Hooks::hkPushRenderTargetAndViewport.fOriginal(ctx, initialTarget, nullptr, 0, 0, width, height);
+            }
 
             if (m_ScopeMaskTexture)
             {
@@ -410,7 +416,8 @@ void VR::CreateVRTextures()
                 ctx->ClearBuffers(true, true, true);
             }
 
-            Hooks::hkPopRenderTargetAndViewport.fOriginal(ctx);
+            if (initialTarget)
+                Hooks::hkPopRenderTargetAndViewport.fOriginal(ctx);
         }
     }
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -67,6 +67,11 @@ public:
 	std::array<vr::VROverlayHandle_t, 4> m_HUDBottomHandles{};
 	// Gun-mounted scope overlay (render-to-texture lens)
 	vr::VROverlayHandle_t m_ScopeHandle = vr::k_ulOverlayHandleInvalid;
+	// Rear mirror overlay (off-hand)
+	vr::VROverlayHandle_t m_RearMirrorHandle = vr::k_ulOverlayHandleInvalid;
+	// Bottom mask overlays (solid color strips to hide incomplete RTT rendering)
+	vr::VROverlayHandle_t m_ScopeBottomMaskHandle = vr::k_ulOverlayHandleInvalid;
+	vr::VROverlayHandle_t m_RearMirrorBottomMaskHandle = vr::k_ulOverlayHandleInvalid;
 
 	float m_HorizontalOffsetLeft;
 	float m_VerticalOffsetLeft;
@@ -225,6 +230,9 @@ public:
 		Texture_RightEye,
 		Texture_HUD,
 		Texture_Scope,
+		Texture_RearMirror,
+		Texture_ScopeMask,
+		Texture_RearMirrorMask,
 		Texture_Blank
 	};
 
@@ -232,12 +240,18 @@ public:
 	ITexture* m_RightEyeTexture;
 	ITexture* m_HUDTexture;
 	ITexture* m_ScopeTexture = nullptr;
+	ITexture* m_RearMirrorTexture = nullptr;
+	ITexture* m_ScopeMaskTexture = nullptr;
+	ITexture* m_RearMirrorMaskTexture = nullptr;
 	ITexture* m_BlankTexture = nullptr;
 
 	IDirect3DSurface9* m_D9LeftEyeSurface;
 	IDirect3DSurface9* m_D9RightEyeSurface;
 	IDirect3DSurface9* m_D9HUDSurface;
 	IDirect3DSurface9* m_D9ScopeSurface;
+	IDirect3DSurface9* m_D9RearMirrorSurface = nullptr;
+	IDirect3DSurface9* m_D9ScopeMaskSurface = nullptr;
+	IDirect3DSurface9* m_D9RearMirrorMaskSurface = nullptr;
 	IDirect3DSurface9* m_D9BlankSurface;
 
 	SharedTextureHolder m_VKLeftEye;
@@ -245,6 +259,9 @@ public:
 	SharedTextureHolder m_VKBackBuffer;
 	SharedTextureHolder m_VKHUD;
 	SharedTextureHolder m_VKScope;
+	SharedTextureHolder m_VKRearMirror;
+	SharedTextureHolder m_VKScopeMask;
+	SharedTextureHolder m_VKRearMirrorMask;
 	SharedTextureHolder m_VKBlankTexture;
 
 	bool m_IsVREnabled = false;
@@ -544,6 +561,14 @@ public:
 	bool  m_ScopeOverlayAlwaysVisible = true;
 	float m_ScopeOverlayIdleAlpha = 0.35f;
 
+	// Bottom mask strip (helps hide incomplete scope RTT rendering / transparency artifacts)
+	bool  m_ScopeBottomMaskEnabled = true;
+	float m_ScopeBottomMaskHeightRatio = 0.18f; // 0..1 of overlay height
+	int   m_ScopeBottomMaskColorR = 0;
+	int   m_ScopeBottomMaskColorG = 0;
+	int   m_ScopeBottomMaskColorB = 0;
+	int   m_ScopeBottomMaskColorA = 255;
+
 	// Runtime state
 	Vector m_ScopeCameraPosAbs = { 0.0f, 0.0f, 0.0f };
 	QAngle m_ScopeCameraAngAbs = { 0.0f, 0.0f, 0.0f };
@@ -555,6 +580,27 @@ public:
 	bool   ShouldRenderScope() const { return m_ScopeEnabled && (m_ScopeOverlayAlwaysVisible || IsScopeActive()); }
 	void   CycleScopeMagnification();
 	void   UpdateScopeAimLineState();
+
+	// ----------------------------
+	// Rear mirror (RTT overlay)
+	// ----------------------------
+	bool  m_RearMirrorEnabled = false;
+	int   m_RearMirrorRTTSize = 512;           // square RTT size in pixels
+	float m_RearMirrorOverlayWidthMeters = 0.18f;
+	float m_RearMirrorOverlayXOffset = 0.00f;
+	float m_RearMirrorOverlayYOffset = 0.00f;
+	float m_RearMirrorOverlayZOffset = 0.10f;
+	QAngle m_RearMirrorOverlayAngleOffset = { 0.0f, 180.0f, 0.0f };
+	float  m_RearMirrorAlpha = 1.0f;
+	bool   ShouldRenderRearMirror() const { return m_RearMirrorEnabled; }
+
+	// Bottom mask strip (helps hide incomplete rear mirror RTT rendering / transparency artifacts)
+	bool  m_RearMirrorBottomMaskEnabled = true;
+	float m_RearMirrorBottomMaskHeightRatio = 0.18f; // 0..1 of overlay height
+	int   m_RearMirrorBottomMaskColorR = 0;
+	int   m_RearMirrorBottomMaskColorG = 0;
+	int   m_RearMirrorBottomMaskColorB = 0;
+	int   m_RearMirrorBottomMaskColorA = 255;
 
 	VR() {};
 	VR(Game* game);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -586,6 +586,10 @@ public:
 	// ----------------------------
 	bool  m_RearMirrorEnabled = false;
 	int   m_RearMirrorRTTSize = 512;           // square RTT size in pixels
+	float m_RearMirrorFov = 60.0f;
+	float m_RearMirrorZNear = 2.0f;            // game units
+	Vector m_RearMirrorCameraOffset = { 0.0f, 0.0f, 0.0f };
+	QAngle m_RearMirrorCameraAngleOffset = { 0.0f, 180.0f, 0.0f };
 	float m_RearMirrorOverlayWidthMeters = 0.18f;
 	float m_RearMirrorOverlayXOffset = 0.00f;
 	float m_RearMirrorOverlayYOffset = 0.00f;
@@ -601,6 +605,13 @@ public:
 	int   m_RearMirrorBottomMaskColorG = 0;
 	int   m_RearMirrorBottomMaskColorB = 0;
 	int   m_RearMirrorBottomMaskColorA = 255;
+
+	// Runtime state
+	Vector m_RearMirrorCameraPosAbs = { 0.0f, 0.0f, 0.0f };
+	QAngle m_RearMirrorCameraAngAbs = { 0.0f, 0.0f, 0.0f };
+
+	Vector GetRearMirrorCameraAbsPos() const { return m_RearMirrorCameraPosAbs; }
+	QAngle GetRearMirrorCameraAbsAngle() const { return m_RearMirrorCameraAngAbs; }
 
 	VR() {};
 	VR(Game* game);


### PR DESCRIPTION
### Motivation
- Reduce visible artifacts from incomplete render-to-texture (RTT) passes for the gun-mounted scope and rear mirror by drawing small solid-color mask strips at the bottom of those overlays.
- Provide configurable mask size, color and enable/disable options so users can tune the masking to their headset/setup.

### Description
- Added overlay handles, texture IDs and state fields for scope/rear mirror masks (`m_ScopeBottomMaskHandle`, `m_RearMirrorBottomMaskHandle`, `Texture_ScopeMask`, `Texture_RearMirrorMask`, and related `ITexture`/surface/`SharedTextureHolder` members) and new rear mirror RTT support in `vr.h`.
- Allocate rear mirror and mask render targets in `CreateVRTextures()` and clear mask RTTs to solid white so they can be tinted via `IVROverlay::SetOverlayColor` in `vr.cpp`.
- Implement overlay presentation and visibility logic in `SubmitVRTextures()` including `apply*Texture` helpers, color/alpha computation, show/hide decisions, and placement transforms for mask overlays so masks track the bottom edge of their parent overlays.
- Extend D3D9 texture registration to map `Texture_ScopeMask`/`Texture_RearMirrorMask` and guard against null `textureTarget` in `d3d9_device.cpp` to avoid processing unknown texture IDs.

### Testing
- No automated tests were executed as part of this change.
- Manual validation was not recorded in automated logs (no CI/test run reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f6e1f68708321bea6465488ee1336)