### PR TITLE
Add render-thread camera fix and config toggle

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -14,6 +14,100 @@
 #include <chrono>
 #include <cmath>
 
+// ------------------------------------------------------------
+// Render-thread camera fix (mat_queue_mode 2)
+//
+// Problem:
+// - With Source's queued rendering enabled (mat_queue_mode 2), the render thread may
+//   consume camera state after the main thread has already restored view angles.
+// - The old workaround was to temporarily call engine->SetViewAngles(...) around each
+//   RenderView call, but this is fragile when work is queued.
+//
+// Fix (B-route):
+// - Main thread: queue desired view angles for each RenderView() we submit.
+// - Render thread (shaderapidx9): hook MatrixMode / LoadMatrix, and when MATERIAL_VIEW is
+//   loaded for the first time in a view, patch the rotation portion with queued angles.
+// ------------------------------------------------------------
+
+static std::deque<QAngle> g_RenderThreadViewAnglesQueue;
+static std::mutex g_RenderThreadViewAnglesMutex;
+static void* g_ShaderApi = nullptr;
+static Hooks::tShaderMatrixMode g_OrigShader_MatrixMode = nullptr;
+static Hooks::tShaderLoadMatrix g_OrigShader_LoadMatrix = nullptr;
+static bool g_RenderThreadCameraFixHooksInstalled = false;
+
+// Render-thread TLS state
+static thread_local MaterialMatrixMode_t g_TlsMatrixMode = MATERIAL_MODEL;
+static thread_local bool g_TlsUsedFirstViewLoad = false;
+
+static float OrthoScore3(const Vector& a, const Vector& b, const Vector& c)
+{
+    const float la = fabsf(a.Length() - 1.0f);
+    const float lb = fabsf(b.Length() - 1.0f);
+    const float lc = fabsf(c.Length() - 1.0f);
+    const float dab = fabsf(DotProduct(a, b));
+    const float dac = fabsf(DotProduct(a, c));
+    const float dbc = fabsf(DotProduct(b, c));
+    return la + lb + lc + dab + dac + dbc;
+}
+
+static void PatchViewMatrixRotation(float out16[16], const float* in16, const QAngle& desiredAngles)
+{
+    // Copy input as base (keep translation untouched).
+    memcpy(out16, in16, sizeof(float) * 16);
+
+    // Determine whether the basis is stored column-major-ish (0,1,2 / 4,5,6 / 8,9,10)
+    // or transposed (0,4,8 / 1,5,9 / 2,6,10). Pick the interpretation that looks most orthonormal.
+    Vector c0(in16[0], in16[1], in16[2]);
+    Vector c1(in16[4], in16[5], in16[6]);
+    Vector c2(in16[8], in16[9], in16[10]);
+    const float scoreCols = OrthoScore3(c0, c1, c2);
+
+    Vector r0(in16[0], in16[4], in16[8]);
+    Vector r1(in16[1], in16[5], in16[9]);
+    Vector r2(in16[2], in16[6], in16[10]);
+    const float scoreRows = OrthoScore3(r0, r1, r2);
+
+    const bool useCols = (scoreCols <= scoreRows);
+
+    // Preserve handedness from original basis:
+    Vector b0 = useCols ? c0 : r0;
+    Vector b1 = useCols ? c1 : r1;
+    Vector b2 = useCols ? c2 : r2;
+    Vector cross01;
+    CrossProduct(b0, b1, cross01);
+    const float handed = DotProduct(cross01, b2); // >0 => b2 ~ cross(b0,b1); <0 => b2 ~ -cross
+
+    // Build new basis from angles (use right/up, then derive b2 via cross to match handedness)
+    Vector forward, right, up;
+    desiredAngles.AngleVectors(&forward, &right, &up);
+
+    // Normalize just in case
+    right.NormalizeInPlace();
+    up.NormalizeInPlace();
+
+    Vector newB2;
+    CrossProduct(right, up, newB2);
+    if (handed < 0.0f)
+    {
+        newB2.x = -newB2.x;
+        newB2.y = -newB2.y;
+        newB2.z = -newB2.z;
+    }
+
+    if (useCols)
+    {
+        out16[0] = right.x; out16[1] = right.y; out16[2] = right.z;
+        out16[4] = up.x;    out16[5] = up.y;    out16[6] = up.z;
+        out16[8] = newB2.x; out16[9] = newB2.y; out16[10] = newB2.z;
+    }
+    else
+    {
+        out16[0] = right.x; out16[4] = right.y; out16[8]  = right.z;
+        out16[1] = up.x;    out16[5] = up.y;    out16[9]  = up.z;
+        out16[2] = newB2.x; out16[6] = newB2.y; out16[10] = newB2.z;
+    }
+}
 // Normalize Source-style angles:
 // - Bring pitch/yaw into [-180, 180] first (avoid -30 becoming 330 and then clamped to 89).
 // - Then clamp pitch to [-89, 89].
