### PR TITLE
Add `ThirdPersonDefault` option to prefer third-person and reduce camera flicker

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -5409,6 +5409,7 @@ void VR::ParseConfigFile()
     m_IpdScale = getFloat("IPDScale", m_IpdScale);
     m_ThirdPersonVRCameraOffset = std::max(0.0f, getFloat("ThirdPersonVRCameraOffset", m_ThirdPersonVRCameraOffset));
     m_ThirdPersonRenderOnCustomWalk = getBool("ThirdPersonRenderOnCustomWalk", m_ThirdPersonRenderOnCustomWalk);
+    m_ThirdPersonDefault = getBool("ThirdPersonDefault", m_ThirdPersonDefault);
     m_HideArms = getBool("HideArms", m_HideArms);
     m_HudDistance = getFloat("HudDistance", m_HudDistance);
     m_HudSize = getFloat("HudSize", m_HudSize);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -133,6 +133,9 @@ public:
 	// (e.g. slide mods that switch to 3P while +walk is held).
 	bool m_CustomWalkHeld = false;
 	bool m_ThirdPersonRenderOnCustomWalk = false;
+	// If enabled, render in third-person by default to avoid camera mode flicker.
+	// Only a small whitelist of explicitly-handled cases will remain first-person.
+	bool m_ThirdPersonDefault = false;
 	bool m_ObserverThirdPerson = false;
 	int m_ThirdPersonHoldFrames = 0;
 	Vector m_ThirdPersonViewOrigin = { 0,0,0 };


### PR DESCRIPTION
### Motivation
- Prevent camera-mode flicker in VR by allowing third-person to be the default rendering mode when desired.
- Handle mods that temporarily change the engine view entity (e.g. VScript slide mods) which can produce camera offsets that look wrong in VR.

### Description
- Add `bool m_ThirdPersonDefault` to `VR` state in `L4D2VR/vr.h` to expose a configurable default third-person flag.
- Read the new setting via `m_ThirdPersonDefault = getBool("ThirdPersonDefault", m_ThirdPersonDefault);` in `L4D2VR/vr.cpp`.
- Update `L4D2VR/hooks.cpp` to detect `m_hViewEntity` overrides and introduce a camera policy that either honors engine/state detection or, when `m_ThirdPersonDefault` is enabled, renders third-person except for explicitly whitelisted first-person cases such as revive and view-entity override, and clear stale hold-frames when forcing default 3P.
- Move and reuse the `hasViewEntityOverride` check to avoid borrowing `setup.origin.z` when an override is present and to keep third-person decision logic consistent.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff34354b08321be20b6987dbc2dff)