### PR TITLE
Add scoped aim sensitivity scaling

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -565,6 +565,15 @@ public:
 	float m_ScopeStabilizationBeta = 0.08f;      // responsiveness to fast motion
 	float m_ScopeStabilizationDCutoff = 1.0f;    // Hz (derivative low-pass cutoff)
 
+	// Scoped aim sensitivity scaling (mouse-style ADS / zoom sensitivity).
+	// Multiplies controller aim delta while scoped-in:
+	//  - 1.0 = unchanged
+	//  - 0.8 = 80% sensitivity (slower)
+	// Supports per-magnification values via config: ScopeAimSensitivityScale=100,85,70,55
+	std::vector<float> m_ScopeAimSensitivityScales{ 1.0f };
+	bool   m_ScopeAimSensitivityInit = false;
+	QAngle m_ScopeAimSensitivityBaseAng = { 0.0f, 0.0f, 0.0f };
+
 	// Runtime state
 	Vector m_ScopeCameraPosAbs = { 0.0f, 0.0f, 0.0f };
 	QAngle m_ScopeCameraAngAbs = { 0.0f, 0.0f, 0.0f };

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -580,6 +580,19 @@ Option g_Options[] =
         30.f, 180.f,
         "90"
     },
+    // Scope
+    {
+        "ScopeAimSensitivityScale",
+        OptionType::String,
+        { u8"Scope", u8"瞄准镜" },
+        { u8"Scoped Aim Sensitivity Scale", u8"开镜灵敏度缩放" },
+        { u8"Scales controller aim while scope is active (ADS / zoom sensitivity).",
+          u8"瞄准镜触发时按比例降低手柄瞄准灵敏度（类似开镜灵敏度）。" },
+        { u8"Accepts 0~1 or 0~100; comma list matches ScopeMagnification order.",
+          u8"支持 0~1 或 0~100；也支持逗号列表，对应 ScopeMagnification 的档位顺序。" },
+        0.0f, 0.0f,
+        "100"
+    },
 
     // Motion Gestures
     {


### PR DESCRIPTION
### Motivation

- Provide ADS/zoom-style sensitivity scaling for controller aim while scoped to mimic mouse-style scope sensitivity. 
- Ensure scope camera render pose, aim line, and bullets remain consistent when applying sensitivity scaling. 
- Allow per-magnification sensitivity settings so different zoom levels can use different multipliers. 
- Avoid sudden aim jumps when changing magnification or configuration.

### Description

- Added new state to `vr.h`: `m_ScopeAimSensitivityScales`, `m_ScopeAimSensitivityInit`, and `m_ScopeAimSensitivityBaseAng` to track scaling and baseline angles. 
- Implemented scaling in `vr.cpp` by computing a scaled aim angle, updating the controller basis, recomputing `scopePosFinal`/`scopeAngFinal`, and using those final poses for stabilization and rendering. 
- Kept scope stabilization (`OneEuroFilterVec3`/`OneEuroFilterAngles`) applied to the final render pose and added a final sync that forces the gameplay aim basis to match the scope camera while scoped. 
- Added config parsing in `ParseConfigFile` for `ScopeAimSensitivityScale` (accepts single value or comma list, supports `0..1` or `0..100` styles), clamps/resizes the table to match magnification count, and resets the sensitivity baseline on magnification/config changes. 
- Exposed the new option metadata and UI strings in `L4D2VRConfigTool/src/Options.cpp` as `ScopeAimSensitivityScale`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69633d06040c83218fdc2f6d11b9a03b)