@@ -308,8 +402,8 @@ Hooks::~Hooks()
 
 int Hooks::initSourceHooks()
 {
-	LPVOID pGetRenderTargetVFunc = (LPVOID)(m_Game->m_Offsets->GetRenderTarget.address);
-	hkGetRenderTarget.createHook(pGetRenderTargetVFunc, &dGetRenderTarget);
+    LPVOID pGetRenderTargetVFunc = (LPVOID)(m_Game->m_Offsets->GetRenderTarget.address);
+    hkGetRenderTarget.createHook(pGetRenderTargetVFunc, &dGetRenderTarget);
 
 	LPVOID pRenderViewVFunc = (LPVOID)(m_Game->m_Offsets->RenderView.address);
 	hkRenderView.createHook(pRenderViewVFunc, &dRenderView);
@@ -425,9 +519,112 @@ int Hooks::initSourceHooks()
 		return 0;
 	}
 
-	hkCreateMove.createHook(clientModeVTable[27], dCreateMove);
+    hkCreateMove.createHook(clientModeVTable[27], dCreateMove);
 
-	return 1;
+    return 1;
+}
+
+void Hooks::QueueRenderThreadViewAngles(const QAngle& angles)
+{
+    // Called on the main thread during RenderView; keep it simple and safe.
+    std::lock_guard<std::mutex> lock(g_RenderThreadViewAnglesMutex);
+    g_RenderThreadViewAnglesQueue.push_back(angles);
+
+    // If something goes off the rails (mismatch between push/pop), don't let it grow unbounded.
+    if (g_RenderThreadViewAnglesQueue.size() > 64)
+        g_RenderThreadViewAnglesQueue.pop_front();
+}
+
+void Hooks::InitRenderThreadCameraFixHooks()
+{
+    if (g_RenderThreadCameraFixHooksInstalled)
+        return;
+    if (!m_VR || !m_VR->m_RenderThreadViewMatrixFixEnabled)
+        return;
+
+    // shaderapidx9 interface is usually ShaderApi030 on Source 1.
+    const char* candidates[] = { "ShaderApi030", "ShaderApi031", "ShaderApi032" };
+    for (const char* iface : candidates)
+    {
+        g_ShaderApi = m_Game->GetInterface("shaderapidx9.dll", iface);
+        if (g_ShaderApi)
+            break;
+    }
+
+    if (!g_ShaderApi)
+    {
+        Game::logMsg("RenderThreadViewMatrixFixEnabled: shaderapidx9 ShaderApi0xx interface not found (camera fix disabled)");
+        return;
+    }
+
+    void** vtable = *reinterpret_cast<void***>(g_ShaderApi);
+    if (!vtable)
+        return;
+
+    // IShaderDynamicAPI (Source SDK) vtable indices:
+    // 15 = MatrixMode, 18 = LoadMatrix
+    auto targetMatrixMode = reinterpret_cast<tShaderMatrixMode>(vtable[15]);
+    auto targetLoadMatrix = reinterpret_cast<tShaderLoadMatrix>(vtable[18]);
+    if (!targetMatrixMode || !targetLoadMatrix)
+        return;
+
+    if (MH_CreateHook(reinterpret_cast<LPVOID>(targetMatrixMode), reinterpret_cast<LPVOID>(&Hooks::dShader_MatrixMode), reinterpret_cast<LPVOID*>(&g_OrigShader_MatrixMode)) != MH_OK)
+    {
+        Game::logMsg("Failed to hook shaderapidx9 MatrixMode");
+        return;
+    }
+    if (MH_CreateHook(reinterpret_cast<LPVOID>(targetLoadMatrix), reinterpret_cast<LPVOID>(&Hooks::dShader_LoadMatrix), reinterpret_cast<LPVOID*>(&g_OrigShader_LoadMatrix)) != MH_OK)
+    {
+        Game::logMsg("Failed to hook shaderapidx9 LoadMatrix");
+        return;
+    }
+
+    MH_EnableHook(reinterpret_cast<LPVOID>(targetMatrixMode));
+    MH_EnableHook(reinterpret_cast<LPVOID>(targetLoadMatrix));
+
+    g_RenderThreadCameraFixHooksInstalled = true;
+    Game::logMsg("RenderThreadViewMatrixFixEnabled: shaderapidx9 MatrixMode/LoadMatrix hooks installed");
+}
+
+void __fastcall Hooks::dShader_MatrixMode(void* ecx, void* edx, MaterialMatrixMode_t mode)
+{
+    g_TlsMatrixMode = mode;
+    if (mode == MATERIAL_VIEW)
+        g_TlsUsedFirstViewLoad = false;
+
+    if (g_OrigShader_MatrixMode)
+        g_OrigShader_MatrixMode(ecx, mode);
+}
+
+void __fastcall Hooks::dShader_LoadMatrix(void* ecx, void* edx, const float* matrix)
+{
+    // Only apply once per view (first LoadMatrix while in MATERIAL_VIEW).
+    if (matrix && g_TlsMatrixMode == MATERIAL_VIEW && !g_TlsUsedFirstViewLoad && m_VR && m_VR->m_RenderThreadViewMatrixFixEnabled)
+    {
+        QAngle nextAngles{};
+        bool haveAngles = false;
+        {
+            std::lock_guard<std::mutex> lock(g_RenderThreadViewAnglesMutex);
+            if (!g_RenderThreadViewAnglesQueue.empty())
+            {
+                nextAngles = g_RenderThreadViewAnglesQueue.front();
+                g_RenderThreadViewAnglesQueue.pop_front();
+                haveAngles = true;
+            }
+        }
+
+        if (haveAngles)
+        {
+            float patched[16];
+            PatchViewMatrixRotation(patched, matrix, nextAngles);
+            g_TlsUsedFirstViewLoad = true;
+            g_OrigShader_LoadMatrix(ecx, patched);
+            return;
+        }
+    }
+
+    if (g_OrigShader_LoadMatrix)
+        g_OrigShader_LoadMatrix(ecx, matrix);
 }
 
 
