### PR TITLE
Skip redundant VR RenderView passes

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -525,6 +525,14 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		return hkRenderView.fOriginal(ecx, setup, hudViewSetup, nClearFlags, whatToDraw);
 	}
 
+	// If we've already produced the VR eye textures for this frame, don't do the full
+	// VR stereo path again. Source can call RenderView multiple times per frame
+	// (screenshots, special views, etc.), which blows CPU frametime and can increase crash risk.
+	if (m_VR->m_RenderedNewFrame)
+	{
+		return hkRenderView.fOriginal(ecx, setup, hudViewSetup, nClearFlags, whatToDraw);
+	}
+
 	// ------------------------------
 	// Third-person camera fix:
 	// If engine is in third-person, setup.origin is a shoulder camera,


### PR DESCRIPTION
### Motivation
- Prevent executing the VR stereo rendering path multiple times per frame (e.g. screenshots or special views) to reduce CPU frametime and crash risk.

### Description
- Add an early-return in `Hooks::dRenderView` that checks `m_VR->m_RenderedNewFrame` and calls `hkRenderView.fOriginal(...)` to skip the VR stereo path if eye textures were already produced this frame.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d0f36756c83219619043e167b7596)