### PR TITLE
Add Source entity access helpers and use in network name lookup

### DIFF
--- a/L4D2VR/game.cpp
+++ b/L4D2VR/game.cpp
@@ -9,6 +9,7 @@
 #include <mutex>
 
 #include "sdk.h"
+#include "source_access.h"
 #include "vr.h"
 #include "hooks.h"
 #include "offsets.h"
@@ -195,44 +196,14 @@ C_BaseEntity* Game::GetClientEntity(int entityIndex)
 // === Network Name Utility ===
 char* Game::getNetworkName(uintptr_t* entity)
 {
-    if (!entity)
-        return nullptr;
-
-    uintptr_t* vtable = reinterpret_cast<uintptr_t*>(*(entity + 0x8));
-    if (!vtable)
-        return nullptr;
-
-    uintptr_t* getClientClassFn = reinterpret_cast<uintptr_t*>(*(vtable + 0x8));
-    if (!getClientClassFn)
-        return nullptr;
-
-    uintptr_t* clientClass = reinterpret_cast<uintptr_t*>(*(getClientClassFn + 0x1));
-    if (!clientClass)
-        return nullptr;
-
-    char* name = reinterpret_cast<char*>(*(clientClass + 0x8));
-    int classID = static_cast<int>(*(clientClass + 0x10));
-    return name;
+    // Legacy helper (kept for callsites); now uses a proper vtable call rather than
+    // reading immediates from function code.
+    return const_cast<char*>(SourceAccess::GetNetworkName(entity));
 }
 
 const char* Game::GetNetworkClassName(uintptr_t* entity) const
 {
-    if (!entity)
-        return nullptr;
-
-    uintptr_t* vtable = reinterpret_cast<uintptr_t*>(*(entity + 0x8));
-    if (!vtable)
-        return nullptr;
-
-    uintptr_t* getClientClassFn = reinterpret_cast<uintptr_t*>(*(vtable + 0x8));
-    if (!getClientClassFn)
-        return nullptr;
-
-    uintptr_t* clientClass = reinterpret_cast<uintptr_t*>(*(getClientClassFn + 0x1));
-    if (!clientClass)
-        return nullptr;
-
-    return reinterpret_cast<const char*>(*(clientClass + 0x8));
+    return SourceAccess::GetNetworkName(entity);
 }
 
 // === Commands ===

