### PR TITLE
Refine VR input ownership and add mouse-mode aiming

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2397,14 +2397,18 @@ void VR::ProcessInput()
         }
     }
 
-    bool crouchActive = (!suppressCrouch) && (crouchButtonDown || m_CrouchToggleActive);
-    if (crouchActive)
+    const bool wantDuck = (!suppressCrouch) && (crouchButtonDown || m_CrouchToggleActive);
+    // IMPORTANT: only release -duck if *we* previously issued +duck.
+    // Otherwise we would cancel the player's real keyboard input (e.g. Ctrl +duck in mouse mode).
+    if (wantDuck && !m_DuckCmdOwned)
     {
         m_Game->ClientCmd_Unrestricted("+duck");
+        m_DuckCmdOwned = true;
     }
-    else
+    else if (!wantDuck && m_DuckCmdOwned)
     {
         m_Game->ClientCmd_Unrestricted("-duck");
+        m_DuckCmdOwned = false;
     }
 
     if (flashlightJustPressed)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -283,6 +283,7 @@ public:
 	bool m_JumpCmdOwned = false;
 	bool m_UseCmdOwned = false;
 	bool m_ReloadCmdOwned = false;
+	bool m_DuckCmdOwned = false;
 	bool m_LeftGripPressedPrev = false;
 	bool m_RightGripPressedPrev = false;
 


### PR DESCRIPTION
### Motivation
- Avoid cancelling a user's real keyboard crouch input when VR toggles crouch by tracking whether VR issued `+duck` so we only release `-duck` when owned. 
- Provide a consistent mouse-mode aiming path for mouse+keyboard play so bullets/aim lines originate from a configurable HMD-anchored viewmodel point and aim toward a computed target. 
- Prevent transient revive camera offsets from incorrectly triggering third-person rendering and preserve intended first-person VR view during revives.

### Description
- Add `m_DuckCmdOwned` to `VR` (`vr.h`) and change duck handling in `VR::ProcessInput()` (`vr.cpp`) to issue `+duck`/`-duck` only when ownership changes and to clear ownership on release. 
- Add mouse-mode aiming helpers to `hooks.cpp`: `GetMouseModeGunOriginAbs`, `GetMouseModeEyeDir`, `GetMouseModeDefaultTargetAbs`, `GetMouseModeAimAnglesToTarget`, and `GetMouseModeFallbackAimAngles`. 
- Integrate mouse-mode into firing hooks: `Hooks::dServerFireTerrorBullets` and `Hooks::dClientFireTerrorBullets` now select origin/angles from the mouse-mode helpers when `m_MouseModeEnabled`, while preserving third-person converge and non-VR server movement handling. 
- Make third-person detection revive-aware by skipping engine third-person when revive netvars indicate `playerReviving`, and remove revive from the state-based third-person forcing in `ShouldForceThirdPersonByState` (`hooks.cpp`).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bcf2a24208321803016e14e376d3d)