### PR TITLE
Friendly-fire aim guard: add hysteresis to prevent flicker-induced auto-fire

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -1373,8 +1373,8 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 	}
 	
 	// Aim-line friendly-fire guard: if enabled and the aim line is currently hitting a teammate,
-   // suppress primary fire for this tick by clearing IN_ATTACK.
-	if (m_VR->ShouldSuppressPrimaryFire())
+	// suppress primary fire for this tick by clearing IN_ATTACK.
+	if (m_VR->ShouldSuppressPrimaryFireForCmd(cmd))
 	{
 		cmd->buttons &= ~(1 << 0); // IN_ATTACK
 	}


### PR DESCRIPTION
### Motivation
- The aim-line friendly-fire guard can flicker at hitbox edges and cause repeated press/release edges that turn semi-auto weapons into full-auto while holding the trigger, so add hysteresis to stabilize suppression behavior.
- Make suppression decisions aware of the current `CUserCmd` so held-fire behaviour can be latched/unlatched correctly during input generation.

### Description
- Added a `CUserCmd` forward declaration and an include of `usercmd.h` where needed and introduced hysteresis state in `VR`: `m_FriendlyFireGuardLatched`, `m_FriendlyFireGuardLastFriendlyHit`, and `m_FriendlyFireGuardUnlatchDelaySeconds` in `vr.h`.
- Implemented `bool VR::ShouldSuppressPrimaryFireForCmd(const CUserCmd* cmd)` in `vr.cpp` which latches suppression while the attack button is held and requires a short clean window before unlatching, and resets state when the feature is disabled.
- Fixed throttled debug logging inversion in `UpdateAimingLaser` so guard log messages are emitted at most once per second as intended.
- Updated input handling to call the command-aware suppression API in `Hooks::dCreateMove` and clear `IN_ATTACK` via `cmd->buttons` when suppression is active.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f664446ec832194090cff278a748c)