### PR TITLE
Add client-side DispatchEffect hook and effect filtering with budget

### DIFF
--- a/L4D2VR/hooks.h
+++ b/L4D2VR/hooks.h
@@ -15,9 +15,9 @@ class ModelRenderInfo_t;
 
 template <typename T>
 struct Hook {
-	T fOriginal;
-	LPVOID pTarget;
-	bool isEnabled;
+	T fOriginal = nullptr;
+	LPVOID pTarget = nullptr;
+	bool isEnabled = false;
 
 	int createHook(LPVOID targetFunc, LPVOID detourFunc)
 	{
@@ -83,6 +83,10 @@ typedef void(__thiscall* tPopRenderTargetAndViewport)(void* thisptr);
 typedef void(__thiscall* tVgui_Paint)(void* thisptr, int mode);
 typedef int(__cdecl* tIsSplitScreen)();
 typedef DWORD* (__thiscall* tPrePushRenderTarget)(void* thisptr, int a2);
+// Client-side effect dispatch (temp entities -> effects)
+// Source signature: DispatchEffect( const char* pName, const CEffectData& data )
+// We treat CEffectData as opaque and only filter by name.
+typedef void(__cdecl* tDispatchEffect)(const char* pName, const void* pData);
 
 
 class Hooks
@@ -119,6 +123,7 @@ public:
 	static inline Hook<tVgui_Paint> hkVgui_Paint;
 	static inline Hook<tIsSplitScreen> hkIsSplitScreen;
 	static inline Hook<tPrePushRenderTarget> hkPrePushRenderTarget;
+	static inline Hook<tDispatchEffect> hkDispatchEffect;
 	static bool s_ServerUnderstandsVR;
 
 	Hooks() {};
@@ -157,6 +162,10 @@ public:
 	static void __fastcall dVGui_Paint(void* ecx, void* edx, int mode);
 	static int __fastcall dIsSplitScreen();
 	static DWORD* __fastcall dPrePushRenderTarget(void* ecx, void* edx, int a2);
+	static void __cdecl dDispatchEffect(const char* pName, const void* pData);
+
+	// Monotonic frame counter (incremented in dVGui_Paint/dEndFrame). Useful for per-frame budgets.
+	static inline unsigned long long s_FrameId = 0;
 
 	static inline int m_PushHUDStep;
 	static inline bool m_PushedHud;

--- a/L4D2VR/offsets.h
+++ b/L4D2VR/offsets.h
@@ -6,10 +6,10 @@
 struct Offset
 {
     std::string moduleName;
-    int offset;
-    int address;
+    int offset = 0;
+    int address = 0;
     std::string signature;
-    int sigOffset;
+    int sigOffset = 0;
 
     Offset(std::string moduleName, int currentOffset, std::string signature, int sigOffset = 0)
     {
@@ -27,6 +27,7 @@ struct Offset
         if (newOffset == -1)
         {
             Game::errorMsg(("Signature not found: " + signature).c_str());
+            this->address = 0;
             return;
         }
 
@@ -49,6 +50,10 @@ public:
     Offset GetMeleeWeaponInfoClient =    { "client.dll", 0x30B570, "8B 81 ? ? ? ? 50 B9 ? ? ? ? E8 ? ? ? ? C3" };
     Offset IsSplitScreen =               { "client.dll", 0x1B2A60, "33 C0 83 3D ? ? ? ? ? 0F 9D C0" };
     Offset PrePushRenderTarget =         { "client.dll", 0xA8C80, "55 8B EC 8B C1 56 8B 75 08 8B 0E 89 08 8B 56 04 89" };
+
+    // Client-side effects (temp entities / effect dispatch)
+    // NOTE: Signature may drift between builds. If this fails to resolve, effect filtering is simply disabled.
+    Offset DispatchEffect =              { "client.dll", 0x0, "55 8B EC 83 EC ? 56 8B F1 8B 0D ? ? ? ? 57" };
 
     Offset ServerFireTerrorBullets =     { "server.dll", 0x3C3FC0, "55 8B EC 81 EC ? ? ? ? A1 ? ? ? ? 33 C5 89 45 FC 8B 45 08 8B 4D 10" };
     Offset ReadUserCmd =                 { "server.dll", 0x205100, "55 8B EC 53 8B 5D 10 56 57 8B 7D 0C 53" };

--- a/L4D2VR/sigscanner.h
+++ b/L4D2VR/sigscanner.h
@@ -31,19 +31,22 @@ public:
 
 		int patternLen = pattern.size();
 
-		// Check if current offset is good
-		bool offsetMatchesSig = true;
-		for (int i = 0; i < patternLen; ++i)
+		// Check if current offset is good (skip if caller passed an invalid/unknown offset)
+		if (currentOffset > 0)
 		{
-			if ( (bytes[currentOffset - sigOffset + i] != pattern[i]) && (pattern[i] != -1) )
+			bool offsetMatchesSig = true;
+			for (int i = 0; i < patternLen; ++i)
 			{
-				offsetMatchesSig = false;
-				break;
+				if ((bytes[currentOffset - sigOffset + i] != pattern[i]) && (pattern[i] != -1))
+				{
+					offsetMatchesSig = false;
+					break;
+				}
 			}
-		}
 
-		if (offsetMatchesSig)
-			return 0;
+			if (offsetMatchesSig)
+				return 0;
+		}
 
 		// Scan the dll for new offset
 		for (int i = 0; i < moduleInfo.SizeOfImage; ++i)

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -6016,6 +6016,26 @@ void VR::ParseConfigFile()
     m_ThrowArcLandingOffset = std::max(-10000.0f, std::min(10000.0f, getFloat("ThrowArcLandingOffset", m_ThrowArcLandingOffset)));
     m_ThrowArcMaxHz = std::max(0.0f, getFloat("ThrowArcMaxHz", m_ThrowArcMaxHz));
 
+    // Effect filtering (client-side temp entities / DispatchEffect)
+    m_EffectFilterEnabled = getBool("EffectFilterEnabled", m_EffectFilterEnabled);
+    m_EffectFilterLog = getBool("EffectFilterLog", m_EffectFilterLog);
+    m_EffectFilterMaxPerFrame = std::max(0, getInt("EffectFilterMaxPerFrame", m_EffectFilterMaxPerFrame));
+    m_EffectFilterDenyList = getString("EffectFilterDenyList", m_EffectFilterDenyList);
+    m_EffectFilterDenyTokens.clear();
+    if (!m_EffectFilterDenyList.empty())
+    {
+        std::stringstream ss(m_EffectFilterDenyList);
+        std::string token;
+        while (std::getline(ss, token, ','))
+        {
+            trim(token);
+            if (token.empty()) continue;
+            std::transform(token.begin(), token.end(), token.begin(),
+                [](unsigned char c) { return (char)std::tolower(c); });
+            m_EffectFilterDenyTokens.push_back(token);
+        }
+    }
+
     // Gun-mounted scope
     m_ScopeEnabled = getBool("ScopeEnabled", m_ScopeEnabled);
     m_ScopeRTTSize = std::clamp(getInt("ScopeRTTSize", m_ScopeRTTSize), 128, 4096);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -215,6 +215,13 @@ public:
 	float m_SpecialInfectedOverlayMaxHz = 20.0f; // caps arrow drawing + prewarning refresh per entity
 	float m_SpecialInfectedTraceMaxHz = 15.0f;   // caps TraceRay per entity
 
+	// --- Effect filtering (client-side temp entities / DispatchEffect) ---
+	bool m_EffectFilterEnabled = false;
+	bool m_EffectFilterLog = false;              // log effect names (for building deny list)
+	int  m_EffectFilterMaxPerFrame = 0;          // 0 = unlimited
+	std::string m_EffectFilterDenyList;          // comma-separated keywords/effect names
+	std::vector<std::string> m_EffectFilterDenyTokens;
+
 	std::chrono::steady_clock::time_point m_LastAimLineDrawTime{};
 	std::chrono::steady_clock::time_point m_LastThrowArcDrawTime{};
 	mutable std::unordered_map<int, std::chrono::steady_clock::time_point> m_LastSpecialInfectedOverlayTime{};


### PR DESCRIPTION
### Motivation
- Reduce noisy client-side temp-entity effects by providing an opt-in filter that can deny effects by name and cap effects per frame. 
- Harden signature/offset handling so optional hooks can safely be skipped when signatures drift or offsets are unknown. 

### Description
- Add an optional `DispatchEffect` offset and make `Offset` fields default-initialized and set `address = 0` when signature lookup fails so hooks may be skipped safely (`offsets.h`, `sigscanner.h`).
- Introduce a `tDispatchEffect` typedef, `hkDispatchEffect` hook slot and a `dDispatchEffect` detour that applies deny-list matching, per-frame budget, and optional unique-name logging before calling the original (`hooks.h`, `hooks.cpp`).
- Track a monotonic frame counter `s_FrameId` (incremented in `dEndFrame` and from a best-effort marker in `dVGui_Paint`) to reset per-frame budgets (`hooks.h`, `hooks.cpp`).
- Harden `Hook<T>` members with safe defaults (`fOriginal = nullptr`, `pTarget = nullptr`, `isEnabled = false`) and conditionally enable the `DispatchEffect` hook only when its address resolves (`hooks.h`, `hooks.cpp`).
- Add configuration/state for effect filtering to the `VR` class and parse a comma-separated deny list into lowercase tokens at config load (`vr.h`, `vr.cpp`).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d75af83408321bbcafa2dc01836f1)