### PR TITLE
See-through friendly-fire trace for pinned teammates

### DIFF
--- a/L4D2VR/sdk/trace.h
+++ b/L4D2VR/sdk/trace.h
@@ -210,10 +210,10 @@ public:
 class CTraceFilterSkipSelf : public CTraceFilter
 {
 public:
-	CTraceFilterSkipSelf(IHandleEntity* passentity, int collisionGroup)
-		: CTraceFilter(passentity, collisionGroup)
-	{
-	}
+    CTraceFilterSkipSelf(IHandleEntity* passentity, int collisionGroup)
+        : CTraceFilter(passentity, collisionGroup)
+    {
+    }
 
 	virtual bool ShouldHitEntity(IHandleEntity* pServerEntity, int contentsMask)
 	{
@@ -224,7 +224,33 @@ public:
 			return false;
 
 		return true;
-	}
+    }
+};
+
+// Skip two specific entities (typically the local player + one more).
+// Useful when you want to "see through" a teammate hit to find what is behind them.
+class CTraceFilterSkipTwoEntities : public CTraceFilter
+{
+public:
+    CTraceFilterSkipTwoEntities(IHandleEntity* passentity, IHandleEntity* skipentity, int collisionGroup)
+        : CTraceFilter(passentity, collisionGroup)
+        , m_pSkipEnt(skipentity)
+    {
+    }
+
+    virtual bool ShouldHitEntity(IHandleEntity* pServerEntity, int contentsMask)
+    {
+        if (!pServerEntity)
+            return true;
+
+        if (m_pPassEnt == pServerEntity || m_pSkipEnt == pServerEntity)
+            return false;
+
+        return true;
+    }
+
+private:
+    IHandleEntity* m_pSkipEnt;
 };
 
 class CTraceFilterSkipNPCsAndEntity : public CTraceFilter

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -561,9 +561,9 @@ public:
 		Count
 	};
 
-	static constexpr int kZombieClassOffset = 0x1c90;
-	static constexpr int kLifeStateOffset = 0x147;
-	static constexpr int kTeamNumOffset = 0xE4; // DT_BaseEntity::m_iTeamNum
+    static constexpr int kZombieClassOffset = 0x1c90;
+    static constexpr int kLifeStateOffset = 0x147;
+    static constexpr int kTeamNumOffset = 0xE4; // DT_BaseEntity::m_iTeamNum
 
 	// Aim-line friendly-fire guard (client-side fire suppression)
 	vr::VRActionHandle_t m_ActionFriendlyFireBlockToggle;
@@ -571,7 +571,18 @@ public:
 	bool m_AimLineHitsFriendly = false;           // updated from a ray trace (aim ray)
 	std::chrono::steady_clock::time_point m_LastFriendlyFireGuardLogTime{};
 	// Latch suppression while attack is held (prevents flicker causing intermittent firing).
-	bool m_FriendlyFireGuardLatched = false;
+    bool m_FriendlyFireGuardLatched = false;
+
+    // CTerrorPlayer netvars (from offsets.txt). These are used for a special-case in the
+    // friendly-fire aim guard: if the aim ray hits a teammate who is currently pinned/
+    // controlled, we allow a "see-through" trace to hit the attacker behind them.
+    // NOTE: These offsets can change between game builds.
+    static constexpr int kIsIncapacitatedOffset = 0x1EA9; // DT_TerrorPlayer::m_isIncapacitated
+    static constexpr int kTongueOwnerOffset     = 0x1F6C; // DT_TerrorPlayer::m_tongueOwner
+    static constexpr int kPummelAttackerOffset  = 0x2720; // DT_TerrorPlayer::m_pummelAttacker
+    static constexpr int kCarryAttackerOffset   = 0x2714; // DT_TerrorPlayer::m_carryAttacker
+    static constexpr int kPounceAttackerOffset  = 0x272C; // DT_TerrorPlayer::m_pounceAttacker
+    static constexpr int kJockeyAttackerOffset  = 0x274C; // DT_TerrorPlayer::m_jockeyAttacker
 	bool m_SpecialInfectedArrowEnabled = false;
 	bool m_SpecialInfectedDebug = false;
 	float m_SpecialInfectedArrowSize = 12.0f;


### PR DESCRIPTION
### Motivation
- Improve the aim-line friendly-fire guard so players can shoot attackers who are pinning/controlling teammates instead of being blocked by the teammate's body.
- Provide a trace helper that can ignore two entities for second-pass traces used in the special-case logic.

### Description
- Added `CTraceFilterSkipTwoEntities` to `L4D2VR/sdk/trace.h` to allow traces that skip both the local player and one additional entity.
- Added CTerrorPlayer netvar offsets in `L4D2VR/vr.h` (`kIsIncapacitatedOffset`, `kTongueOwnerOffset`, `kPummelAttackerOffset`, `kCarryAttackerOffset`, `kPounceAttackerOffset`, `kJockeyAttackerOffset`) for detecting pinned/controlled teammate states.
- Updated `VR::UpdateFriendlyFireAimHit` in `L4D2VR/vr.cpp` to read those netvars via byte/handle checks and, when a teammate is pinned/controlled, perform a second trace using `CTraceFilterSkipTwoEntities` to see if an attacker (other-team player) or an alive NPC is behind the teammate; the guard allows firing if the second trace hits a hostile target.
- Introduced helper lambdas `hasValidHandle`, `isPinnedOrControlledTeammate`, and `isSameTeamAlivePlayer` to encapsulate netvar and team checks.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970181114cc8321b9267956219c7842)