### PR TITLE
Add optional controller-based movement yaw for hand-oriented locomotion

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -3995,6 +3995,20 @@ Vector VR::GetViewAngle()
     return Vector(m_HmdAngAbs.x, m_HmdAngAbs.y, m_HmdAngAbs.z);
 }
 
+float VR::GetMovementYawDeg()
+{
+    if (!m_MoveDirectionFromController)
+    {
+        Vector hmdAng = GetViewAngle();
+        return hmdAng.y;
+    }
+
+    // Use the dominant (right) controller yaw as the movement basis.
+    // This is intentionally yaw-only; pitch/roll should not affect locomotion.
+    QAngle ctrlAng = GetRightControllerAbsAngle();
+    return ctrlAng.y;
+}
+
 Vector VR::GetViewOriginLeft()
 {
     Vector viewOriginLeft;
@@ -4609,6 +4623,9 @@ void VR::ParseConfigFile()
     m_SnapTurning = getBool("SnapTurning", m_SnapTurning);
     m_SnapTurnAngle = getFloat("SnapTurnAngle", m_SnapTurnAngle);
     m_TurnSpeed = getFloat("TurnSpeed", m_TurnSpeed);
+    // Locomotion direction: default is HMD-yaw-based. Optional hand-yaw-based.
+    m_MoveDirectionFromController = getBool("MoveDirectionFromController", m_MoveDirectionFromController);
+    m_MoveDirectionFromController = getBool("MovementDirectionFromController", m_MoveDirectionFromController);
     m_InventoryGestureRange = getFloat("InventoryGestureRange", m_InventoryGestureRange);
     m_InventoryChestOffset = getVector3("InventoryChestOffset", m_InventoryChestOffset);
     m_InventoryBackOffset = getVector3("InventoryBackOffset", m_InventoryBackOffset);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -335,6 +335,9 @@ public:
 	bool m_SnapTurning = false;
 	float m_SnapTurnAngle = 45.0;
 	bool m_LeftHanded = false;
+	// If false: movement (walk axis) follows HMD yaw ("head-oriented locomotion").
+	// If true:  movement follows the right-hand controller yaw ("hand-oriented locomotion").
+	bool m_MoveDirectionFromController = false;
 	float m_VRScale = 43.2;
 	float m_IpdScale = 1.0;
 	bool m_HideArms = false;
@@ -642,6 +645,9 @@ public:
 	void UpdateMotionGestures(C_BasePlayer* localPlayer);
 	bool UpdateThirdPersonViewState(const Vector& cameraOrigin, const Vector& cameraAngles);
 	Vector GetViewAngle();
+	// Yaw (degrees) used as the movement basis for the walk axis.
+	// Default: HMD yaw. Optional: right-controller yaw (hand-oriented locomotion).
+	float GetMovementYawDeg();
 	Vector GetViewOriginLeft();
 	Vector GetViewOriginRight();
 	Vector GetThirdPersonViewOrigin() const { return m_ThirdPersonViewOrigin; }


### PR DESCRIPTION
### Motivation
- Provide an option to drive locomotion direction from the right-hand controller instead of the HMD to support "hand-oriented" movement.
- Ensure consistent movement behavior for both VR-aware and non-VR servers by converting walk input into the server-facing command basis. 

### Description
- Added a new config-backed flag `m_MoveDirectionFromController` and a helper `GetMovementYawDeg()` to choose between HMD yaw and right-controller yaw as the movement basis. 
- Parsed the new config keys `MoveDirectionFromController` and `MovementDirectionFromController` in `ParseConfigFile()` for backwards/alias compatibility. 
- For VR-aware servers, converted walk input from the selected movement basis into the `cmd` (view) basis before applying `forwardmove`/`sidemove`. 
- For non-VR servers, switched the VR stick rebasing step to use the new movement-yaw basis so keyboard, VR-stick, and final `cmd->viewangles` project consistently. 

### Testing
- No automated tests were run for this change.
- Local change committed and code modified in `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, and `L4D2VR/hooks.cpp` with no runtime tests executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69631c0869608321b9e844677ed8632c)