### PR TITLE
Auto-evade: stop automatic jump and add per-target cooldown/rearm

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -500,6 +500,10 @@ public:
 	bool m_SpecialInfectedBlindSpotWarningActive = false;
 	std::chrono::steady_clock::time_point m_LastSpecialInfectedWarningTime{};
 	float m_SpecialInfectedPreWarningEvadeDistance = 260.0f;
+	float m_SpecialInfectedPreWarningEvadeCooldown = 0.85f;
+	int m_LastSpecialInfectedEvadeEntityIndex = -1;
+	bool m_SpecialInfectedPreWarningEvadeArmed = true;
+	std::chrono::steady_clock::time_point m_SpecialInfectedPreWarningEvadeCooldownEnd{};
 	bool m_SpecialInfectedPreWarningEvadeTriggered = false;
 	float m_SpecialInfectedWarningSecondaryHoldDuration = 0.15f;
 	float m_SpecialInfectedWarningPostAttackDelay = 0.1f;


### PR DESCRIPTION
### Motivation
- Prevent the auto-evade routine from performing an automatic `+jump` after the shove so the action only pushes once. 
- Avoid repeated shoves when a pouncing special infected lingers at close range by adding anti-spam logic. 
- Ensure input state is cleared if the action is aborted mid-sequence to avoid stuck `+attack2`/`+jump` states. 

### Description
- End the warning action at `ReleaseSecondaryAttack` by calling `ResetSpecialInfectedWarningAction()` instead of moving to `PressJump`, and have `ResetSpecialInfectedWarningAction()` re-issue `-attack2` and `-jump`. 
- Add new members in `vr.h`: `m_SpecialInfectedPreWarningEvadeCooldown`, `m_LastSpecialInfectedEvadeEntityIndex`, `m_SpecialInfectedPreWarningEvadeArmed`, and `m_SpecialInfectedPreWarningEvadeCooldownEnd` to track per-target rearm and cooldown. 
- Implement per-target rearm and cooldown checks in `RefreshSpecialInfectedPreWarning()` so a target must either cool down for `m_SpecialInfectedPreWarningEvadeCooldown` seconds or move beyond a rearm distance (1.2×) before re-triggering. 
- Load the new cooldown config with `getFloat("SpecialInfectedPreWarningEvadeCooldown", ...)` and reset the new state fields in `UpdateSpecialInfectedPreWarningState()` when appropriate. 

### Testing
- No automated tests were executed for this change. 
- The patch was applied and committed to the repository (`git` commit recorded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965379f41748321831cdebd3af24d7c)