### PR TITLE
Add ALT-held software cursor for mouse-mode UI interaction in VR

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -364,6 +364,19 @@ public:
 	//  - Aim line starts at the anchored viewmodel point, but converges to the mouse-aim ray
 	//    at MouseModeAimConvergeDistance (scheme B).
 	bool m_MouseModeEnabled = false;
+	// MouseMode helper: hold ALT to temporarily show a software cursor on the HUD and
+	// route mouse clicks to VGUI (useful for UI panels when playing without controllers).
+	bool  m_MouseModeAltCursorEnabled = true;
+	// Runtime state for ALT cursor overlay (updated from CreateMove/input).
+	bool  m_MouseModeAltCursorActive = false;
+	float m_MouseModeAltCursorX = 0.0f;
+	float m_MouseModeAltCursorY = 0.0f;
+	bool  m_MouseModeAltCursorInitialized = false;
+	bool  m_MouseModeAltCursorLmbPrev = false;
+	int   m_MouseModeAltCursorWindowW = 0;
+	int   m_MouseModeAltCursorWindowH = 0;
+	// D3D resources for cursor rendering.
+	IDirect3DTexture9* m_MouseModeCursorTex = nullptr;
 	// Mouse-mode aiming source.
 	// If false (default): aim direction is driven by the accumulated mouse pitch + body yaw (m_RotationOffset).
 	// If true:            aim direction follows the HMD center ray (view direction), while the aim line origin


### PR DESCRIPTION
### Motivation
- Provide a way for desktop-style `m_MouseMode` users to interact with VGUI panels in VR when controllers are not available by showing a temporary software cursor and routing clicks.
- Ensure the HUD overlay shows the cursor because OS cursors are not present in the captured backbuffer used for VR overlays.
- Prevent gameplay inputs (e.g., firing) from triggering while the user is interacting with UI via the temporary cursor.

### Description
- Added runtime state and configuration to `VR` in `vr.h` (`m_MouseModeAltCursorEnabled`, `m_MouseModeAltCursorActive`, cursor position/state, window size cache, and `m_MouseModeCursorTex`).
- Implemented helpers in `vr.cpp`: `IsAltHeld()`, `EnsureAltCursorTexture()` to create a small D3D cursor texture, and `RenderAltCursorToSurface()` to draw the software cursor into the HUD render target (top half of the packed HUD texture).
- Updated `VR::Update()` to cache window size, track ALT-cursor active state, route ALT-held left-click press/release to VGUI via `InternalMousePressed/Released`, and gate `ProcessInput()` when ALT cursor is active.
- Updated `VR::SubmitVRTextures()` to render the ALT cursor into `m_D9HUDSurface` when active and show the HUD overlays when either VGUI cursor or ALT cursor mode is active.
- Updated `CreateMove` handling in `hooks.cpp` to convert raw mouse deltas into the ALT software cursor when ALT is held (`m_MouseModeAltCursorX/Y`), call `m_VguiInput->SetCursorPos()`, suppress attack buttons (`IN_ATTACK` / `IN_ATTACK2`), and zero mouse deltas to avoid moving the view while interacting with UI.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b176168c88321aa4f268e276538db)