### PR TITLE
Stabilize VR render targets for queued/multicore rendering

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -482,8 +482,11 @@ bool VR::GetWalkAxis(float& x, float& y) {
 
 void VR::CreateVRTextures()
 {
-    int windowWidth, windowHeight;
-    m_Game->m_MaterialSystem->GetRenderContext()->GetWindowSize(windowWidth, windowHeight);
+    // NOTE: With multicore/queued rendering enabled, IMatRenderContext::GetWindowSize()
+    // can report transient/worker viewport dimensions which breaks HUD RT sizing and
+    // overlay placement. Backbuffer dimensions are stable.
+    int windowWidth = 0, windowHeight = 0;
+    m_Game->m_MaterialSystem->GetBackBufferDimensions(windowWidth, windowHeight);
 
     // HUD overlays require a real alpha channel; with multicore rendering the backbuffer
     // format can be a no-alpha variant (e.g. BGRX8888), which makes the HUD quad opaque
@@ -1090,8 +1093,10 @@ void VR::RepositionOverlays(bool attachToControllers)
     Vector hmdPosition = { hmdMat.m[0][3], hmdMat.m[1][3], hmdMat.m[2][3] };
     Vector hmdForward = { -hmdMat.m[0][2], 0, -hmdMat.m[2][2] };
 
-    int windowWidth, windowHeight;
-    m_Game->m_MaterialSystem->GetRenderContext()->GetWindowSize(windowWidth, windowHeight);
+    // Use backbuffer dimensions instead of IMatRenderContext::GetWindowSize() because
+    // with multicore/queued rendering the render context can report transient sizes.
+    int windowWidth = 0, windowHeight = 0;
+    m_Game->m_MaterialSystem->GetBackBufferDimensions(windowWidth, windowHeight);
 
     vr::HmdMatrix34_t menuTransform =
     {


### PR DESCRIPTION
### Motivation
- Queued/multicore rendering can cause `IMatRenderContext::GetWindowSize()` to return transient worker viewport sizes and can defer draw calls, which breaks HUD render target sizing and causes cross-pass render-target bleed and HUD flicker.
- The changes aim to make HUD/overlay sizing and capture deterministic and to ensure draw calls are executed while the intended render target is bound.

### Description
- Replaced calls to `GetRenderContext()->GetWindowSize()` with `m_MaterialSystem->GetBackBufferDimensions()` in `L4D2VR/vr.cpp` for `VR::CreateVRTextures` and `VR::RepositionOverlays` to use stable backbuffer dimensions for HUD/overlay layout.
- Added `m_Game->m_MaterialSystem->Flush(true)` after eye renders and offscreen RTT passes in `L4D2VR/hooks.cpp` (in the left/right eye paths, the offscreen `renderToTexture_SetRT` fallback path and when rendering scope/rear-mirror passes) to force queued draw calls to execute while the intended RT is bound.
- Switched HUD capture in `Hooks::dVGui_Paint` to use backbuffer dimensions and added `Flush(true)` after VGUI paint calls (both viewport-hook and fallback paths) so HUD draw commands do not spill into subsequent passes.
- Updated comments explaining rationale and referenced the modified functions and files (`L4D2VR/vr.cpp`, `L4D2VR/hooks.cpp`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e401a7e08321bf48cf2e6937e8e8)