### PR TITLE
Keep friendly-fire guard active without aim line

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -565,6 +565,7 @@ public:
 	vr::VRActionHandle_t m_ActionFriendlyFireBlockToggle;
 	bool m_BlockFireOnFriendlyAimEnabled = false; // toggled by SteamVR binding
 	bool m_AimLineHitsFriendly = false;           // updated each frame from aim-line trace
+	std::chrono::steady_clock::time_point m_LastFriendlyFireGuardLogTime{};
 	bool m_SpecialInfectedArrowEnabled = false;
 	bool m_SpecialInfectedDebug = false;
 	float m_SpecialInfectedArrowSize = 12.0f;


### PR DESCRIPTION
### Motivation
- Ensure the client-side friendly-fire suppression (aim guard) continues to operate even when the aim line is hidden or the debug overlay is unavailable. 
- Provide optional, throttled debug feedback so developers can confirm the guard is arming and suppressing fire when appropriate.

### Description
- Add `m_LastFriendlyFireGuardLogTime` (`std::chrono::steady_clock::time_point`) to `VR` state to support throttled logging. 
- Extract the aim-ray teammate hit logic into a `computeFriendlyHit` lambda and use it wherever the guard needs to run. 
- Keep the friendly-fire guard active when `ShouldShowAimLine` is false or when `m_Game->m_DebugOverlay` is null and still skip guard for throwable weapons, replicating previous exclusions. 
- Only call `DrawAimLine` when the debug overlay is available and emit a throttled log via `ShouldThrottle` when a friendly hit is detected while the block toggle is enabled.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5d56fe548321aca255ceae62358d)