@@ -613,13 +810,23 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	leftEyeView.angles = viewAngles;
 
 	// --- IMPORTANT: avoid "dragging/ghosting" when turning with thumbstick ---
-	// Do NOT permanently overwrite engine viewangles. Only set them during our stereo renders,
-	// then restore, so the engine's view history/interp isn't corrupted.
-	QAngle prevEngineAngles;
-	m_Game->m_EngineClient->GetViewAngles(prevEngineAngles);
+    // Do NOT permanently overwrite engine viewangles. Only set them during our stereo renders,
+    // then restore, so the engine's view history/interp isn't corrupted.
+    QAngle prevEngineAngles;
+    m_Game->m_EngineClient->GetViewAngles(prevEngineAngles);
 
-	QAngle renderAngles(viewAngles.x, viewAngles.y, viewAngles.z);
-	m_Game->m_EngineClient->SetViewAngles(renderAngles);
+    QAngle renderAngles(viewAngles.x, viewAngles.y, viewAngles.z);
+    const bool useRenderThreadCameraFix = (m_VR && m_VR->m_RenderThreadViewMatrixFixEnabled);
+    if (!useRenderThreadCameraFix)
+    {
+        // Legacy path: temporarily change engine angles around RenderView.
+        m_Game->m_EngineClient->SetViewAngles(renderAngles);
+    }
+    else
+    {
+        // Render-thread path: keep game state untouched; patch MATERIAL_VIEW matrix on render thread.
+        QueueRenderThreadViewAngles(renderAngles);
+    }
 
 	// Align HUD view to the same origin/angles; otherwise you can get a second layer that
 	// appears to "follow the controller / stick" (classic double-image artifact).
