### PR TITLE
Add quick-turn impulse handler for CreateMove (impulse 204)

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -926,6 +926,13 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 
 	bool result = hkCreateMove.fOriginal(ecx, flInputSampleTime, cmd);
 
+	// impulse 204 -> QuickTurnCombo (Quick 180° turn)
+	if (cmd && cmd->impulse == Hooks::kImpulseQuickTurnCombo)
+	{
+		Hooks::ApplyQuickTurn180(cmd);
+		cmd->impulse = 0; // consume it
+	}
+
 	if (m_VR->m_IsVREnabled) {
 		const bool treatServerAsNonVR = m_VR->m_ForceNonVRServerMovement;
 

--- a/L4D2VR/hooks.h
+++ b/L4D2VR/hooks.h
@@ -88,6 +88,21 @@ typedef DWORD* (__thiscall* tPrePushRenderTarget)(void* thisptr, int a2);
 class Hooks
 {
 public:
+	// Console: impulse 204 -> QuickTurn (180 deg)
+	static constexpr int kImpulseQuickTurnCombo = 204;
+
+	// Apply a 180° yaw turn to the current usercmd viewangles, normalized to [-180, 180].
+	static inline void ApplyQuickTurn180(CUserCmd* cmd)
+	{
+		if (!cmd)
+			return;
+		cmd->viewangles.y += 180.0f;
+		if (cmd->viewangles.y > 180.0f)
+			cmd->viewangles.y -= 360.0f;
+		else if (cmd->viewangles.y < -180.0f)
+			cmd->viewangles.y += 360.0f;
+	}
+
 	static inline Game* m_Game;
 	static inline VR* m_VR;
 


### PR DESCRIPTION
### Motivation

- Provide a simple console-bindable quick-turn (180° yaw) so players can trigger an instant turn via an impulse, useful for quick orientation adjustments in VR/mouse modes.

### Description

- Add `kImpulseQuickTurnCombo` constant and `ApplyQuickTurn180(CUserCmd*)` helper to `L4D2VR/hooks.h` which applies a 180° yaw and normalizes angles to the `[-180, 180]` range.
- Update `Hooks::dCreateMove` in `L4D2VR/hooks.cpp` to consume `cmd->impulse == Hooks::kImpulseQuickTurnCombo`, call `ApplyQuickTurn180`, and clear the impulse.
- Changes are limited to `L4D2VR/hooks.h` and `L4D2VR/hooks.cpp` and do not alter other input handling logic.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db5380b708321931e00d291fdc92a)