### PR TITLE
Auto-reset tracking origin shortly after level load

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -565,11 +565,18 @@ public:
 	bool m_BlockFireOnFriendlyAimEnabled = false; // toggled by SteamVR binding
 	bool m_AimLineHitsFriendly = false;           // updated from a ray trace (aim ray)
 	std::chrono::steady_clock::time_point m_LastFriendlyFireGuardLogTime{};
-	// Latch suppression while attack is held (prevents flicker causing intermittent firing).
-	bool m_FriendlyFireGuardLatched = false;
+    // Latch suppression while attack is held (prevents flicker causing intermittent firing).
+    bool m_FriendlyFireGuardLatched = false;
 
-	// CTerrorPlayer netvars (from offsets.txt). These are used for a special-case in the
-	// friendly-fire aim guard: if the aim ray hits a teammate who is currently pinned/
+    // Auto ResetPosition after a level finishes loading.
+    // Config: AutoResetPositionAfterLoadSeconds (0 disables)
+    float m_AutoResetPositionAfterLoadSeconds = 5.0f;
+    bool m_AutoResetPositionPending = false;
+    std::chrono::steady_clock::time_point m_AutoResetPositionDueTime{};
+    bool m_AutoResetHadLocalPlayerPrev = false;
+
+    // CTerrorPlayer netvars (from offsets.txt). These are used for a special-case in the
+    // friendly-fire aim guard: if the aim ray hits a teammate who is currently pinned/
 	// controlled, we allow a "see-through" trace to hit the attacker behind them.
 	// NOTE: These offsets can change between game builds.
 	static constexpr int kIsIncapacitatedOffset = 0x1EA9; // DT_TerrorPlayer::m_isIncapacitated


### PR DESCRIPTION
### Motivation
- Ensure the VR tracking origin is automatically reset shortly after a level finishes loading so the player is correctly centered once the local player entity appears. 
- Provide a configurable delay so the reset can be deferred for maps or load sequences that require a short wait.

### Description
- Added member state to `VR` to track the auto-reset feature: `m_AutoResetPositionAfterLoadSeconds`, `m_AutoResetPositionPending`, `m_AutoResetPositionDueTime`, and `m_AutoResetHadLocalPlayerPrev` in `vr.h`.
- Implemented scheduling logic in `VR::Update()` that detects when the local player entity first becomes available and schedules a delayed call to `ResetPosition()` after the configured delay.
- Wired the configuration key into `VR::ParseConfigFile()` by reading `AutoResetPositionAfterLoadSeconds` with `getFloat(...)` and clamping it to `0.0f..60.0f` (0 disables).
- Uses `std::chrono::steady_clock` to compute the due time and to perform the delayed trigger when the due time is reached.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ad7bfb5c832192c5ed0f9fe9a52a)