### PR TITLE
Add PerfLowEffectsCvars preset and apply-on-entry hook

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <chrono>
 #include <algorithm>
+#include <atomic>
 #include <limits>
 #include <optional>
 #include <string>
@@ -214,6 +215,13 @@ public:
 	float m_ThrowArcMaxHz = 30.0f;             // caps throw arc overlay calls
 	float m_SpecialInfectedOverlayMaxHz = 20.0f; // caps arrow drawing + prewarning refresh per entity
 	float m_SpecialInfectedTraceMaxHz = 15.0f;   // caps TraceRay per entity
+
+	// --- Performance: client cvar preset to reduce CPU-heavy effects (safe/soft approach) ---
+	// When enabled, we issue a small set of client cvars (decals/dynamic lights/flecks/etc.)
+	// once when entering the game (and whenever the config toggles).
+	bool m_PerfLowEffectsCvars = false;
+	std::atomic<bool> m_PerfLowEffectsCvarsDirty{ false };
+	bool m_PerfWasInGame = false;
 
 	std::chrono::steady_clock::time_point m_LastAimLineDrawTime{};
 	std::chrono::steady_clock::time_point m_LastThrowArcDrawTime{};
@@ -790,6 +798,8 @@ public:
 	int SetActionManifest(const char* fileName);
 	void InstallApplicationManifest(const char* fileName);
 	void Update();
+	void ApplyPerfLowEffectsCvarsIfNeeded();
+	void ApplyPerfLowEffectsCvars();
 	void CreateVRTextures();
 	void HandleMissingRenderContext(const char* location);
 	void SubmitVRTextures();


### PR DESCRIPTION
### Motivation

- Provide a soft, client-side performance preset to reduce CPU-heavy visual effects (decals, dynamic lights, flecks, detail props) when running VR to improve runtime performance.
- Ensure the preset can be toggled from config and is applied safely from the main thread only when entering an in-game session.

### Description

- Added state to `VR` to track the preset and its pending application (`m_PerfLowEffectsCvars`, `m_PerfLowEffectsCvarsDirty`, `m_PerfWasInGame`) and included the header `<atomic>` in `L4D2VR/vr.h`.
- Implemented `ApplyPerfLowEffectsCvarsIfNeeded()` and `ApplyPerfLowEffectsCvars()` in `L4D2VR/vr.cpp`, and invoke `ApplyPerfLowEffectsCvarsIfNeeded()` from `VR::Update()` to apply the preset on in-game entry.
- The preset issues a small list of client commands via `ClientCmd_Unrestricted` (e.g. `r_decals 0`, `r_dynamic 0`, `r_drawflecks 0`, `r_drawdetailprops 0`) and logs application with `Game::logMsg`.
- Wired config parsing in `VR::ParseConfigFile()` to read `PerfLowEffectsCvars` and mark the atomic dirty flag so the preset is re-applied after hot-reloads or when the config key is explicitly set.

### Testing

- No automated tests were executed as part of this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d895678a483219b88088a887dde4b)