### PR TITLE
Include usercmd definitions in hooks header

### DIFF
--- a/L4D2VR/hooks.h
+++ b/L4D2VR/hooks.h
@@ -1,12 +1,12 @@
 #pragma once
 #include <iostream>
 #include "MinHook.h"
+#include "usercmd.h" // for CUserCmd / QAngle (needed by inline helpers)
 
 class Game;
 class VR;
 class ITexture;
 class CViewSetup;
-class CUserCmd;
 class QAngle;
 class Vector;
 class edict_t;
@@ -91,7 +91,7 @@ public:
 	// Console: impulse 204 -> QuickTurn (180 deg)
 	static constexpr int kImpulseQuickTurnCombo = 204;
 
-	// Apply a 180° yaw turn to the current usercmd viewangles, normalized to [-180, 180].
+	// Apply a 180 deg yaw turn to the current usercmd viewangles, normalized to [-180, 180].
 	static inline void ApplyQuickTurn180(CUserCmd* cmd)
 	{
 		if (!cmd)


### PR DESCRIPTION
### Motivation
- Ensure inline helper functions that reference `CUserCmd`/`QAngle` in `hooks.h` have the proper type definitions and avoid character-encoding issues in comments.

### Description
- Add `#include "usercmd.h"` to `L4D2VR/hooks.h`, remove the now-unneeded forward declaration of `CUserCmd`, and replace the `°` symbol in the QuickTurn comment with `deg`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db82ebbb483219c6996a2118e79eb)