--- a/L4D2VR/source_access.h
+++ b/L4D2VR/source_access.h
@@ -1,0 +1,126 @@
+#pragma once
+
+// Lightweight, version-tolerant helpers for Source (L4D2) client entity access.
+//
+// Design goals:
+//  - Keep dependencies minimal and avoid pulling in huge SDK headers.
+//  - Prefer safe, read-only accessors that are useful for VR rendering and debugging.
+//  - Centralize entity sub-interface offsets and common vtable indices.
+//
+// This file intentionally does NOT provide packet manipulation, command forgery, or other
+// exploit-oriented primitives.
+
+#include <cstdint>
+#include "vector.h"
+
+class C_BaseEntity;
+
+namespace SourceAccess
+{
+	constexpr std::ptrdiff_t kRenderableOffset  = 0x4;
+	constexpr std::ptrdiff_t kNetworkableOffset = 0x8;
+
+	struct ClientClass
+	{
+		void* m_pCreateFn;          // 0x00
+		void* m_pCreateEventFn;     // 0x04
+		const char* m_pNetworkName; // 0x08
+		void* m_pRecvTable;         // 0x0C
+		int m_ClassID;              // 0x10
+		ClientClass* m_pNext;       // 0x14
+	};
+
+	namespace VTable
+	{
+		constexpr int GetClientClass = 1;
+		constexpr int IsDormant      = 7;
+		constexpr int EntIndex       = 8;
+
+		constexpr int SetupBones     = 13;
+
+		constexpr int GetAbsOrigin   = 11;
+		constexpr int GetAbsAngles   = 12;
+	}
+
+	template <typename Fn>
+	inline Fn GetVFunc(void* base, int index)
+	{
+		if (!base)
+			return nullptr;
+		auto** vtable = *reinterpret_cast<void***>(base);
+		return vtable ? reinterpret_cast<Fn>(vtable[index]) : nullptr;
+	}
+
+	inline void* GetRenderable(const void* entity)
+	{
+		if (!entity)
+			return nullptr;
+		return *reinterpret_cast<void* const*>(reinterpret_cast<const std::uint8_t*>(entity) + kRenderableOffset);
+	}
+
+	inline void* GetNetworkable(const void* entity)
+	{
+		if (!entity)
+			return nullptr;
+		return *reinterpret_cast<void* const*>(reinterpret_cast<const std::uint8_t*>(entity) + kNetworkableOffset);
+	}
+
+	inline const ClientClass* GetClientClassPtr(const void* entity)
+	{
+		void* net = GetNetworkable(entity);
+		using Fn = ClientClass*(__thiscall*)(void*);
+		Fn fn = GetVFunc<Fn>(net, VTable::GetClientClass);
+		return fn ? fn(net) : nullptr;
+	}
+
+	inline const char* GetNetworkName(const void* entity)
+	{
+		const ClientClass* cc = GetClientClassPtr(entity);
+		return cc ? cc->m_pNetworkName : nullptr;
+	}
+
+	inline int GetClassID(const void* entity)
+	{
+		const ClientClass* cc = GetClientClassPtr(entity);
+		return cc ? cc->m_ClassID : -1;
+	}
+
+	inline bool IsDormantEntity(const void* entity)
+	{
+		void* net = GetNetworkable(entity);
+		using Fn = bool(__thiscall*)(void*);
+		Fn fn = GetVFunc<Fn>(net, VTable::IsDormant);
+		return fn ? fn(net) : false;
+	}
+
+	inline int EntIndex(const void* entity)
+	{
+		void* net = GetNetworkable(entity);
+		using Fn = int(__thiscall*)(void*);
+		Fn fn = GetVFunc<Fn>(net, VTable::EntIndex);
+		return fn ? fn(net) : -1;
+	}
+
+	inline bool SetupBones(const void* entity, matrix3x4_t* out, int maxBones, int boneMask, float currentTime)
+	{
+		void* rend = GetRenderable(entity);
+		using Fn = bool(__thiscall*)(void*, matrix3x4_t*, int, int, float);
+		Fn fn = GetVFunc<Fn>(rend, VTable::SetupBones);
+		return fn ? fn(rend, out, maxBones, boneMask, currentTime) : false;
+	}
+
+	inline Vector GetAbsOrigin(const void* entity)
+	{
+		using Fn = const Vector&(__thiscall*)(void*);
+		Fn fn = GetVFunc<Fn>(const_cast<void*>(entity), VTable::GetAbsOrigin);
+		return fn ? fn(const_cast<void*>(entity)) : Vector{ 0.f, 0.f, 0.f };
+	}
+
+	inline QAngle GetAbsAngles(const void* entity)
+	{
+		using Fn = const QAngle&(__thiscall*)(void*);
+		Fn fn = GetVFunc<Fn>(const_cast<void*>(entity), VTable::GetAbsAngles);
+		return fn ? fn(const_cast<void*>(entity)) : QAngle{ 0.f, 0.f, 0.f };
+	}
+}
+


### PR DESCRIPTION
### Motivation
- Provide a lightweight, version-tolerant set of helpers for Source (L4D2) client entity access to avoid pulling in large SDK headers.
- Replace fragile immediate-memory parsing used to obtain an entity network name with proper vtable-based accessors for safer read-only use in VR rendering and debugging.

### Description
- Add `L4D2VR/source_access.h` which defines `ClientClass`, common vtable indices and helpers including `GetVFunc`, `GetRenderable`, `GetNetworkable`, `GetClientClassPtr`, `GetNetworkName`, `GetClassID`, `IsDormantEntity`, `EntIndex`, `SetupBones`, `GetAbsOrigin`, and `GetAbsAngles`.
- Include `source_access.h` in `L4D2VR/game.cpp` and refactor `Game::getNetworkName` and `Game::GetNetworkClassName` to use `SourceAccess::GetNetworkName` instead of reading immediates from function code.
- Keep a thin compatibility wrapper in `Game::getNetworkName` (returns `const_cast<char*>`) and document the reason with a comment.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c31d813a8832183e3a37571c6189e)