### PR TITLE
Add mouse-mode HMD aim sensitivity and centralize mouse eye-ray computation

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -371,6 +371,11 @@ public:
 	// If true:            aim direction follows the HMD center ray (view direction), while the aim line origin
 	//                     remains at the mouse-mode viewmodel anchor (so we do NOT move the aim line to the HMD).
 	bool m_MouseModeAimFromHmd = false;
+	// Mouse-mode HMD aim sensitivity (only when MouseModeAimFromHmd is true).
+	// 1.0 = 1:1 head rotation, 0 = frozen at enable, >1 amplifies head motion.
+	float m_MouseModeHmdAimSensitivity = 1.0f;
+	QAngle m_MouseModeHmdAimReferenceAng = { 0.0f, 0.0f, 0.0f };
+	bool m_MouseModeHmdAimReferenceInitialized = false;
 	// If true, mouse Y also tilts the rendered view (adds a pitch offset on top of head tracking).
 	// This makes it possible to aim high/low without physically tilting your head (more like flatscreen).
 	bool m_MouseModePitchAffectsView = true;
@@ -804,6 +809,8 @@ public:
 	Vector GetRightControllerAbsPos();
 	Vector GetRecommendedViewmodelAbsPos();
 	QAngle GetRecommendedViewmodelAbsAngle();
+	// Mouse-mode: compute the eye-center ray used for aiming (mouse pitch+yaw or HMD-based, optionally sensitivity-scaled).
+	void GetMouseModeEyeRay(Vector& eyeDirOut, QAngle* eyeAngOut = nullptr);
 	void UpdateTracking();
 	void UpdateMotionGestures(C_BasePlayer* localPlayer);
 	bool UpdateThirdPersonViewState(const Vector& cameraOrigin, const Vector& cameraAngles);

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -569,6 +569,18 @@ Option g_Options[] =
         0.0f, 0.0f,
         "false"
     },
+    {
+        "MouseModeHmdAimSensitivity",
+        OptionType::Float,
+        { u8"Mouse Mode", u8"鼠标模式" },
+        { u8"HMD Aim Sensitivity", u8"HMD 瞄准灵敏度" },
+        { u8"When MouseModeAimFromHmd is enabled, scales how much head rotation affects the aim direction (1.0 = 1:1).",
+          u8"当开启 MouseModeAimFromHmd 时，用于缩放头部转动对瞄准方向的影响（1.0 表示 1:1）。" },
+        { u8"0 freezes aim at the moment HMD aiming becomes active; >1 amplifies head movement.",
+          u8"0 表示锁定为开启 HMD 瞄准时的方向；>1 会放大头部转动。" },
+        0.0f, 3.0f,
+        "1.0"
+    },
 
     // HUD (Main)
     {


### PR DESCRIPTION
### Motivation
- Provide a configurable sensitivity when using HMD-driven aiming in mouse-mode so head rotation can be scaled or frozen. 
- Reduce duplicated code by centralizing the logic that computes the mouse-mode eye-center ray used for aiming.

### Description
- Added state fields `m_MouseModeHmdAimSensitivity`, `m_MouseModeHmdAimReferenceAng`, and `m_MouseModeHmdAimReferenceInitialized` to `vr.h` to track sensitivity and a captured reference HMD angle. 
- Implemented `VR::GetMouseModeEyeRay(Vector& eyeDirOut, QAngle* eyeAngOut = nullptr)` in `vr.cpp` to compute the eye-center ray for mouse-mode, supporting both mouse-derived and HMD-derived (reference-scaled) modes. 
- Replaced duplicated per-file eye-ray computations with calls to `GetMouseModeEyeRay` in scope handling, viewmodel orientation, non-VR aim solution, and aiming laser logic in `vr.cpp`. 
- Loaded the new `MouseModeHmdAimSensitivity` from config in `VR::ParseConfigFile` and exposed the option in the configuration UI by adding `MouseModeHmdAimSensitivity` to `L4D2VRConfigTool/src/Options.cpp`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c143efff88321b479ea9fa1919877)