### PR TITLE
Rear mirror: aim-line hide & threat-based scaling

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -848,7 +848,7 @@ bool VR::ShouldRenderRearMirror()
     if (!m_RearMirrorAbsTransformValid || !m_HasAimLine)
         return true;
 
-    if (!m_HmdPose.bPoseIsValid)
+    if (!m_Poses[vr::k_unTrackedDeviceIndex_Hmd].bPoseIsValid)
         return true;
 
     const Vector mirrorOriginTracking = {
@@ -876,7 +876,7 @@ bool VR::ShouldRenderRearMirror()
     if (VectorNormalize(mirrorRight) == 0.0f || VectorNormalize(mirrorUp) == 0.0f || VectorNormalize(mirrorNormal) == 0.0f)
         return true;
 
-    const Vector trackingOriginWorld = m_HmdPosAbs - (m_HmdPose.TrackedDevicePos * m_VRScale);
+    const Vector trackingOriginWorld = m_HmdPosAbs - (m_Poses[vr::k_unTrackedDeviceIndex_Hmd].TrackedDevicePos * m_VRScale);
     const Vector mirrorOriginWorld = trackingOriginWorld + (mirrorOriginTracking * m_VRScale);
 
     const Vector lineStart = m_AimLineStart;

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -876,7 +876,7 @@ bool VR::ShouldRenderRearMirror()
     if (VectorNormalize(mirrorRight) == 0.0f || VectorNormalize(mirrorUp) == 0.0f || VectorNormalize(mirrorNormal) == 0.0f)
         return true;
 
-    const Vector trackingOriginWorld = m_HmdPosAbs - (m_Poses[vr::k_unTrackedDeviceIndex_Hmd].TrackedDevicePos * m_VRScale);
+    const Vector trackingOriginWorld = m_HmdPosAbs - (m_HmdPose.TrackedDevicePos * m_VRScale);
     const Vector mirrorOriginWorld = trackingOriginWorld + (mirrorOriginTracking * m_VRScale);
 
     const Vector lineStart = m_AimLineStart;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -614,12 +614,23 @@ public:
 	QAngle m_RearMirrorOverlayAngleOffset = { 0.0f, 180.0f, 0.0f };
 	float  m_RearMirrorAlpha = 1.0f;
 
+	// Rear mirror UX tweaks
+	bool  m_RearMirrorHideWhenAimLineCrosses = false;
+	float m_RearMirrorAimLineHideHoldSeconds = 0.10f;
+	float m_RearMirrorAimLineHidePaddingMeters = 0.0f;
+	bool  m_RearMirrorScaleOnThreat = false;
+	float m_RearMirrorThreatScale = 2.0f;
+
+	std::chrono::steady_clock::time_point m_RearMirrorAimLineHideUntil{};
+	bool m_RearMirrorAbsTransformValid = false;
+	vr::HmdMatrix34_t m_RearMirrorAbsTransform{};
+
 	Vector m_RearMirrorCameraPosAbs = { 0.0f, 0.0f, 0.0f };
 	QAngle m_RearMirrorCameraAngAbs = { 0.0f, 0.0f, 0.0f };
 
 	Vector GetRearMirrorCameraAbsPos() const { return m_RearMirrorCameraPosAbs; }
 	QAngle GetRearMirrorCameraAbsAngle() const { return m_RearMirrorCameraAngAbs; }
-	bool   ShouldRenderRearMirror() const { return m_RearMirrorEnabled; }
+	bool   ShouldRenderRearMirror();
 
 	VR() {};
 	VR(Game* game);


### PR DESCRIPTION
### Motivation

- Reduce rear-mirror obstruction and improve situational awareness by hiding the mirror when the player's aim line crosses it and by optionally increasing mirror size when threats are present.
- Provide configuration knobs so users can tune hide behavior, padding, hold time, and threat scaling.

### Description

- Add new state and configuration fields in `vr.h` for aim-line hiding, hold duration, padding, threat-scaling and cached overlay transform (e.g. `m_RearMirrorHideWhenAimLineCrosses`, `m_RearMirrorAimLineHideHoldSeconds`, `m_RearMirrorAimLineHidePaddingMeters`, `m_RearMirrorScaleOnThreat`, `m_RearMirrorThreatScale`, `m_RearMirrorAbsTransform`).
- Enhance `UpdateRearMirrorOverlayTransform` to apply optional threat-based scaling and cache the overlay absolute transform into `m_RearMirrorAbsTransform` while marking validity via `m_RearMirrorAbsTransformValid`.
- Implement `ShouldRenderRearMirror()` which performs a line-plane intersection between the aim line and the cached mirror plane, applies padding and threat-aware extents, and uses a hold timer (`m_RearMirrorAimLineHideUntil`) to temporarily hide the mirror when the aim line intersects the mirror rect.
- Load the new options from config in `ParseConfigFile()` (keys such as `RearMirrorHideWhenAimLineCrosses`, `RearMirrorAimLineHideHoldSeconds`, `RearMirrorAimLineHidePaddingMeters`, `RearMirrorScaleOnThreat`, `RearMirrorThreatScale`) and reset `m_RearMirrorAimLineHideUntil` when the feature is disabled.

### Testing

- No automated tests were run on the modified code.
- The change compiles were not executed as part of this rollout (no CI/build was run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a1f475088321a85c719e8bb4050c)