### PR TITLE
Anchor rear-mirror overlay to body origin

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -619,6 +619,7 @@ public:
 	void SubmitVRTextures();
 	void LogCompositorError(const char* action, vr::EVRCompositorError error);
 	void RepositionOverlays(bool attachToControllers = true);
+	void UpdateRearMirrorOverlayTransform();
 	void GetPoses();
 	bool UpdatePosesAndActions();
 	void GetViewParameters();


### PR DESCRIPTION
### Motivation
- Make the rear-mirror overlay position stable and consistent by anchoring it to the player/body origin instead of a controller.
- Ensure the rear mirror transform is updated each frame so the overlay follows the player's movement correctly.
- Centralize and simplify the overlay transform logic to avoid duplicating controller-relative math in multiple places.

### Description
- Added `UpdateRearMirrorOverlayTransform()` to `vr.h` and implemented the function in `vr.cpp` to compute a body-anchored overlay transform from the HMD pose and `m_InventoryBodyOriginOffset`.
- Replaced controller-relative rear-mirror positioning with a yaw-only body basis and applied user angle offsets to build a `vr::HmdMatrix34_t` used with `SetOverlayTransformAbsolute`.
- Invoke `UpdateRearMirrorOverlayTransform()` from `SubmitVRTextures()` and `RepositionOverlays()` and set overlay width via `SetOverlayWidthInMeters`.
- Removed the old code path that positioned the rear mirror relative to the off-hand controller.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962776138948321b21aae1402a47f80)