### PR TITLE
Mouse-mode scope toggles, scoped viewmodel anchors and per-magnification sensitivity

### DIFF
--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -460,6 +460,54 @@ Option g_Options[] =
         "0.22,0.00,-0.18"
     },
     {
+        "MouseModeScopedViewmodelAnchorOffset",
+        OptionType::Vec3,
+        { u8"Input / Mouse Mode", u8"输入 / 键鼠模式" },
+        { u8"Scoped Viewmodel Anchor Offset (m)", u8"开镜 Viewmodel 锚点偏移 (米)" },
+        { u8"Alternate viewmodel anchor offset used while mouse-mode scope toggle is active.",
+          u8"键鼠模式开镜切换启用时使用的备用 viewmodel 锚点偏移。" },
+        { u8"Use this to shift the gun into an ADS-like position.",
+          u8"用于把枪移动到更像开镜/贴腮的位置。" },
+        -1.0f, 1.0f,
+        "0.22,0.00,-0.18"
+    },
+    {
+        "MouseModeScopeToggleKey",
+        OptionType::String,
+        { u8"Input / Mouse Mode", u8"输入 / 键鼠模式" },
+        { u8"Scope Toggle Key", u8"开关瞄准镜快捷键" },
+        { u8"Keyboard shortcut to toggle ScopeRTT on/off in mouse mode (e.g. key:f9).",
+          u8"键鼠模式下开关 ScopeRTT 的快捷键（例如 key:f9）。" },
+        { u8"Format: key:<letter> or key:f1..f12. Empty disables.",
+          u8"格式：key:<字母> 或 key:f1..f12。留空禁用。" },
+        0.0f, 0.0f,
+        "key:f9"
+    },
+    {
+        "MouseModeScopeMagnificationKey",
+        OptionType::String,
+        { u8"Input / Mouse Mode", u8"输入 / 键鼠模式" },
+        { u8"Scope Magnification Key", u8"倍镜切换快捷键" },
+        { u8"Keyboard shortcut to cycle scope magnification while scope is active in mouse mode.",
+          u8"键鼠模式开镜时用于切换倍镜倍率的快捷键。" },
+        { u8"Format: key:<letter> or key:f1..f12. Empty disables.",
+          u8"格式：key:<字母> 或 key:f1..f12。留空禁用。" },
+        0.0f, 0.0f,
+        "key:f10"
+    },
+    {
+        "MouseModeScopeSensitivityScale",
+        OptionType::String,
+        { u8"Input / Mouse Mode", u8"输入 / 键鼠模式" },
+        { u8"Scope Sensitivity Scale (%)", u8"倍镜灵敏度缩放 (%)" },
+        { u8"Per-magnification mouse sensitivity scale (comma-separated, in %). First value is 1x.",
+          u8"按倍率分档的鼠标灵敏度缩放（逗号分隔，单位%），第一个对应1x。" },
+        { u8"Example: 100,85,70 for 1x/2x/4x. Missing entries repeat the last.",
+          u8"示例：100,85,70 表示 1x/2x/4x。缺失的档位将沿用最后一个值。" },
+        0.0f, 0.0f,
+        "100"
+    },
+    {
         "MouseModeAimConvergeDistance",
         OptionType::Float,
         { u8"Input / Mouse Mode", u8"输入 / 键鼠模式" },


### PR DESCRIPTION
### Motivation
- Add mouse-mode-friendly scope behavior so players using keyboard/mouse in VR can toggle/show a ScopeRTT and get an ADS-like viewmodel anchor while scoping.
- Provide per-magnification mouse sensitivity scaling while scoped in mouse mode to make aiming consistent across zoom levels.
- Expose new mouse-mode scope settings to the config UI and read hotkeys from config for toggling/cycling magnification.

### Description
- Added mouse-mode scope state, hotkeys and sensitivity table fields and accessors in `vr.h` including `IsMouseModeScopeActive`, `GetMouseModeScopeSensitivityScale`, and `ToggleMouseModeScope`.
- Implemented mouse-mode-aware viewmodel anchoring and scope overlay handling in `vr.cpp`, including `UpdateScopeOverlayTransform`, using the scoped anchor when the mouse-mode scope toggle is active and applying scope camera/aim logic when in mouse mode (`m_MouseModeScopedViewmodelAnchorOffset`, keyboard-driven scope activation, updating `m_ScopeCameraPosAbs`/`m_ScopeCameraAngAbs`).
- Made mouse-mode aim/input changes in `hooks.cpp`: added `#include <windows.h>`, polled keyboard hotkeys in `dCreateMove` to toggle scope and cycle magnification, and applied per-magnification sensitivity scaling to mouse yaw/pitch while scoped in mouse mode.
- Added config parsing & defaults in `vr.cpp` and GUI entries in `L4D2VRConfigTool/src/Options.cpp` for `MouseModeScopedViewmodelAnchorOffset`, `MouseModeScopeToggleKey`, `MouseModeScopeMagnificationKey`, and `MouseModeScopeSensitivityScale` (comma-separated % values), and adjusted `getFloatList` helper to accept defaults.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bd933f61083218a19238a25c4d510)