### PR TITLE
Add RenderView draw mask configuration controls

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -5612,6 +5612,13 @@ void VR::ParseConfigFile()
         try { return std::stoi(it->second); }
         catch (...) { return defVal; }
         };
+    // Like getInt(), but supports 0x... hex (base=0). Useful for bitmasks.
+    auto getIntAnyBase = [&](const char* k, int defVal)->int {
+        auto it = userConfig.find(k);
+        if (it == userConfig.end() || it->second.empty()) return defVal;
+        try { return std::stoi(it->second, nullptr, 0); }
+        catch (...) { return defVal; }
+        };
     auto getColor = [&](const char* k, int defR, int defG, int defB, int defA)->std::array<int, 4> {
         std::array<int, 4> defaults{ defR, defG, defB, defA };
         auto it = userConfig.find(k);
@@ -6215,6 +6222,13 @@ void VR::ParseConfigFile()
     m_SpecialInfectedPreWarningTargetUpdateInterval = std::max(0.0f, getFloat("SpecialInfectedPreWarningTargetUpdateInterval", m_SpecialInfectedPreWarningTargetUpdateInterval));
     m_SpecialInfectedOverlayMaxHz = std::max(0.0f, getFloat("SpecialInfectedOverlayMaxHz", m_SpecialInfectedOverlayMaxHz));
     m_SpecialInfectedTraceMaxHz = std::max(0.0f, getFloat("SpecialInfectedTraceMaxHz", m_SpecialInfectedTraceMaxHz));
+    // RenderView draw-mask (experimental): AND/OR whatToDraw to skip draw categories.
+    // Use -1/0 (defaults) for no change. Accepts hex (0x...).
+    m_RenderViewWhatToDrawAndMask = getIntAnyBase("RenderViewWhatToDrawAndMask", m_RenderViewWhatToDrawAndMask);
+    m_RenderViewWhatToDrawOrMask = getIntAnyBase("RenderViewWhatToDrawOrMask", m_RenderViewWhatToDrawOrMask);
+    m_OffscreenWhatToDrawAndMask = getIntAnyBase("OffscreenWhatToDrawAndMask", m_OffscreenWhatToDrawAndMask);
+    m_OffscreenWhatToDrawOrMask = getIntAnyBase("OffscreenWhatToDrawOrMask", m_OffscreenWhatToDrawOrMask);
+    m_RenderViewMaskDebug = getBool("RenderViewMaskDebug", m_RenderViewMaskDebug);
     const float preWarningAimAngle = getFloat("SpecialInfectedPreWarningAimAngle", m_SpecialInfectedPreWarningAimAngle);
     m_SpecialInfectedPreWarningAimAngle = m_SpecialInfectedDebug
         ? std::max(0.0f, preWarningAimAngle)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -215,6 +215,16 @@ public:
 	float m_SpecialInfectedOverlayMaxHz = 20.0f; // caps arrow drawing + prewarning refresh per entity
 	float m_SpecialInfectedTraceMaxHz = 15.0f;   // caps TraceRay per entity
 
+	// --- RenderView draw-mask (experimental performance tool) ---
+	// RenderView is called with an engine-defined bitmask (whatToDraw).
+	// We can AND/OR that mask to skip certain categories of drawing.
+	// NOTE: exact bit meanings are branch/game dependent; use RenderViewMaskDebug to inspect values.
+	int m_RenderViewWhatToDrawAndMask = -1;   // applied to main stereo eye renders
+	int m_RenderViewWhatToDrawOrMask = 0;     // applied to main stereo eye renders
+	int m_OffscreenWhatToDrawAndMask = -1;    // applied to offscreen RTT passes (scope/rear-mirror)
+	int m_OffscreenWhatToDrawOrMask = 0;      // applied to offscreen RTT passes (scope/rear-mirror)
+	bool m_RenderViewMaskDebug = false;       // log whatToDraw / masked values (throttled)
+
 	std::chrono::steady_clock::time_point m_LastAimLineDrawTime{};
 	std::chrono::steady_clock::time_point m_LastThrowArcDrawTime{};
 	mutable std::unordered_map<int, std::chrono::steady_clock::time_point> m_LastSpecialInfectedOverlayTime{};


### PR DESCRIPTION
### Motivation
- Add an experimental, runtime-configurable draw-mask to let users AND/OR the engine `whatToDraw` bitmask in order to skip categories of rendering for performance investigation and debugging.

### Description
- Add configuration fields to the `VR` struct: `m_RenderViewWhatToDrawAndMask`, `m_RenderViewWhatToDrawOrMask`, `m_OffscreenWhatToDrawAndMask`, `m_OffscreenWhatToDrawOrMask`, and `m_RenderViewMaskDebug`.
- Add `getIntAnyBase` to `VR::ParseConfigFile()` to parse integer config values (supports `0x...` hex) and read the new mask and debug keys with sensible defaults (`-1`/`0`).
- Apply the masks inside `Hooks::dRenderView` by computing `whatToDrawMain` and `whatToDrawOffscreen` and passing those to `hkRenderView.fOriginal` for stereo eye renders and offscreen RTT passes respectively.
- Add throttled debug logging controlled by `m_RenderViewMaskDebug` that logs the original and masked `whatToDraw` values when they change (rate-limited to ~1s).

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d823a283883218e95094ac4b1d964)