### PR TITLE
Add scoped aim sensitivity scaling (ADS zoom sensitivity)

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -559,11 +559,20 @@ public:
 	bool  m_ScopeOverlayAlwaysVisible = true;
 	float m_ScopeOverlayIdleAlpha = 0.35f;
 	// Scope stabilization (visual only): smooth the scope RTT camera pose when scoped-in.
-	// This reduces high-magnification jitter without changing shooting / aim direction.
+	// This reduces high-magnification jitter.
 	bool  m_ScopeStabilizationEnabled = true;
 	float m_ScopeStabilizationMinCutoff = 1.0f;  // Hz (lower = smoother, more latency)
 	float m_ScopeStabilizationBeta = 0.08f;      // responsiveness to fast motion
 	float m_ScopeStabilizationDCutoff = 1.0f;    // Hz (derivative low-pass cutoff)
+
+	// Scoped aim sensitivity scaling (mouse-style zoom sensitivity).
+	// Value is a multiplier for controller aim delta when scoped-in:
+	//  - 1.0 = unchanged
+	//  - 0.8 = 80% sensitivity (slower)
+	// Supports per-magnification values via config (ScopeAimSensitivityScale=...)
+	std::vector<float> m_ScopeAimSensitivityScales{ 1.0f, 1.0f, 1.0f, 1.0f };
+	bool   m_ScopeAimSensitivityInit = false;
+	QAngle m_ScopeAimSensitivityBaseAng = { 0.0f, 0.0f, 0.0f };
 
 	// Runtime state
 	Vector m_ScopeCameraPosAbs = { 0.0f, 0.0f, 0.0f };

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -581,6 +581,20 @@ Option g_Options[] =
         "90"
     },
 
+    // Gun-mounted scope
+    {
+        "ScopeAimSensitivityScale",
+        OptionType::String,
+        { u8"Scope", u8"瞄准镜" },
+        { u8"Scoped Aim Sensitivity Scale", u8"开镜灵敏度缩放" },
+        { u8"Scales controller aim delta when scope is active (ADS / zoom sensitivity).",
+          u8"瞄准镜触发时按比例降低手柄瞄准灵敏度（类似开镜灵敏度）。" },
+        { u8"Accepts 0~1 or 0~100; supports comma list matching ScopeMagnification.",
+          u8"支持 0~1 或 0~100；也支持逗号列表，对应 ScopeMagnification 的档位顺序。" },
+        0.0f, 0.0f,
+        "100,100,100,100"
+    },
+
     // Motion Gestures
     {
         "MotionGestureSwingThreshold",


### PR DESCRIPTION
### Motivation
- Provide a mouse-style zoom/ADS sensitivity multiplier for controller aim while scoped so users can slow down look deltas when zoomed.
- Support per-magnification sensitivity values so different scope FOVs can use different gains.
- Avoid abrupt camera jumps when changing magnification while already scoped.

### Description
- Add `m_ScopeAimSensitivityScales`, `m_ScopeAimSensitivityInit`, and `m_ScopeAimSensitivityBaseAng` state to `vr.h` to track scaling and initialization.
- Apply a per-magnification gain to the scope camera pose by computing `scopeAngForCamera` and using it as the pre-stabilization camera angle in `vr.cpp`, with clamping and angle wrapping.
- Feed the scaled camera angle into the existing One Euro stabilization filter so stabilization and sensitivity interact smoothly, and reset/init the base angle when scope state changes.
- Parse `ScopeAimSensitivityScale` in `ParseConfigFile()` and expose the `ScopeAimSensitivityScale` option in the config tool (`L4D2VRConfigTool/src/Options.cpp`), with support for both `0..1` and `0..100` formats and comma-separated per-magnification entries.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69632ed5ec30832196d6b798c5e18c76)