### PR TITLE
Enlarge rear-mirror overlay when special-infected arrows are detected

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -814,7 +814,10 @@ void VR::UpdateRearMirrorOverlayTransform()
 
     const vr::ETrackingUniverseOrigin trackingOrigin = vr::VRCompositor()->GetTrackingSpace();
     vr::VROverlay()->SetOverlayTransformAbsolute(m_RearMirrorHandle, trackingOrigin, &mirrorAbs);
-    vr::VROverlay()->SetOverlayWidthInMeters(m_RearMirrorHandle, std::max(0.01f, m_RearMirrorOverlayWidthMeters));
+    float mirrorWidth = std::max(0.01f, m_RearMirrorOverlayWidthMeters);
+    if (m_RearMirrorSpecialWarningDistance > 0.0f && m_RearMirrorSpecialEnlargeActive)
+        mirrorWidth *= 2.0f;
+    vr::VROverlay()->SetOverlayWidthInMeters(m_RearMirrorHandle, mirrorWidth);
 }
 
 void VR::RepositionOverlays(bool attachToControllers)
@@ -5003,6 +5006,11 @@ void VR::ParseConfigFile()
         m_RearMirrorOverlayAngleOffset = QAngle{ tmp.x, tmp.y, tmp.z };
     }
     m_RearMirrorAlpha = std::clamp(getFloat("RearMirrorAlpha", m_RearMirrorAlpha), 0.0f, 1.0f);
+
+    // Rear mirror hint: enlarge overlay when special-infected arrows are visible in the mirror render pass
+    m_RearMirrorSpecialWarningDistance = std::max(0.0f, getFloat("RearMirrorSpecialWarningDistance", m_RearMirrorSpecialWarningDistance));
+    if (m_RearMirrorSpecialWarningDistance <= 0.0f)
+        m_RearMirrorSpecialEnlargeActive = false;
 
     m_ForceNonVRServerMovement = getBool("ForceNonVRServerMovement", m_ForceNonVRServerMovement);
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -614,6 +614,16 @@ public:
 	QAngle m_RearMirrorOverlayAngleOffset = { 0.0f, 180.0f, 0.0f };
 	float  m_RearMirrorAlpha = 1.0f;
 
+	// Rear mirror hint: when special-infected arrows are visible in the mirror pass,
+	// temporarily enlarge the rear-mirror overlay (2x width).
+	// Distance is in Source units (same as SpecialInfected* distances). <= 0 disables this hint.
+	float  m_RearMirrorSpecialWarningDistance = 180.0f;
+	float  m_RearMirrorSpecialEnlargeHoldSeconds = 0.35f;
+	bool   m_RearMirrorRenderingPass = false;
+	bool   m_RearMirrorSawSpecialThisPass = false;	// set from DrawModelExecute during mirror RTT pass
+	bool   m_RearMirrorSpecialEnlargeActive = false;
+	std::chrono::steady_clock::time_point m_LastRearMirrorSpecialSeenTime{};
+
 	Vector m_RearMirrorCameraPosAbs = { 0.0f, 0.0f, 0.0f };
 	QAngle m_RearMirrorCameraAngAbs = { 0.0f, 0.0f, 0.0f };
 

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -936,6 +936,19 @@ Option g_Options[] =
         { u8"", u8"" },
         -60.0f, 60.0f,
         "5,0,25"
+    },
+
+    // Rear mirror
+    {
+        "RearMirrorSpecialWarningDistance",
+        OptionType::Float,
+        { u8"Rear Mirror", u8"后视镜" },
+        { u8"Special Warning Distance", u8"特感警示距离" },
+        { u8"Enlarge the rear mirror when special-infected arrows are visible within this distance.",
+          u8"当后视镜中可见特感箭头且距离在此范围内时放大后视镜。" },
+        { u8"Set <= 0 to disable.", u8"设为 <= 0 以禁用。" },
+        0.0f, 2000.0f,
+        "180.0"
     }
 };
 


### PR DESCRIPTION
### Motivation

- Provide a visual hint by temporarily enlarging the rear-mirror overlay when special-infected arrows are visible in the mirror render pass.
- Make the behavior configurable so users can set a distance threshold or disable the hint.

### Description

- Added rear-mirror hint state and timing fields to `L4D2VR/vr.h` (`m_RearMirrorSpecialWarningDistance`, `m_RearMirrorSpecialEnlargeHoldSeconds`, `m_RearMirrorRenderingPass`, `m_RearMirrorSawSpecialThisPass`, `m_RearMirrorSpecialEnlargeActive`, and `m_LastRearMirrorSpecialSeenTime`).
- Adjusted `VR::UpdateRearMirrorOverlayTransform()` in `L4D2VR/vr.cpp` to double the overlay width while the special-warning enlarge state is active.
- Wrapped the rear-mirror RTT call in `L4D2VR/hooks.cpp` with start/end markers so the mirror render pass can be tracked, and added logic to timestamp and time out the enlarge state after a hold duration.
- During model rendering in `L4D2VR/hooks.cpp` the code now detects special-infected arrows rendered inside the mirror pass and within the configured distance and sets the per-pass flag to trigger the enlarge behavior.
- Exposed the new `RearMirrorSpecialWarningDistance` option in `L4D2VRConfigTool/src/Options.cpp` with UI labels and help text.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963ca843cd88321b31baad8752c2edd)