### PR TITLE
Add mouse-mode scope impulses

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -927,6 +927,25 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 		// We zero cmd->mousedx/y so Source doesn't also apply them to viewangles.
 		if (m_VR->m_MouseModeEnabled)
 		{
+			// Mouse mode scope triggers via CUserCmd::impulse (bindable from Source console).
+			// This is more reliable than polling Windows virtual keys (GetAsyncKeyState) and
+			// allows normal binds / alias chains.
+			if (cmd->impulse != 0)
+			{
+				const int imp = (int)cmd->impulse;
+				if (m_VR->m_MouseModeScopeToggleImpulse > 0 && imp == m_VR->m_MouseModeScopeToggleImpulse)
+				{
+					m_VR->ToggleMouseModeScope();
+					cmd->impulse = 0; // consume
+				}
+				else if (m_VR->m_MouseModeScopeMagnificationImpulse > 0 && imp == m_VR->m_MouseModeScopeMagnificationImpulse)
+				{
+					if (m_VR->IsMouseModeScopeActive())
+						m_VR->CycleScopeMagnification();
+					cmd->impulse = 0; // consume
+				}
+			}
+
 			// Mouse mode hotkeys (keyboard). Polled here because CreateMove runs at input tick rate.
 			auto pollKeyPressed = [&](const std::optional<WORD>& vk, bool& prevDown) -> bool
 				{

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -3385,7 +3385,7 @@ void VR::UpdateTracking()
             QAngle aimAngBase = m_HmdAngAbs;
             aimAngBase.x = m_MouseAimPitchOffset;
             Vector aimRay;
-            QAngle::AngleVectors(aimAngBase, &aimRay);
+            QAngle::AngleVectors(aimAngBase, &aimRay, nullptr, nullptr);
             Vector eyeDir = m_MouseModeAimFromHmd ? aimRay : m_HmdForward;
             if (!eyeDir.IsZero())
                 VectorNormalize(eyeDir);
@@ -3399,7 +3399,7 @@ void VR::UpdateTracking()
             VectorNormalize(aimDir);
 
             QAngle aimAng;
-            VectorAngles(aimDir, m_HmdUp, aimAng);
+            QAngle::VectorAngles(aimDir, m_HmdUp, aimAng);
 
             Vector f, r, u;
             QAngle::AngleVectors(aimAng, &f, &r, &u);

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -6116,6 +6116,11 @@ void VR::ParseConfigFile()
     m_MouseModeScopeToggleKey = parseVirtualKey(getString("MouseModeScopeToggleKey", "key:f9"));
     m_MouseModeScopeMagnificationKey = parseVirtualKey(getString("MouseModeScopeMagnificationKey", "key:f10"));
 
+    // Optional bindable impulses for mouse-mode scope control.
+    // Using impulses avoids GetAsyncKeyState issues and allows normal Source binds.
+    m_MouseModeScopeToggleImpulse = std::clamp(getInt("MouseModeScopeToggleImpulse", m_MouseModeScopeToggleImpulse), 0, 255);
+    m_MouseModeScopeMagnificationImpulse = std::clamp(getInt("MouseModeScopeMagnificationImpulse", m_MouseModeScopeMagnificationImpulse), 0, 255);
+
     auto mouseModeScopeSensitivityList = getFloatList("MouseModeScopeSensitivityScale", "100");
     if (mouseModeScopeSensitivityList.empty())
         mouseModeScopeSensitivityList.push_back(100.0f);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -411,6 +411,13 @@ public:
 	// Mouse-mode scope hotkeys (keyboard). Format in config.txt: key:X, key:F1..F12 (see parseVirtualKey).
 	std::optional<WORD> m_MouseModeScopeToggleKey;
 	std::optional<WORD> m_MouseModeScopeMagnificationKey;
+	// Mouse-mode scope triggers via CUserCmd::impulse (bindable from the in-game console).
+	// Example binds:
+	//   bind q "impulse 202"   // toggle mouse-mode scope
+	//   bind z "impulse 203"   // cycle mouse-mode scope magnification
+	// Set to 0 to disable (do nothing).
+	int m_MouseModeScopeToggleImpulse = 202;
+	int m_MouseModeScopeMagnificationImpulse = 203;
 	bool m_MouseModeScopeToggleActive = false;
 	bool m_MouseModeScopeToggleKeyDownPrev = false;
 	bool m_MouseModeScopeMagnificationKeyDownPrev = false;

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -1145,6 +1145,32 @@ Option g_Options[] =
         "5,0,25"
     },
 
+    // Mouse Mode (Desktop aiming in VR)
+    {
+        "MouseModeScopeToggleImpulse",
+        OptionType::Int,
+        { u8"Mouse Mode", u8"鼠标模式" },
+        { u8"Scope Toggle Impulse", u8"开镜切换 Impulse" },
+        { u8"When Mouse Mode is enabled, this CUserCmd impulse value toggles the mouse-mode scope state.",
+          u8"开启鼠标模式时，该 CUserCmd impulse 数值将切换鼠标模式的开镜状态。" },
+        { u8"Bind a key in console, e.g.: bind q \"impulse 202\". Set 0 to disable.",
+          u8"可在控制台绑定按键，例如：bind q \"impulse 202\"。设为 0 则禁用。" },
+        0.f, 255.f,
+        "202"
+    },
+    {
+        "MouseModeScopeMagnificationImpulse",
+        OptionType::Int,
+        { u8"Mouse Mode", u8"鼠标模式" },
+        { u8"Scope Magnification Impulse", u8"镜倍切换 Impulse" },
+        { u8"When mouse-mode scope is active, this CUserCmd impulse cycles scope magnification.",
+          u8"鼠标模式开镜激活时，该 CUserCmd impulse 将循环切换瞄准镜倍率。" },
+        { u8"Bind a key in console, e.g.: bind z \"impulse 203\". Set 0 to disable.",
+          u8"可在控制台绑定按键，例如：bind z \"impulse 203\"。设为 0 则禁用。" },
+        0.f, 255.f,
+        "203"
+    },
+
     // Rear mirror
     {
         "RearMirrorFlipHorizontal",


### PR DESCRIPTION
### Motivation

- Provide a reliable, bindable way to toggle mouse-mode scope and cycle scope magnification using `CUserCmd::impulse` instead of polling OS virtual keys. 
- Avoid `GetAsyncKeyState` limitations and enable normal Source console binds / alias chains for mouse-mode scope controls.

### Description

- Added `m_MouseModeScopeToggleImpulse` and `m_MouseModeScopeMagnificationImpulse` (defaults `202`/`203`) and comments to `VR` state in `L4D2VR/vr.h` for configurable impulse triggers. 
- Parse and clamp the new impulse options from the config in `L4D2VR/vr.cpp` via `getInt(... )` to the `0..255` range. 
- Consume matching `cmd->impulse` values in `CreateMove` (`L4D2VR/hooks.cpp`) to call `ToggleMouseModeScope()` or `CycleScopeMagnification()` and clear the impulse so it does not propagate. 
- Expose new options in the configuration UI (`L4D2VRConfigTool/src/Options.cpp`) with English/Chinese labels, help text, and defaults for users to bind (example: `bind q "impulse 202"`).

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696be230496483219962d4feb0c6186f)