### PR TITLE
Add visual scope stabilization using One Euro filter

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -550,10 +550,25 @@ public:
 	bool  m_ScopeOverlayAlwaysVisible = true;
 	float m_ScopeOverlayIdleAlpha = 0.35f;
 
+	// Scope stabilization (visual only): smooth the scope RTT camera pose when scoped-in.
+	// This reduces high-magnification jitter without changing shooting / aim direction.
+	bool  m_ScopeStabilizationEnabled = true;
+	float m_ScopeStabilizationMinCutoff = 1.0f;  // Hz (lower = smoother, more latency)
+	float m_ScopeStabilizationBeta = 0.08f;      // responsiveness to fast motion
+	float m_ScopeStabilizationDCutoff = 1.0f;    // Hz (derivative low-pass cutoff)
+
 	// Runtime state
 	Vector m_ScopeCameraPosAbs = { 0.0f, 0.0f, 0.0f };
 	QAngle m_ScopeCameraAngAbs = { 0.0f, 0.0f, 0.0f };
 	bool   m_ScopeActive = false;
+
+	// Scope stabilization filter state (One Euro filter)
+	bool   m_ScopeStabilizationInit = false;
+	Vector m_ScopeStabPos = { 0.0f, 0.0f, 0.0f };
+	Vector m_ScopeStabPosDeriv = { 0.0f, 0.0f, 0.0f };
+	QAngle m_ScopeStabAng = { 0.0f, 0.0f, 0.0f };
+	QAngle m_ScopeStabAngDeriv = { 0.0f, 0.0f, 0.0f };
+	std::chrono::steady_clock::time_point m_ScopeStabilizationLastTime{};
 
 	Vector GetScopeCameraAbsPos() const { return m_ScopeCameraPosAbs; }
 	QAngle GetScopeCameraAbsAngle() const { return m_ScopeCameraAngAbs; }


### PR DESCRIPTION
### Motivation

- Reduce visible jitter when using high-magnification scopes by smoothing the scope RTT camera pose without changing shooting/aim direction.
- Provide tunable stabilization parameters so users can trade smoothness for responsiveness.

### Description

- Added configuration and runtime fields in `vr.h` for scope stabilization including `m_ScopeStabilizationEnabled`, `m_ScopeStabilizationMinCutoff`, `m_ScopeStabilizationBeta`, `m_ScopeStabilizationDCutoff`, and One Euro filter state variables.
- Implemented One Euro filter helpers in `vr.cpp`: `OneEuroAlpha`, `AngleDeltaDeg`, `OneEuroFilterVec3`, and `OneEuroFilterAngles` and integrated them into the scope pose update path.
- Changed scope logic to compute a raw pose (`scopePosRaw`/`scopeAngRaw`), only enable rendering/stabilization for firearms via `m_ScopeWeaponIsFirearm`, and apply smoothing only when `m_ScopeActive` and `m_ScopeStabilizationEnabled` are true.
- Loaded stabilization settings from config in `ParseConfigFile()` using `getBool`/`getFloat` with clamping and reset filter state when stabilization is disabled.

### Testing

- No automated tests were executed for this change.
- A normal commit was created containing the changes and the repository state shows modified `L4D2VR/vr.cpp` and `L4D2VR/vr.h` files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69609ad39f4483219686b102d18c6c94)