### PR TITLE
Improve VR overlay stability and HUD alpha handling

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -261,6 +261,9 @@ public:
 	bool m_IsVREnabled = false;
 	bool m_IsInitialized = false;
 	bool m_RenderedNewFrame = false;
+	// Once we've successfully rendered at least one VR frame. Used to avoid flickering
+	// overlays when multicore rendering occasionally skips our render-view hook.
+	bool m_HasEverRenderedFrame = false;
 	bool m_RenderedHud = false;
 	bool m_CreatedVRTextures = false;
 	// Used by extra offscreen passes (scope RTT): prevents HUD hooks from hijacking RT stack


### PR DESCRIPTION
### Motivation
- Prevent HUD overlays from appearing opaque when the backbuffer format lacks an alpha channel under multicore/DXVK paths.
- Avoid one-frame overlay flicker when the engine's render thread intermittently skips the VR render-view hook.
- Ensure HUD render passes use a full-window viewport so HUD elements are not scaled or offset by odd viewports.

### Description
- Added the `m_HasEverRenderedFrame` flag to `VR` (in `vr.h`) to track whether a valid VR frame has been rendered and to avoid falling back to menu/blank overlays unnecessarily.
- In `VR::CreateVRTextures` (`vr.cpp`) read the backbuffer format once and use an `ensureAlphaFormat` helper so HUD render targets use an alpha-capable format when the backbuffer is BGRX/RGB variants, while reusing the detected `backBufferFormat` for eye textures. 
- Updated `VR::SubmitVRTextures` (`vr.cpp`) to keep and re-submit the last eye textures on stale frames instead of immediately switching to the main menu overlay, falling back to the menu/blank path only when not in-game or if `m_HasEverRenderedFrame` is false. 
- In `Hooks::dRenderView` and `Hooks::dPushRenderTargetAndViewport` (`hooks.cpp`) mark `m_HasEverRenderedFrame` true on a successful render and force a full-window viewport (using `GetWindowSize` and `0,0,w,h`) when pushing the HUD render target to avoid scaled/offset HUD content.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969bdf135888321a8ac07d91ce0201d)