### PR TITLE
Add rear-mirror horizontal flip option

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -594,8 +594,10 @@ void VR::SubmitVRTextures()
         };
     auto applyRearMirrorTexture = [&](vr::VROverlayHandle_t overlay)
         {
-            static const vr::VRTextureBounds_t full{ 0.0f, 0.0f, 1.0f, 1.0f };
-            vr::VROverlay()->SetOverlayTextureBounds(overlay, &full);
+            vr::VRTextureBounds_t bounds{ 0.0f, 0.0f, 1.0f, 1.0f };
+            if (m_RearMirrorFlipHorizontal)
+                std::swap(bounds.uMin, bounds.uMax);
+            vr::VROverlay()->SetOverlayTextureBounds(overlay, &bounds);
             vr::VROverlay()->SetOverlayTexture(overlay, &m_VKRearMirror.m_VRTexture);
         };
 
@@ -5550,6 +5552,7 @@ void VR::ParseConfigFile()
         m_RearMirrorOverlayAngleOffset = QAngle{ tmp.x, tmp.y, tmp.z };
     }
     m_RearMirrorAlpha = std::clamp(getFloat("RearMirrorAlpha", m_RearMirrorAlpha), 0.0f, 1.0f);
+    m_RearMirrorFlipHorizontal = getBool("RearMirrorFlipHorizontal", m_RearMirrorFlipHorizontal);
 
     // Hide the rear mirror when the aim line/ray intersects it (prevents blocking your view while aiming).
     m_RearMirrorHideWhenAimLineHits = getBool("RearMirrorHideWhenAimLineHits", m_RearMirrorHideWhenAimLineHits);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -651,6 +651,9 @@ public:
 	QAngle m_RearMirrorOverlayAngleOffset = { 0.0f, 180.0f, 0.0f };
 	float  m_RearMirrorAlpha = 1.0f;
 
+	// If true, mirror the rear-mirror texture horizontally (left/right).
+	bool  m_RearMirrorFlipHorizontal = false;
+
 	// When the aim line/ray intersects the rear-mirror overlay in view, hide the mirror to avoid blocking aim.
 	bool  m_RearMirrorHideWhenAimLineHits = true;
 	float m_RearMirrorAimLineHideHoldSeconds = 0.08f;

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -940,6 +940,18 @@ Option g_Options[] =
 
     // Rear mirror
     {
+        "RearMirrorFlipHorizontal",
+        OptionType::Bool,
+        { u8"Rear Mirror", u8"后视镜" },
+        { u8"Flip Rear Mirror Horizontally", u8"后视镜左右翻转" },
+        { u8"Mirrors the rear-mirror texture left/right.",
+          u8"将后视镜画面做左右镜像翻转。" },
+        { u8"Useful if the mirror feels backward.",
+          u8"觉得画面方向别扭时开启。" },
+        0.0f, 0.0f,
+        "false"
+    },
+    {
         "RearMirrorHideWhenAimLineHits",
         OptionType::Bool,
         { u8"Rear Mirror", u8"后视镜" },


### PR DESCRIPTION
### Motivation

- Provide a runtime option to horizontally mirror the rear-mirror overlay texture when the mirror appears reversed. 
- Give users a simple toggle when the mirror image feels backward without changing rendering code or assets. 

### Description

- Added a new `bool` field `m_RearMirrorFlipHorizontal` to the VR state in `L4D2VR/vr.h` to store the setting. 
- Applied the flip in `applyRearMirrorTexture` by swapping texture bounds (`uMin`/`uMax`) when `m_RearMirrorFlipHorizontal` is true. 
- Load the setting from config with `getBool("RearMirrorFlipHorizontal", m_RearMirrorFlipHorizontal)` in `ParseConfigFile`. 
- Exposed the option in the config tool by adding an entry to `L4D2VRConfigTool/src/Options.cpp` with localized labels and a default of `false`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69667b96280483218334539eb520d3ea)