### PR TITLE
Gate rear mirror rendering on detected threats

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -580,12 +580,45 @@ public:
 	QAngle m_RearMirrorOverlayAngleOffset = { 0.0f, 180.0f, 0.0f };
 	float  m_RearMirrorAlpha = 1.0f;
 
+	// If enabled, only render/show the rear mirror when a threat is detected behind the player.
+	// This saves GPU time by skipping the rear-mirror RTT pass when idle.
+	bool  m_RearMirrorRenderOnThreat = false;
+	float m_RearMirrorRenderStopDelaySeconds = 0.50f; // keep rendering briefly after threat disappears
+
+	// Auto alpha: keep the mirror visible (very transparent) and fade in when threats are behind you.
+	bool  m_RearMirrorAutoAlpha = false;
+	float m_RearMirrorIdleAlpha = 0.03f;
+	float m_RearMirrorAlertAlpha = 1.0f;
+	float m_RearMirrorThreatRange = 220.0f;
+	float m_RearMirrorThreatAngleDeg = 70.0f;
+	float m_RearMirrorThreatHoldSeconds = 0.35f;
+	float m_RearMirrorThreatScanHz = 12.0f;
+	float m_RearMirrorAlphaFadeSpeed = 12.0f;
+	bool  m_RearMirrorThreatIncludeCommons = true;
+	bool  m_RearMirrorThreatIncludeSpecials = true;
+
+	// Runtime state
+	float m_RearMirrorCurrentAlpha = 1.0f;
+	bool  m_RearMirrorThreatActive = false;
+	std::chrono::steady_clock::time_point m_LastRearMirrorThreatTime{};
+	std::chrono::steady_clock::time_point m_LastRearMirrorThreatScanTime{};
+	bool  m_RearMirrorRenderActive = false;
+
 	Vector m_RearMirrorCameraPosAbs = { 0.0f, 0.0f, 0.0f };
 	QAngle m_RearMirrorCameraAngAbs = { 0.0f, 0.0f, 0.0f };
 
 	Vector GetRearMirrorCameraAbsPos() const { return m_RearMirrorCameraPosAbs; }
 	QAngle GetRearMirrorCameraAbsAngle() const { return m_RearMirrorCameraAngAbs; }
-	bool   ShouldRenderRearMirror() const { return m_RearMirrorEnabled; }
+	bool   ShouldRenderRearMirror() const
+	{
+		if (!m_RearMirrorEnabled)
+			return false;
+		if (!m_RearMirrorRenderOnThreat)
+			return true;
+		return m_RearMirrorRenderActive;
+	}
+
+	void   UpdateRearMirrorThreatState(C_BasePlayer* localPlayer);
 
 	VR() {};
 	VR(Game* game);


### PR DESCRIPTION
### Motivation
- Reduce GPU work and overlay clutter by skipping the rear-mirror RTT pass when no threats are detected behind the player.
- Keep the mirror unobtrusive by keeping it mostly transparent and only fading it in when an approaching threat is present.
- Avoid mirror flicker by debouncing scans, holding alert state briefly after a detection, and smoothing alpha transitions.

### Description
- Added new config/state fields `m_RearMirrorRenderOnThreat`, `m_RearMirrorRenderStopDelaySeconds`, and `m_RearMirrorRenderActive` and extended rear-mirror runtime state with `m_RearMirrorCurrentAlpha` and threat timing fields.
- Implemented `UpdateRearMirrorThreatState` (entity scan throttling, classification helpers `IsRearMirrorCommonInfectedClass` / `IsRearMirrorPlayerClass`, distance/angle checks, hold timer, alpha smoothing) and call it from `UpdateTracking`.
- Gate rendering and overlay alpha by switching overlay alpha to `m_RearMirrorCurrentAlpha` in `SubmitVRTextures` and making `ShouldRenderRearMirror()` consult `m_RearMirrorRenderOnThreat`/`m_RearMirrorRenderActive`.
- Parse the new config keys (e.g. `RearMirrorRenderOnThreat`, `RearMirrorRenderStopDelaySeconds`) in the config loader and keep fail-open behavior when the entity list is unavailable.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696089b2df9c832184b8acb73174d876)