### PR TITLE
Add explicit-only third-person mode toggle

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -5409,6 +5409,7 @@ void VR::ParseConfigFile()
     m_IpdScale = getFloat("IPDScale", m_IpdScale);
     m_ThirdPersonVRCameraOffset = std::max(0.0f, getFloat("ThirdPersonVRCameraOffset", m_ThirdPersonVRCameraOffset));
     m_ThirdPersonRenderOnCustomWalk = getBool("ThirdPersonRenderOnCustomWalk", m_ThirdPersonRenderOnCustomWalk);
+    m_ThirdPersonExplicitOnly = getBool("ThirdPersonExplicitOnly", m_ThirdPersonExplicitOnly);
     m_HideArms = getBool("HideArms", m_HideArms);
     m_HudDistance = getFloat("HudDistance", m_HudDistance);
     m_HudSize = getFloat("HudSize", m_HudSize);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -133,6 +133,10 @@ public:
 	// (e.g. slide mods that switch to 3P while +walk is held).
 	bool m_CustomWalkHeld = false;
 	bool m_ThirdPersonRenderOnCustomWalk = false;
+	// If enabled, third-person rendering will only activate for explicitly handled cases
+	// (e.g. pinned/controlled states or custom +walk helpers). Any unknown/unhandled cases
+	// will stay in first-person to reduce 1P/3P flicker.
+	bool m_ThirdPersonExplicitOnly = false;
 	bool m_ObserverThirdPerson = false;
 	int m_ThirdPersonHoldFrames = 0;
 	Vector m_ThirdPersonViewOrigin = { 0,0,0 };


### PR DESCRIPTION
### Motivation

- Reduce 1P/3P flicker by giving an option to only enable third-person rendering for explicitly handled cases (state locks and custom +walk helpers).
- Provide a configuration toggle so users can opt into conservative third-person activation without changing existing heuristics by default.

### Description

- Add a new member `m_ThirdPersonExplicitOnly` to `VR` state in `L4D2VR/vr.h` with a descriptive comment.  
- Expose the new `ThirdPersonExplicitOnly` option in `L4D2VR/vr.cpp` via `getBool("ThirdPersonExplicitOnly", ...)` so it is loaded from config.  
- Update third-person logic in `L4D2VR/hooks.cpp` to skip the geometric `engineThirdPersonNow` heuristic when explicit-only mode is active, adjust hold-frame decrement behavior, and make `renderThirdPerson` respect the explicit-only setting.  

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff833a1f4832196a5722ded534ee6)