### PR TITLE
Refine third-person default policy

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -623,11 +623,14 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	bool renderThirdPerson = false;
 	if (m_VR->m_ThirdPersonDefault)
 	{
-		// Keep first-person only for explicitly handled cases where third-person is known to be problematic.
-		const bool explicitFirstPerson = playerReviving || hasViewEntityOverride;
+		// Policy: ONLY fall back to third-person when we're not in any explicitly-known first-person state.
+		// The bug we want to avoid: enabling ThirdPersonDefault shouldn't turn normal first-person gameplay
+		// (or "倒地" / incapacitated) into third-person rendering.
+		const bool isIncap = tpStateDbg.incap;
+		const bool explicitlyNormalFirstPerson =
+			!engineThirdPersonNow && !customWalkThirdPersonNow && !stateWantsThirdPerson && (m_VR->m_ThirdPersonHoldFrames <= 0);
+		const bool explicitFirstPerson = playerReviving || hasViewEntityOverride || isIncap || explicitlyNormalFirstPerson;
 		renderThirdPerson = !explicitFirstPerson;
-		// When forcing default-3P, don't let stale hold-frames keep us stuck.
-		m_VR->m_ThirdPersonHoldFrames = 0;
 	}
 	else
 	{


### PR DESCRIPTION
### Motivation
- Avoid ThirdPersonDefault from accidentally switching normal first-person gameplay or incapacitated states into third-person and make the intended policy explicit.

### Description
- Update `L4D2VR/hooks.cpp` so that when `m_VR->m_ThirdPersonDefault` is enabled the code treats `playerReviving`, `hasViewEntityOverride`, incapacitation (`tpStateDbg.incap`), and an explicit "normal first-person" check (`!engineThirdPersonNow && !customWalkThirdPersonNow && !stateWantsThirdPerson && (m_VR->m_ThirdPersonHoldFrames <= 0)`) as explicit first-person cases and only enables third-person when none apply, and remove the previous forced reset of `m_ThirdPersonHoldFrames`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ffb7d62248321a76b64f50bee99ec)