### PR TITLE
Add HMD-anchored mouse-mode scope overlay

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -408,6 +408,10 @@ public:
 	// Optional HMD-local anchor to use while mouse-mode scope is toggled on (meters; scaled by VRScale).
 	// If you want a more "ADS"-like viewmodel position when using ScopeRTT in mouse mode, set this.
 	Vector m_MouseModeScopedViewmodelAnchorOffset = { 0.0f, 0.0f, 0.0f };
+	// Mouse-mode scope overlay offset relative to the HMD (meters, in HMD-local axes).
+	// x = right, y = up, z = back (towards the player's face).
+	// If non-zero, the scope overlay is anchored to the HMD instead of the viewmodel anchor in mouse mode.
+	Vector m_MouseModeScopeOverlayOffset = { 0.0f, 0.0f, 0.0f };
 	// Mouse-mode scope hotkeys (keyboard). Format in config.txt: key:X, key:F1..F12 (see parseVirtualKey).
 	std::optional<WORD> m_MouseModeScopeToggleKey;
 	std::optional<WORD> m_MouseModeScopeMagnificationKey;

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -1170,6 +1170,18 @@ Option g_Options[] =
         0.f, 255.f,
         "203"
     },
+    {
+        "MouseModeScopeOverlayOffset",
+        OptionType::Vec3,
+        { u8"Mouse Mode", u8"鼠标模式" },
+        { u8"Scope Overlay Offset (HMD) (x,y,z)", u8"瞄准镜Overlay偏移(基于HMD)(x,y,z)" },
+        { u8"In mouse mode, anchor the scope overlay to the HMD and apply this offset in HMD-local axes (meters).",
+          u8"键鼠模式下将瞄准镜Overlay挂在HMD上，并按HMD本地坐标应用偏移（米）。" },
+        { u8"x=right, y=up, z=back (towards your face). Set non-zero to prevent the overlay from disappearing.",
+          u8"x=右, y=上, z=向后(靠近脸). 设为非零可避免Overlay看不到。" },
+        -1.0f, 1.0f,
+        "0,0,0"
+    },
 
     // Rear mirror
     {


### PR DESCRIPTION
### Motivation
- Ensure the mouse-mode scope overlay remains visible when the viewmodel basis is invalid or off-screen by allowing it to be anchored to the HMD with an adjustable offset.
- Provide a configurable, HMD-local offset so users can position the overlay ergonomically in mouse mode.

### Description
- Add a new member `m_MouseModeScopeOverlayOffset` to `vr.h` to store an HMD-local offset (meters, x=right,y=up,z=back).
- Update `UpdateScopeOverlayTransform` in `vr.cpp` to optionally anchor the scope overlay to the HMD when `m_MouseModeScopeOverlayOffset` is non-zero, and to fall back to the HMD anchor if the viewmodel basis or recommended viewmodel position are missing.
- Parse the new `MouseModeScopeOverlayOffset` config key in the configuration parsing path (`vr.cpp`) using `getVector3`.
- Expose the setting in the configuration UI by adding `MouseModeScopeOverlayOffset` to `L4D2VRConfigTool/src/Options.cpp` with help text describing axes/units and behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696bf59388048321b46045736c5387ab)