@@ -647,8 +854,10 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	hudRight.origin = rightEyeView.origin;
 	hudRight.angles = viewAngles;
 
-	rndrContext->SetRenderTarget(m_VR->m_RightEyeTexture);
-	hkRenderView.fOriginal(ecx, rightEyeView, hudRight, nClearFlags, whatToDraw);
+    rndrContext->SetRenderTarget(m_VR->m_RightEyeTexture);
+    if (useRenderThreadCameraFix)
+        QueueRenderThreadViewAngles(renderAngles);
+    hkRenderView.fOriginal(ecx, rightEyeView, hudRight, nClearFlags, whatToDraw);
 
 	auto renderToTexture_SetRT = [&](ITexture* target, int texW, int texH, QAngle passAngles,
 		CViewSetup& view, CViewSetup& hud)
@@ -665,16 +874,20 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 			{
 				hkPushRenderTargetAndViewport.fOriginal(rc, target, nullptr, 0, 0, texW, texH);
 
-				QAngle oldEngineAngles;
-				m_Game->m_EngineClient->GetViewAngles(oldEngineAngles);
-				m_Game->m_EngineClient->SetViewAngles(passAngles);
+                QAngle oldEngineAngles;
+                m_Game->m_EngineClient->GetViewAngles(oldEngineAngles);
+                if (!useRenderThreadCameraFix)
+                    m_Game->m_EngineClient->SetViewAngles(passAngles);
+                else
+                    QueueRenderThreadViewAngles(passAngles);
 
-				hkRenderView.fOriginal(ecx, view, hud, nClearFlags, whatToDraw);
+                hkRenderView.fOriginal(ecx, view, hud, nClearFlags, whatToDraw);
 
-				m_Game->m_EngineClient->SetViewAngles(oldEngineAngles);
-				hkPopRenderTargetAndViewport.fOriginal(rc);
-				return;
-			}
+                if (!useRenderThreadCameraFix)
+                    m_Game->m_EngineClient->SetViewAngles(oldEngineAngles);
+                hkPopRenderTargetAndViewport.fOriginal(rc);
+                return;
+            }
 
 			const bool prevSuppress = m_VR->m_SuppressHudCapture;
 			m_VR->m_SuppressHudCapture = true;
@@ -689,13 +902,17 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 			rc->ClearColor4ub(0, 0, 0, 255);
 			rc->ClearBuffers(true, true, true);
 
-			QAngle oldEngineAngles;
-			m_Game->m_EngineClient->GetViewAngles(oldEngineAngles);
-			m_Game->m_EngineClient->SetViewAngles(passAngles);
+            QAngle oldEngineAngles;
+            m_Game->m_EngineClient->GetViewAngles(oldEngineAngles);
+            if (!useRenderThreadCameraFix)
+                m_Game->m_EngineClient->SetViewAngles(passAngles);
+            else
+                QueueRenderThreadViewAngles(passAngles);
 
-			hkRenderView.fOriginal(ecx, view, hud, nClearFlags, whatToDraw);
+            hkRenderView.fOriginal(ecx, view, hud, nClearFlags, whatToDraw);
 
