### PR TITLE
Improve VR HUD capture stability under multicore rendering

### DIFF
--- a/L4D2VR/hooks.h
+++ b/L4D2VR/hooks.h
@@ -158,6 +158,4 @@ public:
 	static int __fastcall dIsSplitScreen();
 	static DWORD* __fastcall dPrePushRenderTarget(void* ecx, void* edx, int a2);
 
-	static inline int m_PushHUDStep;
-	static inline bool m_PushedHud;
 };

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -485,16 +485,36 @@ void VR::CreateVRTextures()
     int windowWidth, windowHeight;
     m_Game->m_MaterialSystem->GetRenderContext()->GetWindowSize(windowWidth, windowHeight);
 
+    // HUD overlays require a real alpha channel; with multicore rendering the backbuffer
+    // format can be a no-alpha variant (e.g. BGRX8888), which makes the HUD quad opaque
+    // black in SteamVR.
+    auto ensureHudAlphaFormat = [](ImageFormat fmt) -> ImageFormat
+        {
+            switch (fmt)
+            {
+            case IMAGE_FORMAT_BGRX8888:  return IMAGE_FORMAT_BGRA8888;
+            case IMAGE_FORMAT_LINEAR_BGRX8888: return IMAGE_FORMAT_LINEAR_BGRA8888;
+            case IMAGE_FORMAT_LE_BGRX8888: return IMAGE_FORMAT_LE_BGRA8888;
+            case IMAGE_FORMAT_BGRX5551:  return IMAGE_FORMAT_BGRA5551;
+            case IMAGE_FORMAT_LINEAR_BGRX5551: return IMAGE_FORMAT_BGRA5551;
+            default:
+                return fmt;
+            }
+        };
+
+    const ImageFormat backFmt = m_Game->m_MaterialSystem->GetBackBufferFormat();
+    const ImageFormat hudFmt = ensureHudAlphaFormat(backFmt);
+
     m_Game->m_MaterialSystem->isGameRunning = false;
     m_Game->m_MaterialSystem->BeginRenderTargetAllocation();
     m_Game->m_MaterialSystem->isGameRunning = true;
 
     m_CreatingTextureID = Texture_LeftEye;
-    m_LeftEyeTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("leftEye0", m_RenderWidth, m_RenderHeight, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SEPARATE, TEXTUREFLAGS_NOMIP);
+    m_LeftEyeTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("leftEye0", m_RenderWidth, m_RenderHeight, RT_SIZE_NO_CHANGE, backFmt, MATERIAL_RT_DEPTH_SEPARATE, TEXTUREFLAGS_NOMIP);
     m_CreatingTextureID = Texture_RightEye;
-    m_RightEyeTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("rightEye0", m_RenderWidth, m_RenderHeight, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SEPARATE, TEXTUREFLAGS_NOMIP);
+    m_RightEyeTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("rightEye0", m_RenderWidth, m_RenderHeight, RT_SIZE_NO_CHANGE, backFmt, MATERIAL_RT_DEPTH_SEPARATE, TEXTUREFLAGS_NOMIP);
     m_CreatingTextureID = Texture_HUD;
-    m_HUDTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("vrHUD", windowWidth, windowHeight, RT_SIZE_NO_CHANGE, m_Game->m_MaterialSystem->GetBackBufferFormat(), MATERIAL_RT_DEPTH_SHARED, TEXTUREFLAGS_NOMIP);
+    m_HUDTexture = m_Game->m_MaterialSystem->CreateNamedRenderTargetTextureEx("vrHUD", windowWidth, windowHeight, RT_SIZE_NO_CHANGE, hudFmt, MATERIAL_RT_DEPTH_SHARED, TEXTUREFLAGS_NOMIP);
 
     // Square RTT for gun-mounted scope lens
     m_CreatingTextureID = Texture_Scope;
@@ -601,34 +621,39 @@ void VR::SubmitVRTextures()
             vr::VROverlay()->SetOverlayTexture(overlay, &m_VKRearMirror.m_VRTexture);
         };
 
