### PR TITLE
Auto-hide rear mirror when aim line intersects it

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -614,6 +614,11 @@ public:
 	QAngle m_RearMirrorOverlayAngleOffset = { 0.0f, 180.0f, 0.0f };
 	float  m_RearMirrorAlpha = 1.0f;
 
+	// When the aim line/ray intersects the rear-mirror overlay in view, hide the mirror to avoid blocking aim.
+	bool  m_RearMirrorHideWhenAimLineHits = true;
+	float m_RearMirrorAimLineHideHoldSeconds = 0.08f;
+	std::chrono::steady_clock::time_point m_RearMirrorAimLineHideUntil{};
+
 	// Rear mirror hint: when special-infected arrows are visible in the mirror pass,
 	// temporarily enlarge the rear-mirror overlay (2x width).
 	// Distance is in Source units (same as SpecialInfected* distances). <= 0 disables this hint.

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -940,6 +940,30 @@ Option g_Options[] =
 
     // Rear mirror
     {
+        "RearMirrorHideWhenAimLineHits",
+        OptionType::Bool,
+        { u8"Rear Mirror", u8"后视镜" },
+        { u8"Hide When Aim Line Hits", u8"瞄准线碰到时隐藏" },
+        { u8"Auto-hides the rear mirror when your aim line would pass through it.",
+          u8"当瞄准线会穿过后视镜时自动隐藏，避免遮挡瞄准视线。" },
+        { u8"Useful if you keep the mirror near the weapon/center view.",
+          u8"后视镜靠近枪口/视线中心时很有用。" },
+        0.0f, 0.0f,
+        "true"
+    },
+    {
+        "RearMirrorAimLineHideHoldSeconds",
+        OptionType::Float,
+        { u8"Rear Mirror", u8"后视镜" },
+        { u8"Aim-Line Hide Hold (sec)", u8"隐藏保持时间(秒)" },
+        { u8"How long to keep the mirror hidden after a hit, to reduce flicker.",
+          u8"命中后视镜后保持隐藏的时间，用于减少边缘抖动/闪烁。" },
+        { u8"0.05~0.15 is usually enough.",
+          u8"通常 0.05~0.15 就够了。" },
+        0.0f, 1.0f,
+        "0.08"
+    },
+    {
         "RearMirrorSpecialWarningDistance",
         OptionType::Float,
         { u8"Rear Mirror", u8"后视镜" },


### PR DESCRIPTION
### Motivation

- Prevent the rear-mirror overlay from blocking the player's aim when the aiming ray/aim line would pass through the mirror. 
- Reduce flicker around mirror edges by holding the hidden state briefly after a detected hit. 
- Expose user-configurable options so players can enable/disable the behavior and tune the hide hold time.

### Description

- Added state and config members to the VR state struct: `m_RearMirrorHideWhenAimLineHits`, `m_RearMirrorAimLineHideHoldSeconds`, and `m_RearMirrorAimLineHideUntil` in `L4D2VR/vr.h`.
- Implemented an aim-line vs. mirror quad intersection check inside `SubmitVRTextures()` (`shouldHideRearMirrorDueToAimLine`), which computes an aim ray, constructs the mirror quad in world space to match `UpdateRearMirrorOverlayTransform()`, and sets a hide-until timestamp when a hit is detected.
- Use the intersection result to conditionally show/hide the overlay (`vr::VROverlay()->ShowOverlay` / `HideOverlay`) so the mirror is temporarily hidden while aiming through it.
- Loaded the new settings in the config parsing (`ParseConfigFile()`), clamped the hold time, and added UI entries in `L4D2VRConfigTool/src/Options.cpp` to expose `RearMirrorHideWhenAimLineHits` and `RearMirrorAimLineHideHoldSeconds` with sane defaults.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963d42e2cc48321bd3c8573632ed73a)