-			m_Game->m_EngineClient->SetViewAngles(oldEngineAngles);
+            if (!useRenderThreadCameraFix)
+                m_Game->m_EngineClient->SetViewAngles(oldEngineAngles);
 
 			rc->SetRenderTarget(oldRT);
 			hkViewport.fOriginal(rc, oldX, oldY, oldW, oldH);
@@ -801,7 +1018,8 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	}
 
 	// Restore engine angles immediately after our stereo render.
-	m_Game->m_EngineClient->SetViewAngles(prevEngineAngles);
+    if (!useRenderThreadCameraFix)
+        m_Game->m_EngineClient->SetViewAngles(prevEngineAngles);
 	m_VR->m_RenderedNewFrame = true;
 }
 

--- a/L4D2VR/hooks.h
+++ b/L4D2VR/hooks.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <iostream>
+#include <deque>
+#include <mutex>
+#include <cstdint>
 #include "MinHook.h"
 
 class Game;
@@ -11,6 +14,23 @@ class QAngle;
 class Vector;
 class edict_t;
 class ModelRenderInfo_t;
+
+// Minimal materialsystem matrix-mode enum (matches Source SDK).
+// We only care about MATERIAL_VIEW for the render-thread camera fix.
+enum MaterialMatrixMode_t
+{
+    MATERIAL_VIEW = 0,
+    MATERIAL_PROJECTION,
+    MATERIAL_MODEL,
+    MATERIAL_TEXTURE0,
+    MATERIAL_TEXTURE1,
+    MATERIAL_TEXTURE2,
+    MATERIAL_TEXTURE3,
+    MATERIAL_TEXTURE4,
+    MATERIAL_TEXTURE5,
+    MATERIAL_TEXTURE6,
+    MATERIAL_TEXTURE7
+};
 
 
 template <typename T>
@@ -160,4 +180,15 @@ public:
 
 	static inline int m_PushHUDStep;
 	static inline bool m_PushedHud;
+
+	// --- Render thread camera fix (mat_queue_mode 2) ---
+	static void InitRenderThreadCameraFixHooks();
+	static void QueueRenderThreadViewAngles(const QAngle& angles);
+
+	// shaderapidx9 IShaderDynamicAPI vtable hooks
+	typedef void(__thiscall* tShaderMatrixMode)(void* thisptr, MaterialMatrixMode_t mode);
+	typedef void(__thiscall* tShaderLoadMatrix)(void* thisptr, const float* matrix);
+
+	static void __fastcall dShader_MatrixMode(void* ecx, void* edx, MaterialMatrixMode_t mode);
+	static void __fastcall dShader_LoadMatrix(void* ecx, void* edx, const float* matrix);
 };

--- a/L4D2VR/hooks.h
+++ b/L4D2VR/hooks.h
@@ -3,6 +3,7 @@
 #include <deque>
 #include <mutex>
 #include <cstdint>
+#include <windows.h>
 #include "MinHook.h"
 
 class Game;
@@ -184,6 +185,10 @@ public:
 	// --- Render thread camera fix (mat_queue_mode 2) ---
 	static void InitRenderThreadCameraFixHooks();
 	static void QueueRenderThreadViewAngles(const QAngle& angles);
+
+	// Try install shaderapi vtable hooks from a CreateInterface result.
+	// Returns true if hooks are installed.
+	static bool TryInstallShaderApiHooks(void* shaderApiIface);
 
 	// shaderapidx9 IShaderDynamicAPI vtable hooks
 	typedef void(__thiscall* tShaderMatrixMode)(void* thisptr, MaterialMatrixMode_t mode);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -214,6 +214,16 @@ public:
 	float m_SpecialInfectedOverlayMaxHz = 20.0f; // caps arrow drawing + prewarning refresh per entity
 	float m_SpecialInfectedTraceMaxHz = 15.0f;   // caps TraceRay per entity
 
