### PR TITLE
Sync setup origin to eye in first-person and tighten third-person gating

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -365,18 +365,19 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	m_VR->m_PlayerControlledBySI = IsPlayerControlledBySI(localPlayer);
 	ThirdPersonStateDebug tpStateDbg;
 	const bool stateWantsThirdPerson = ShouldForceThirdPersonByState(localPlayer, &tpStateDbg);
-	const int holdBefore = m_VR->m_ThirdPersonHoldFrames;
 	constexpr int kEngineThirdPersonHoldFrames = 2;
-	constexpr int kStateThirdPersonHoldFrames = 40;
+	constexpr int kStateThirdPersonHoldFrames = 12;
+	const bool hadThirdPerson = m_VR->m_IsThirdPersonCamera || (m_VR->m_ThirdPersonHoldFrames > 0);
+	const bool allowStateThirdPerson = stateWantsThirdPerson && (engineThirdPersonNow || hadThirdPerson);
 
 	// 先按“状态”锁定（优先级最高）
-	if (stateWantsThirdPerson)
+	if (allowStateThirdPerson)
 		m_VR->m_ThirdPersonHoldFrames = std::max(m_VR->m_ThirdPersonHoldFrames, kStateThirdPersonHoldFrames);
 
 	// 再按“引擎第三人称”做短缓冲，但不要覆盖掉状态锁定
 	if (engineThirdPersonNow)
 		m_VR->m_ThirdPersonHoldFrames = std::max(m_VR->m_ThirdPersonHoldFrames, kEngineThirdPersonHoldFrames);
-	else if (!stateWantsThirdPerson && m_VR->m_ThirdPersonHoldFrames > 0)
+	else if (!allowStateThirdPerson && m_VR->m_ThirdPersonHoldFrames > 0)
 		m_VR->m_ThirdPersonHoldFrames--;
 
 	const bool renderThirdPerson = engineThirdPersonNow || (m_VR->m_ThirdPersonHoldFrames > 0);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2165,6 +2165,17 @@ void VR::UpdateTracking()
     m_Game->m_IsMeleeWeaponActive = localPlayer->IsMeleeWeaponActive();
     RefreshActiveViewmodelAdjustment(localPlayer);
 
+    if (!m_IsThirdPersonCamera)
+    {
+        Vector eyeOrigin = localPlayer->EyePosition();
+        if (!eyeOrigin.IsZero())
+        {
+            m_SetupOrigin = eyeOrigin;
+            if (m_SetupOriginPrev.IsZero())
+                m_SetupOriginPrev = eyeOrigin;
+        }
+    }
+
     // --- Fix: third-person camera shifts CViewSetup::origin behind the player.
     // In this codebase, controller world positions are anchored off m_CameraAnchor (NOT directly off m_SetupOrigin),
     // and m_CameraAnchor is advanced by (m_SetupOrigin - m_SetupOriginPrev). If third-person origin pollutes


### PR DESCRIPTION
### Motivation
- Reduce transient viewmodel/controller offsets when the engine briefly toggles between first- and third-person by ensuring anchors follow the eye in true first-person. 
- Prevent controller world positions from being pulled toward a brief third-person camera due to `m_SetupOrigin` pollution. 
- Shorten state-driven third-person holds to make transitions less intrusive and reduce flicker described in prior changes. 

### Description
- Added a guard in `VR::UpdateTracking` (`L4D2VR/vr.cpp`) that, when `!m_IsThirdPersonCamera`, sets `m_SetupOrigin` to the player `EyePosition()` and initializes `m_SetupOriginPrev` when needed to keep anchors stable. 
- Rebased `m_SetupOrigin` earlier so the subsequent anchor rebase logic uses an up-to-date eye origin for planar anchoring. 
- (Related prior change) Tightened third-person state gating in `L4D2VR/hooks.cpp` by lowering `kStateThirdPersonHoldFrames`, and using `hadThirdPerson`/`allowStateThirdPerson` so state-driven holds only apply when recent or current third-person was active. 

### Testing
- No automated tests were run for the `vr.cpp` change. 
- The earlier `hooks.cpp` change was compiled locally as a single-file modification but no automated tests were executed. 
- Manual runtime validation was not recorded in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ff363e6248321954efbcc1b4c9e8d)