-    //     ֡û       ݣ    ߲˵ /Overlay ·  
+    // No new frame this tick. With multicore rendering, our RenderView hook can
+    // intermittently miss a frame even while in-game. Don't aggressively switch to
+    // the main-menu overlay and hide everything; keep the last submitted textures
+    // to avoid one-frame flicker.
+    const bool inGame = m_Game->m_EngineClient->IsInGame();
     if (!m_RenderedNewFrame)
     {
         if (!m_BlankTexture)
             CreateVRTextures();
 
-        if (!vr::VROverlay()->IsOverlayVisible(m_MainMenuHandle))
-            RepositionOverlays();
-
-        vr::VROverlay()->SetOverlayTexture(m_MainMenuHandle, &m_VKBackBuffer.m_VRTexture);
-        vr::VROverlay()->ShowOverlay(m_MainMenuHandle);
-        hideHudOverlays();
-        vr::VROverlay()->HideOverlay(m_ScopeHandle);
-        vr::VROverlay()->HideOverlay(m_RearMirrorHandle);
-
-        if (!m_Game->m_EngineClient->IsInGame())
+        // Only fall back to menu/blank path when we truly have nothing valid to show.
+        if (!inGame || !m_HasEverRenderedFrame)
         {
+            if (!vr::VROverlay()->IsOverlayVisible(m_MainMenuHandle))
+                RepositionOverlays();
+
+            vr::VROverlay()->SetOverlayTexture(m_MainMenuHandle, &m_VKBackBuffer.m_VRTexture);
+            vr::VROverlay()->ShowOverlay(m_MainMenuHandle);
+            hideHudOverlays();
+            vr::VROverlay()->HideOverlay(m_ScopeHandle);
+            vr::VROverlay()->HideOverlay(m_RearMirrorHandle);
+
             submitEye(vr::Eye_Left, &m_VKBlankTexture.m_VRTexture, nullptr);
             submitEye(vr::Eye_Right, &m_VKBlankTexture.m_VRTexture, nullptr);
-        }
 
-        if (successfulSubmit && m_CompositorExplicitTiming)
-        {
-            m_CompositorNeedsHandoff = true;
-            FinishFrame();
+            if (successfulSubmit && m_CompositorExplicitTiming)
+            {
+                m_CompositorNeedsHandoff = true;
+                FinishFrame();
+            }
+            return;
         }
-
-        return;
+        // else: stale frame, fall through and re-submit last textures.
     }
 
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -261,6 +261,13 @@ public:
 	bool m_IsVREnabled = false;
 	bool m_IsInitialized = false;
 	bool m_RenderedNewFrame = false;
+	// With multicore rendering enabled, the engine may occasionally run RenderView on a
+	// different thread/sequence and our hook can miss a frame. Track whether we've
+	// ever produced a valid VR frame so we can avoid flickering overlays on transient
+	// misses.
+	bool m_HasEverRenderedFrame = false;
+	// Guard to prevent recursion when we manually capture VGUI into the HUD RT.
+	bool m_ManualHudCaptureInProgress = false;
 	bool m_RenderedHud = false;
 	bool m_CreatedVRTextures = false;
 	// Used by extra offscreen passes (scope RTT): prevents HUD hooks from hijacking RT stack


### PR DESCRIPTION
### Motivation

- Multicore rendering changes the `RenderView`/RT-stack call order and can cause transient misses of our `RenderView` hook, producing one-frame overlay flicker.
- The previous heuristic that hijacked `PushRenderTargetAndViewport` to capture HUD was brittle under variable call orders and could capture the wrong render target.
- Some backbuffer formats lack an alpha channel (e.g. `BGRX8888`) which makes HUD overlays appear opaque in SteamVR, so the HUD render target must use an alpha-capable format.

### Description

- Added state flags `m_HasEverRenderedFrame` and `m_ManualHudCaptureInProgress` to `VR` (`vr.h`) to track whether a valid VR frame was rendered and to guard manual HUD capture recursion respectively.
- Mark `m_HasEverRenderedFrame` in the `dRenderView` hook so overlay-fallback logic can distinguish true no-frame conditions from transient hook misses.
- Simplified `dPushRenderTargetAndViewport`/`dPopRenderTargetAndViewport` hooks to stop guessing HUD RT stack sequences and moved HUD capture into `dVGui_Paint`, which now deterministically renders VGUI into `m_HUDTexture` by saving/restoring the render target and viewport, managing alpha write, and providing a fallback path when viewport hooks are unavailable.
- Updated `CreateVRTextures` to choose an alpha-capable HUD format derived from the backbuffer (`ensureHudAlphaFormat`) and to use the backbuffer format for eye render targets to avoid format mismatches.
- Changed `SubmitVRTextures` behavior so that when a frame is missed it only falls back to the main-menu/blank overlay if truly out-of-game or if no VR frame has ever been rendered, otherwise it re-submits the last known textures to avoid one-frame flicker.
- Removed the old `m_PushHUDStep` / `m_PushedHud` heuristics and related state from `hooks.h`/`hooks.cpp` to simplify the capture logic.

### Testing

- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969c5bf3844832181646d5ddf8426f7)