### PR TITLE
Add config command injection (execute `cmd`/`Cmd` from VR/config.txt)

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -7,6 +7,7 @@ LeftHanded=false
 AntiAliasing=0
 ThirdPersonVRCameraOffset=50
 ForceNonVRServerMovement=false
+cmd=
 
 HudDistance=1.3
 HudSize=1.8

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -4407,6 +4407,13 @@ void VR::ParseConfigFile()
         return value.empty() ? defVal : value;
         };
 
+    const std::string injectedCmd = getString("cmd", getString("Cmd", ""));
+    if (!injectedCmd.empty())
+    {
+        m_Game->ClientCmd_Unrestricted(injectedCmd.c_str());
+        Game::logMsg("[VR] Executed config cmd: %s", injectedCmd.c_str());
+    }
+
     auto parseVirtualKey = [&](const std::string& rawValue)->std::optional<WORD>
         {
             std::string value = rawValue;


### PR DESCRIPTION
### Motivation
- Allow executing a console command specified in the VR configuration during config parsing to enable simple automation or one-off commands.
- Support both `cmd` and legacy `Cmd` keys for compatibility with different config styles.

### Description
- Read the `cmd`/`Cmd` entry from `VR/config.txt` using the existing `getString` helper during `VR::ParseConfigFile`.
- Execute the command via `m_Game->ClientCmd_Unrestricted` when a non-empty value is present and log the action with `Game::logMsg`.
- Add a `cmd=` placeholder to the default `L4D2VR/config.txt` so users can populate it easily.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615f541c208321a22061392d2de2e7)