+	// --- Performance / threading ---
+	// Enable render-thread camera fix so mat_queue_mode 2 can be used.
+	// Main thread no longer needs to temporarily SetViewAngles() around RenderView.
+	bool m_RenderThreadViewMatrixFixEnabled = true;
+
+	// When RenderThreadViewMatrixFixEnabled is enabled, we try to force mat_queue_mode 2
+	// on the main thread (EngineClient is not thread-safe on worker threads).
+	bool m_ForceMatQueueMode2Pending = true;
+	bool m_ForceMatQueueMode2Done = false;
+
 	std::chrono::steady_clock::time_point m_LastAimLineDrawTime{};
 	std::chrono::steady_clock::time_point m_LastThrowArcDrawTime{};
 	mutable std::unordered_map<int, std::chrono::steady_clock::time_point> m_LastSpecialInfectedOverlayTime{};

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -277,6 +277,18 @@ Option g_Options[] =
         0.8f, 1.2f,
         "1.0"
     },
+    // Performance / Rates
+    {
+        "RenderThreadViewMatrixFixEnabled",
+        OptionType::Bool,
+        { u8"Performance / Rates", u8"性能 / 频率" },
+        { u8"Render Thread Camera Fix (mat_queue_mode 2)", u8"渲染线程相机修复 (mat_queue_mode 2)" },
+        { u8"Allows using Source's render thread path (mat_queue_mode 2) without breaking VR view angles.",
+          u8"允许启用 Source 的渲染线程路径 (mat_queue_mode 2)，同时避免 VR 视角在渲染线程执行时错乱。" },
+        { u8"", u8"" },
+        0.0f, 0.0f,
+        "true"
+    },
     // Input / Turning
     {
         "LeftHanded",


### PR DESCRIPTION
### Motivation
- Allow using Source's queued render path (`mat_queue_mode 2`) to enable multi-threaded rendering for better performance.
- Avoid temporarily calling `SetViewAngles()` on the main thread (fragile when rendering is queued) by patching the view matrix on the render thread instead.
- Expose a user-facing toggle to enable/disable this render-thread camera fix via the config UI.

### Description
- Added configuration flags to `VR` (`m_RenderThreadViewMatrixFixEnabled`, `m_ForceMatQueueMode2Pending`, `m_ForceMatQueueMode2Done`) in `L4D2VR/vr.h` and wired them into `VR::Update()` to issue `ClientCmd_Unrestricted("mat_queue_mode 2\n")` and initialize hooks when requested.
- Updated config parsing in `VR::ParseConfigFile()` to read `RenderThreadViewMatrixFixEnabled` and perform a one-shot request to force `mat_queue_mode 2` when the option transitions on.
- Implemented render-thread camera-fix infrastructure in `L4D2VR/hooks.h` and `L4D2VR/hooks.cpp`, including a queued `QAngle` buffer (`std::deque`) protected by a `std::mutex`, `QueueRenderThreadViewAngles()`, and `InitRenderThreadCameraFixHooks()`.
- Hooked `shaderapidx9` `IShaderDynamicAPI` vtable entries (`MatrixMode` and `LoadMatrix`, vtable indices 15 and 18) using MinHook; added `dShader_MatrixMode` and `dShader_LoadMatrix` to detect `MATERIAL_VIEW` and patch the rotation portion of the view matrix with queued angles via `PatchViewMatrixRotation()` (handles column/row layout and handedness heuristics).
- Changed render-path behavior in `Hooks::dRenderView` and offscreen RTT code to queue view angles instead of calling `SetViewAngles()` when `RenderThreadViewMatrixFixEnabled` is active; restored legacy `SetViewAngles()` path when disabled.
- Exposed the `RenderThreadViewMatrixFixEnabled` toggle in the config UI (`L4D2VRConfigTool/src/Options.cpp`) under `Performance / Rates` with default `true`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967542df9908321b0941fa55135634a)