### PR TITLE
Fix viewmodel snapping during incapacitation and mouse-mode duck/angles

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -1292,7 +1292,7 @@ int Hooks::dServerFireTerrorBullets(int playerId, const Vector& vecOrigin, const
 			}
 			else
 			{
-				vecNewAngles = m_VR->GetRightControllerAbsAngle();
+				vecNewAngles = m_VR->m_MouseModeEnabled ? m_VR->GetRecommendedViewmodelAbsAngle() : m_VR->GetRightControllerAbsAngle();
 			}
 		}
 
@@ -1311,12 +1311,12 @@ int Hooks::dServerFireTerrorBullets(int playerId, const Vector& vecOrigin, const
 			}
 			else
 			{
-				vecNewAngles = m_VR->GetRightControllerAbsAngle();
+				vecNewAngles = m_VR->m_MouseModeEnabled ? m_VR->GetRecommendedViewmodelAbsAngle() : m_VR->GetRightControllerAbsAngle();
 			}
 		}
 		else
 		{
-			vecNewAngles = m_VR->GetRightControllerAbsAngle();
+			vecNewAngles = m_VR->m_MouseModeEnabled ? m_VR->GetRecommendedViewmodelAbsAngle() : m_VR->GetRightControllerAbsAngle();
 		}
 	}
 	// Clients
@@ -1370,12 +1370,12 @@ int Hooks::dClientFireTerrorBullets(
 					}
 					else
 					{
-						vecNewAngles = m_VR->GetRightControllerAbsAngle();
+						vecNewAngles = m_VR->m_MouseModeEnabled ? m_VR->GetRecommendedViewmodelAbsAngle() : m_VR->GetRightControllerAbsAngle();
 					}
 				}
 				else
 				{
-					vecNewAngles = m_VR->GetRightControllerAbsAngle();
+					vecNewAngles = m_VR->m_MouseModeEnabled ? m_VR->GetRecommendedViewmodelAbsAngle() : m_VR->GetRightControllerAbsAngle();
 				}
 			}
 		}
@@ -1408,12 +1408,12 @@ int Hooks::dClientFireTerrorBullets(
 						}
 						else
 						{
-							vecNewAngles = m_VR->GetRightControllerAbsAngle();
+							vecNewAngles = m_VR->m_MouseModeEnabled ? m_VR->GetRecommendedViewmodelAbsAngle() : m_VR->GetRightControllerAbsAngle();
 						}
 					}
 					else
 					{
-						vecNewAngles = m_VR->GetRightControllerAbsAngle();
+						vecNewAngles = m_VR->m_MouseModeEnabled ? m_VR->GetRecommendedViewmodelAbsAngle() : m_VR->GetRightControllerAbsAngle();
 					}
 				}
 			}

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -145,6 +145,11 @@ public:
 
 	Vector m_ViewmodelPosOffset;
 	QAngle m_ViewmodelAngOffset;
+	// Cache the last valid weapon viewmodel offsets. During incap/revive the game can report no active weapon
+	// for a few seconds, which would otherwise snap offsets to zero and push the viewmodel far away.
+	Vector m_LastWeaponViewmodelPosOffset = { 20,3,0 };
+	QAngle m_LastWeaponViewmodelAngOffset = { 0,0,0 };
+	bool m_HasLastWeaponViewmodelOffset = true;
 	Vector m_ViewmodelPosAdjust = { 0,0,0 };
 	QAngle m_ViewmodelAngAdjust = { 0,0,0 };
 	ViewmodelAdjustment m_DefaultViewmodelAdjust{ {0,0,0}, {0,0,0} };
@@ -283,6 +288,7 @@ public:
 	bool m_JumpCmdOwned = false;
 	bool m_UseCmdOwned = false;
 	bool m_ReloadCmdOwned = false;
+	bool m_DuckCmdOwned = false;
 	bool m_LeftGripPressedPrev = false;
 	bool m_RightGripPressedPrev = false;
 


### PR DESCRIPTION
### Motivation

- Prevent the weapon viewmodel from snapping away when the game temporarily reports no active weapon (e.g. during incapacitation/revive). 
- Preserve player keyboard binds for crouch when `MouseMode` is enabled so VR code does not override `Ctrl` or other binds. 
- Make mouse-mode fallback bullet angles use the recommended viewmodel orientation so third-person/mouse-mode visuals match the viewmodel.

### Description

- Added cached offsets `m_LastWeaponViewmodelPosOffset`, `m_LastWeaponViewmodelAngOffset`, and `m_HasLastWeaponViewmodelOffset`, and an ownership flag `m_DuckCmdOwned` to the `VR` class in `vr.h`.
- In `vr.cpp` (viewmodel update) use `GetActiveWeapon()` to determine whether to read `localPlayer->GetViewmodelOffset()` and update the cached offsets, and otherwise fall back to the cached (or sane default) offsets before applying adjustments.
- In `vr.cpp` (input processing) changed crouch handling so `MouseMode` no longer drives `+duck`/`-duck` every frame; instead it releases a previously owned `+duck`, and outside mouse-mode `+duck`/`-duck` are sent only when ownership changes using `m_DuckCmdOwned`.
- In `hooks.cpp` replaced several fallback uses of `GetRightControllerAbsAngle()` with a conditional that uses `GetRecommendedViewmodelAbsAngle()` when `m_MouseModeEnabled` so bullet angle fallbacks match mouse-mode viewmodel orientation.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bb55862d48321811d4dbfd165030c)