### PR TITLE
Add friendly-fire aim guard toggle

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -1372,6 +1372,13 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 		}
 	}
 
+	// Aim-line friendly-fire guard: if enabled and the aim line is currently hitting a teammate,
+	// suppress primary fire for this tick by clearing IN_ATTACK.
+	if (m_VR->ShouldSuppressPrimaryFire())
+	{
+		cmd->buttons &= ~(1 << 0); // IN_ATTACK
+	}
+
 	return result;
 }
 

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -374,6 +374,8 @@ int VR::SetActionManifest(const char* fileName)
     m_Input->GetActionHandle("/actions/main/in/Pause", &m_Pause);
     m_Input->GetActionHandle("/actions/main/in/NonVRServerMovementAngleToggle", &m_NonVRServerMovementAngleToggle);
     m_Input->GetActionHandle("/actions/main/in/ScopeMagnificationToggle", &m_ActionScopeMagnificationToggle);
+    // Aim-line friendly-fire guard toggle (bindable in SteamVR)
+    m_Input->GetActionHandle("/actions/main/in/FriendlyFireBlockToggle", &m_ActionFriendlyFireBlockToggle);
     m_Input->GetActionHandle("/actions/main/in/CustomAction1", &m_CustomAction1);
     m_Input->GetActionHandle("/actions/main/in/CustomAction2", &m_CustomAction2);
     m_Input->GetActionHandle("/actions/main/in/CustomAction3", &m_CustomAction3);
@@ -2438,6 +2440,14 @@ void VR::ProcessInput()
         m_Game->ClientCmd_Unrestricted("impulse 201");
     }
 
+    // Toggle: suppress primary fire when the aim line is currently hitting a teammate.
+    // This is a pure client-side guard: we simply clear IN_ATTACK in CreateMove.
+    if (PressedDigitalAction(m_ActionFriendlyFireBlockToggle, true))
+    {
+        m_BlockFireOnFriendlyAimEnabled = !m_BlockFireOnFriendlyAimEnabled;
+        Game::logMsg("[VR] Friendly-fire aim guard: %s", m_BlockFireOnFriendlyAimEnabled ? "ON" : "OFF");
+    }
+
     auto isWalkPressCommand = [](const std::string& cmd) -> bool
         {
             // Match the first token only (allow "+walk;..." or "+walk ...").
@@ -3982,7 +3992,10 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     UpdateSpecialInfectedPreWarningState();
 
     if (!m_Game->m_DebugOverlay)
+    {
+        m_AimLineHitsFriendly = false;
         return;
+    }
 
     C_WeaponCSBase* activeWeapon = nullptr;
     if (localPlayer)
@@ -3995,6 +4008,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
         m_HasAimConvergePoint = false;
         m_HasThrowArc = false;
         m_LastAimWasThrowable = false;
+        m_AimLineHitsFriendly = false;
         return;
     }
 
@@ -4036,11 +4050,15 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
             if (m_LastAimWasThrowable && m_HasThrowArc)
             {
                 DrawThrowArcFromCache(duration);
+                m_AimLineHitsFriendly = false;
                 return;
             }
 
             if (!m_HasAimLine)
+            {
+                m_AimLineHitsFriendly = false;
                 return;
+            }
 
             DrawLineWithThickness(m_AimLineStart, m_AimLineEnd, duration);
             return;
@@ -4076,6 +4094,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
 
     if (isThrowable)
     {
+        m_AimLineHitsFriendly = false;
         m_HasAimConvergePoint = false;
 
         Vector pitchSource = direction;
@@ -4118,6 +4137,31 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
         else
         {
             m_HasAimConvergePoint = false;
+        }
+    }
+
+    // Friendly-fire aim guard: see if the aim line currently hits a teammate player.
+    // We intentionally do this even in first-person so it works for normal play.
+    m_AimLineHitsFriendly = false;
+    if (localPlayer && m_Game->m_EngineTrace)
+    {
+        CGameTrace trace;
+        Ray_t ray;
+        CTraceFilterSkipSelf tracefilter((IHandleEntity*)localPlayer, 0);
+
+        ray.Init(origin, target);
+        m_Game->m_EngineTrace->TraceRay(ray, STANDARD_TRACE_MASK, &tracefilter, &trace);
+
+        C_BaseEntity* hitEnt = reinterpret_cast<C_BaseEntity*>(trace.m_pEnt);
+        if (hitEnt && hitEnt != localPlayer && hitEnt->IsPlayer() != nullptr)
+        {
+            const unsigned char* myBase  = reinterpret_cast<const unsigned char*>(localPlayer);
+            const unsigned char* hitBase = reinterpret_cast<const unsigned char*>(hitEnt);
+            const int myTeam  = *reinterpret_cast<const int*>(myBase + kTeamNumOffset);
+            const int hitTeam = *reinterpret_cast<const int*>(hitBase + kTeamNumOffset);
+
+            if (myTeam != 0 && myTeam == hitTeam && IsEntityAlive(hitEnt))
+                m_AimLineHitsFriendly = true;
         }
     }
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -559,6 +559,12 @@ public:
 
 	static constexpr int kZombieClassOffset = 0x1c90;
 	static constexpr int kLifeStateOffset = 0x147;
+	static constexpr int kTeamNumOffset = 0xE4; // DT_BaseEntity::m_iTeamNum
+
+	// Aim-line friendly-fire guard (client-side fire suppression)
+	vr::VRActionHandle_t m_ActionFriendlyFireBlockToggle;
+	bool m_BlockFireOnFriendlyAimEnabled = false; // toggled by SteamVR binding
+	bool m_AimLineHitsFriendly = false;           // updated each frame from aim-line trace
 
 	bool m_SpecialInfectedArrowEnabled = false;
 	bool m_SpecialInfectedDebug = false;
@@ -832,6 +838,8 @@ public:
 	void WaitForConfigUpdate();
 	bool GetWalkAxis(float& x, float& y);
 	void UpdateNonVRAimSolution(C_BasePlayer* localPlayer);
+	// If enabled via SteamVR toggle, block IN_ATTACK when the aim line is currently hitting a teammate.
+	bool ShouldSuppressPrimaryFire() const { return m_BlockFireOnFriendlyAimEnabled && m_AimLineHitsFriendly; }
 	bool m_EncodeVRUsercmd = true;
 	void UpdateAimingLaser(C_BasePlayer* localPlayer);
 	bool ShouldShowAimLine(C_WeaponCSBase* weapon) const;


### PR DESCRIPTION
### Motivation
- Provide a client-side, SteamVR-bindable toggle to guard against firing when the VR aim-line is pointing at a teammate to reduce accidental friendly fire.

### Description
- Added `kTeamNumOffset`, action handle `m_ActionFriendlyFireBlockToggle`, and state flags `m_BlockFireOnFriendlyAimEnabled` / `m_AimLineHitsFriendly` to `L4D2VR/vr.h` and exposed a helper `ShouldSuppressPrimaryFire()`.
- Registered the SteamVR action handle and a toggle in `VR::SetActionManifest` and `VR::ProcessInput` so the guard can be toggled via bindings.
- Traced the aim line in `VR::UpdateAimingLaser` to detect teammate hits and update `m_AimLineHitsFriendly`, and cleared the flag on early exits so it remains accurate per-frame.
- Suppressed primary fire for the current tick by clearing `IN_ATTACK` in `Hooks::dCreateMove` when `ShouldSuppressPrimaryFire()` returns true.
- Modified files: `L4D2VR/vr.h`, `L4D2VR/vr.cpp`, and `L4D2VR/hooks.cpp`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f4baea7948321b0ae2844217d0863)