### PR TITLE
Optimize overlay texture binding in VR submit path

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -267,6 +267,10 @@ public:
 	bool m_SuppressHudCapture = false;
 	bool m_CompositorExplicitTiming = false;
 	bool m_CompositorNeedsHandoff = false;
+	// Overlay texture/bounds are expensive to set every frame.
+	// We only re-bind when textures are recreated or when bounds change.
+	bool m_OverlayTexturesBound = false;
+	bool m_LastRearMirrorFlipHorizontal = false;
 	TextureID m_CreatingTextureID = Texture_None;
 
 	bool m_PressedTurn = false;


### PR DESCRIPTION
### Motivation
- Reduce CPU work and potential jitter by avoiding rebinding overlay textures and bounds every frame.
- Only rebind overlays when render targets are recreated or when the rear-mirror horizontal flip state changes.

### Description
- Added cached state flags `m_OverlayTexturesBound` and `m_LastRearMirrorFlipHorizontal` to `VR` in `L4D2VR/vr.h`.
- Reset overlay binding state after recreating textures in `CreateVRTextures()` by setting `m_OverlayTexturesBound = false` and updating `m_LastRearMirrorFlipHorizontal` in `L4D2VR/vr.cpp`.
- Replaced per-overlay per-frame `SetOverlayTextureBounds`/`SetOverlayTexture` helpers with a single `ensureOverlayTexturesBound()` that binds HUD top/bottom segments, scope, and rear mirror only when needed in `SubmitVRTextures()`.
- Preserve existing behavior for showing/hiding overlays and rear-mirror flipping while minimizing redundant API calls.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696991f7b1f08321b06617ffac0ccc67)