### PR TITLE
Add option to force first-person rendering when holding `+walk`

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -133,6 +133,11 @@ public:
 	bool m_ThirdPersonPoseInitialized = false;
 	float m_ThirdPersonCameraSmoothing = 0.5f;
 	float m_ThirdPersonVRCameraOffset = 80.0f;
+
+	// If true, holding a CustomAction bound to +walk will force first-person rendering.
+	// Useful for slide mods that temporarily switch the engine camera to third-person on +walk.
+	bool m_ForceFirstPersonRenderOnWalk = false;
+	bool m_CustomWalkActive = false;
 	Vector m_LeftControllerPosAbs;
 	QAngle m_LeftControllerAngAbs;
 	Vector m_RightControllerPosAbs;


### PR DESCRIPTION
### Motivation
- Some mods bind `+walk` via CustomAction and temporarily flip the engine camera to third-person, which breaks VR first-person rendering and causes visual artifacts. 
- Provide an opt-in configuration to keep VR rendering in first-person while such a CustomAction is held. 
- Track CustomAction press state for `+walk` so VR can decide to override engine third-person detection. 
- Prevent hysteresis from "sticking" in third-person when the override is active.

### Description
- Added `m_ForceFirstPersonRenderOnWalk` and `m_CustomWalkActive` flags to the `VR` class to hold configuration and runtime state. 
- In `VR::ProcessInput` added logic to normalize custom action commands, detect CustomAction bindings of `+walk`, and set `m_CustomWalkActive` when any matching action is held. 
- Read the new config key via `getBool("ForceFirstPersonRenderOnWalk", ...)` during `ParseConfigFile` to enable the behavior. 
- Updated `Hooks::dRenderView` to compute `engineThirdPersonNowRaw`, apply the `forceFirstPersonOnWalk` override, and reset `m_ThirdPersonHoldFrames` to avoid hysteresis when forcing first-person.

### Testing
- No automated tests were executed for this change. 
- The patch was committed to the repository and the three modified files are `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, and `L4D2VR/hooks.cpp`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69616adba55c8321ac00ba43f5f2cf75)