### PR TITLE
Add RenderView spam diagnostics

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -6202,6 +6202,16 @@ void VR::ParseConfigFile()
     m_SpecialInfectedWarningActionEnabled = getBool("SpecialInfectedAutoEvade", m_SpecialInfectedWarningActionEnabled);
     m_SpecialInfectedArrowEnabled = getBool("SpecialInfectedArrowEnabled", m_SpecialInfectedArrowEnabled);
     m_SpecialInfectedDebug = getBool("SpecialInfectedDebug", m_SpecialInfectedDebug);
+
+    // RenderView spam diagnostics (helps identify extra RenderView calls within a VR frame).
+    m_RenderViewSpamDebug = getBool("RenderViewSpamDebug", m_RenderViewSpamDebug);
+    m_RenderViewSpamLogIntervalSec = std::clamp(getFloat("RenderViewSpamLogIntervalSec", m_RenderViewSpamLogIntervalSec), 0.1f, 30.0f);
+    m_RenderViewSpamMinExtraCalls = std::clamp(getInt("RenderViewSpamMinExtraCalls", m_RenderViewSpamMinExtraCalls), 0, 200);
+    m_RenderViewCallCountThisFrame = 0;
+    m_RenderViewExtraCallCountThisFrame = 0;
+    m_RenderViewSpamTop.fill({});
+    m_RenderViewSpamDropped = 0;
+    m_RenderViewSpamLastLogTime = {};
     m_SpecialInfectedArrowSize = std::max(0.0f, getFloat("SpecialInfectedArrowSize", m_SpecialInfectedArrowSize));
     m_SpecialInfectedArrowHeight = std::max(0.0f, getFloat("SpecialInfectedArrowHeight", m_SpecialInfectedArrowHeight));
     m_SpecialInfectedArrowThickness = std::max(0.0f, getFloat("SpecialInfectedArrowThickness", m_SpecialInfectedArrowThickness));

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -576,6 +576,28 @@ public:
 
 	bool m_SpecialInfectedArrowEnabled = false;
 	bool m_SpecialInfectedDebug = false;
+
+	// RenderView spam diagnostics: Source can call RenderView multiple times per VR frame.
+	// If our hook runs the full VR stereo path repeatedly in the same frame, CPU frametime spikes.
+	// These fields help identify which RenderView variants are being called *after* the main VR render.
+	bool m_RenderViewSpamDebug = false;
+	float m_RenderViewSpamLogIntervalSec = 2.0f; // minimum seconds between logs/overlays
+	int m_RenderViewSpamMinExtraCalls = 1;       // only log frames with >= this many extra RenderView calls
+	int m_RenderViewCallCountThisFrame = 0;
+	int m_RenderViewExtraCallCountThisFrame = 0;
+	std::chrono::steady_clock::time_point m_RenderViewSpamLastLogTime{};
+
+	struct RenderViewSpamEntry
+	{
+		uint32_t clearFlags = 0;
+		uint32_t whatToDraw = 0;
+		int count = 0;
+		int sampleW = 0;
+		int sampleH = 0;
+		float sampleFov = 0.0f;
+	};
+	std::array<RenderViewSpamEntry, 8> m_RenderViewSpamTop{};
+	uint32_t m_RenderViewSpamDropped = 0;
 	float m_SpecialInfectedArrowSize = 12.0f;
 	float m_SpecialInfectedArrowHeight = 36.0f;
 	float m_SpecialInfectedArrowThickness = 0.0f;


### PR DESCRIPTION
### Motivation

- Source can call `RenderView` multiple times per VR frame which can re-run the full VR stereo path and cause CPU frametime spikes and instability. 
- Add lightweight diagnostics to detect and report extra `RenderView` invocations that occur after the main VR render so the cause can be identified and throttled.

### Description

- Add diagnostic fields and a `RenderViewSpamEntry` struct to `VR` state in `vr.h` for per-frame call counts, top entries, drop counter and throttled log timing. 
- Parse new config options in `VR::ParseConfigFile()` in `vr.cpp` (`RenderViewSpamDebug`, `RenderViewSpamLogIntervalSec`, `RenderViewSpamMinExtraCalls`) and reset counters on config load via `m_RenderView*` initialization. 
- Instrument `Hooks::dRenderView` in `hooks.cpp` to increment per-frame counters, record distinct `clearFlags`/`whatToDraw` samples via `rvAddSpamEntry`, and early-return when the VR eyes were already rendered while still tracking extras. 
- Emit sorted top-entry diagnostics to `Game::logMsg` and optional in-game overlays throttled by `m_RenderViewSpamLogIntervalSec`, and reset per-frame counters when a new VR frame starts.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d150d2a088321868ce99348678499)