### PR TITLE
Add configurable colored masks for scope and rear mirror overlays

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -133,3 +133,5 @@ ScopeLookThroughDistanceMeters=0.6
 ScopeLookThroughAngleDeg=60
 ScopeOverlayAlwaysVisible=false
 ScopeOverlayIdleAlpha=0.5
+ScopeMaskColor=0,0,0,200
+RearMirrorMaskColor=0,0,0,200

--- a/L4D2VR/d3d9_device.cpp
+++ b/L4D2VR/d3d9_device.cpp
@@ -556,6 +556,12 @@ namespace dxvk {
                     texture.ref()->GetSurfaceLevel(0, &g_Game->m_VR->m_D9RearMirrorSurface);
                     g_D3DVR9->GetVRDesc(g_Game->m_VR->m_D9RearMirrorSurface, &texDesc);
                 }
+                else if (texID == VR::Texture_OverlayMask)
+                {
+                    textureTarget = &g_Game->m_VR->m_VKOverlayMask;
+                    texture.ref()->GetSurfaceLevel(0, &g_Game->m_VR->m_D9OverlayMaskSurface);
+                    g_D3DVR9->GetVRDesc(g_Game->m_VR->m_D9OverlayMaskSurface, &texDesc);
+                }
                 else if (texID == VR::Texture_Blank)
                 {
                     textureTarget = &g_Game->m_VR->m_VKBlankTexture;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -69,6 +69,9 @@ public:
 	vr::VROverlayHandle_t m_ScopeHandle = vr::k_ulOverlayHandleInvalid;
 	// Rear mirror overlay (off-hand)
 	vr::VROverlayHandle_t m_RearMirrorHandle = vr::k_ulOverlayHandleInvalid;
+	// Bottom mask overlays for scope + rear mirror
+	vr::VROverlayHandle_t m_ScopeMaskHandle = vr::k_ulOverlayHandleInvalid;
+	vr::VROverlayHandle_t m_RearMirrorMaskHandle = vr::k_ulOverlayHandleInvalid;
 
 	float m_HorizontalOffsetLeft;
 	float m_VerticalOffsetLeft;
@@ -228,6 +231,7 @@ public:
 		Texture_HUD,
 		Texture_Scope,
 		Texture_RearMirror,
+		Texture_OverlayMask,
 		Texture_Blank
 	};
 
@@ -236,6 +240,7 @@ public:
 	ITexture* m_HUDTexture;
 	ITexture* m_ScopeTexture = nullptr;
 	ITexture* m_RearMirrorTexture = nullptr;
+	ITexture* m_OverlayMaskTexture = nullptr;
 	ITexture* m_BlankTexture = nullptr;
 
 	IDirect3DSurface9* m_D9LeftEyeSurface;
@@ -243,6 +248,7 @@ public:
 	IDirect3DSurface9* m_D9HUDSurface;
 	IDirect3DSurface9* m_D9ScopeSurface;
 	IDirect3DSurface9* m_D9RearMirrorSurface = nullptr;
+	IDirect3DSurface9* m_D9OverlayMaskSurface = nullptr;
 	IDirect3DSurface9* m_D9BlankSurface;
 
 	SharedTextureHolder m_VKLeftEye;
@@ -251,6 +257,7 @@ public:
 	SharedTextureHolder m_VKHUD;
 	SharedTextureHolder m_VKScope;
 	SharedTextureHolder m_VKRearMirror;
+	SharedTextureHolder m_VKOverlayMask;
 	SharedTextureHolder m_VKBlankTexture;
 
 	bool m_IsVREnabled = false;
@@ -549,6 +556,10 @@ public:
 	float m_ScopeLookThroughAngleDeg = 12.0f;
 	bool  m_ScopeOverlayAlwaysVisible = true;
 	float m_ScopeOverlayIdleAlpha = 0.35f;
+	int   m_ScopeMaskColorR = 0;
+	int   m_ScopeMaskColorG = 0;
+	int   m_ScopeMaskColorB = 0;
+	int   m_ScopeMaskColorA = 200;
 
 	// Runtime state
 	Vector m_ScopeCameraPosAbs = { 0.0f, 0.0f, 0.0f };
@@ -579,6 +590,10 @@ public:
 	float  m_RearMirrorOverlayZOffset = 0.08f;
 	QAngle m_RearMirrorOverlayAngleOffset = { 0.0f, 180.0f, 0.0f };
 	float  m_RearMirrorAlpha = 1.0f;
+	int    m_RearMirrorMaskColorR = 0;
+	int    m_RearMirrorMaskColorG = 0;
+	int    m_RearMirrorMaskColorB = 0;
+	int    m_RearMirrorMaskColorA = 200;
 
 	Vector m_RearMirrorCameraPosAbs = { 0.0f, 0.0f, 0.0f };
 	QAngle m_RearMirrorCameraAngAbs = { 0.0f, 0.0f, 0.0f };


### PR DESCRIPTION
### Motivation
- Prevent parts of the scope or rear mirror render-to-texture from appearing faint/transparent when some geometry fails to render by placing a solid-colored mask under the overlay. 
- Allow users to control the mask color/alpha via configuration so the mask can match headset/scene preferences. 
- Use a shared low-res mask texture to avoid extra expensive render passes while keeping overlay alignment consistent. 
- Keep mask overlays non-interactive and ordered beneath the visual overlays so they only tint/occlude missing pixels.

### Description
- Added new overlay handles `m_ScopeMaskHandle` and `m_RearMirrorMaskHandle` and a `Texture_OverlayMask` enum entry plus backing `ITexture`/surface/`SharedTextureHolder` fields in `vr.h`.
- Create a small shared mask render target in `VR::CreateVRTextures()` (`kOverlayMaskTextureWidth` x `kOverlayMaskTextureHeight`), initialize it to a solid texel, and expose it to the compositor via `d3d9_device.cpp` mapping.
- During submission, apply the mask via a new `applyMaskTexture` helper and show/hide the mask overlays next to the scope/rear mirror overlays while setting color and alpha with `vr::VROverlay()->SetOverlayColor`/`SetOverlayAlpha` driven by new config values.
- Position the mask overlays in `RepositionOverlays()` to match the scope/rear mirror placement and parse `ScopeMaskColor` and `RearMirrorMaskColor` from `VR\config.txt` (defaults added to `config.txt`).

### Testing
- No automated tests were run for these changes.
- (No CI/unit tests were executed as part of this change.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f839e7074832183c08080bb0bb45b)