### PR TITLE
Use raw GRIP input for inventory switching and suppress GRIP-origin actions

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -278,6 +278,10 @@ public:
 	bool m_LeftGripPressedPrev = false;
 	bool m_RightGripPressedPrev = false;
 
+	// Raw GRIP input-source handles (used to detect GRIP-bound SteamVR actions via activeOrigin).
+	vr::VRInputValueHandle_t m_GripSourceLeft = vr::k_ulInvalidInputValueHandle;
+	vr::VRInputValueHandle_t m_GripSourceRight = vr::k_ulInvalidInputValueHandle;
+
 	struct ActionCombo
 	{
 		vr::VRActionHandle_t* primary = nullptr;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -275,6 +275,8 @@ public:
 	bool m_VoiceRecordActive = false;
 	bool m_QuickTurnTriggered = false;
 	bool m_PrimaryAttackDown = false;
+	bool m_LeftGripPressedPrev = false;
+	bool m_RightGripPressedPrev = false;
 
 	struct ActionCombo
 	{

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -278,9 +278,10 @@ public:
 	bool m_LeftGripPressedPrev = false;
 	bool m_RightGripPressedPrev = false;
 
-	// Raw GRIP input-source handles (used to detect GRIP-bound SteamVR actions via activeOrigin).
-	vr::VRInputValueHandle_t m_GripSourceLeft = vr::k_ulInvalidInputValueHandle;
-	vr::VRInputValueHandle_t m_GripSourceRight = vr::k_ulInvalidInputValueHandle;
+	// When GRIP is consumed for inventory switching, suppress SteamVR digital actions from that hand
+	// until GRIP is released (prevents GRIP-bound Jump etc).
+	bool m_SuppressActionsUntilGripReleaseLeft = false;
+	bool m_SuppressActionsUntilGripReleaseRight = false;
 
 	struct ActionCombo
 	{


### PR DESCRIPTION
### Motivation
- Inventory gestures should work even when the controller GRIP is not bound to a SteamVR action, by reading the physical GRIP state directly.
- Prevent accidental activation of other SteamVR actions (jump/use/reload/etc.) while the player is performing inventory switching with the GRIP. 
- Track previous GRIP state to detect "just pressed" events reliably for raw polling.

### Description
- Added raw GRIP polling via `pollRawGrip` which calls `m_System->GetControllerState(...)` and updates `inventoryGripLeftDown/RightDown` and just-pressed state. 
- Added previous-state flags `m_LeftGripPressedPrev` and `m_RightGripPressedPrev` in `vr.h` to detect grip edge transitions. 
- Implemented suppression helpers `originIsGrip`, `originMatchesRole`, and `shouldSuppressAction` that use `m_Input->GetOriginLocalizedName(...)` and origin device info to suppress SteamVR actions that originate from GRIP on the active hand. 
- Applied suppression to several actions by clearing their `*ButtonDown`/`*JustPressed` flags when `shouldSuppressAction(...)` returns true, and adjusted input ordering to read `Jump`/`Use` earlier for suppression. 

### Testing
- No automated tests were executed for this change. 
- The change was committed locally (`git commit`) after edits; no build or unit-test runs were requested or performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696549e0da34832190151c1490a246cf)