### PR TITLE
Harden render thread camera fix

### DIFF
--- a/L4D2VR/hooks.h
+++ b/L4D2VR/hooks.h
@@ -184,6 +184,8 @@ public:
 
 	// --- Render thread camera fix (mat_queue_mode 2) ---
 	static void InitRenderThreadCameraFixHooks();
+	static bool IsRenderThreadCameraFixInstalled();
+	static bool IsRenderThreadCameraFixHealthy();
 	static void QueueRenderThreadViewAngles(const QAngle& angles);
 
 	// Try install shaderapi vtable hooks from a CreateInterface result.


### PR DESCRIPTION
### Motivation
- Make the render-thread camera patch for `mat_queue_mode 2` more robust against incorrect vtable hooks and invalid matrix inputs to prevent HUD flicker/corruption.
- Ensure any matrix memory passed to queued `LoadMatrix` calls remains valid after the hook returns so queued rendering does not use stack memory.
- Avoid enabling queued rendering until the shader hooks are confirmed healthy and provide an automatic fallback to single-threaded rendering if the hooks become invalid.

### Description
- Added health/status APIs `Hooks::IsRenderThreadCameraFixInstalled()` and `Hooks::IsRenderThreadCameraFixHealthy()` and included `<atomic>` to track patch disable state.
- Introduced TLS matrix ring storage `g_TlsMatrixRing` and safe indexing to keep patched matrices alive for queued rendering, and switched patched `LoadMatrix` calls to use that stable storage.
- Added sanity checks in `dShader_MatrixMode` and `dShader_LoadMatrix` that detect invalid matrix modes or non-plausible matrices, set `g_RenderThreadPatchDisabled`, and log a single error before disabling the patch and falling back to passthrough.
- Changed `VR::Update()` to call `Hooks::InitRenderThreadCameraFixHooks()` before toggling `mat_queue_mode`, gate `mat_queue_mode 2` on `IsRenderThreadCameraFixHealthy()`, and automatically revert to `mat_queue_mode 0` with a logged error if the hook later proves unhealthy.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69677e9b6e6c8321bd0e956156e8b2bf)