### PR TITLE
Skip mounted gun entities in aim traces

### DIFF
--- a/L4D2VR/sdk/trace.h
+++ b/L4D2VR/sdk/trace.h
@@ -250,8 +250,37 @@ public:
     }
 
 private:
-    IHandleEntity* m_pSkipEnt;
+	IHandleEntity* m_pSkipEnt;
 };
+
+// Skip three specific entities (typically: local player + two additional entities).
+// Useful when you need to "see through" more than one blocker in a single trace.
+class CTraceFilterSkipThreeEntities : public CTraceFilter
+{
+public:
+	CTraceFilterSkipThreeEntities(IHandleEntity* passentity, IHandleEntity* skipentity1, IHandleEntity* skipentity2, int collisionGroup)
+		: CTraceFilter(passentity, collisionGroup)
+		, m_pSkipEnt1(skipentity1)
+		, m_pSkipEnt2(skipentity2)
+	{
+	}
+
+	virtual bool ShouldHitEntity(IHandleEntity* pServerEntity, int contentsMask)
+	{
+		if (!pServerEntity)
+			return true;
+
+		if (m_pPassEnt == pServerEntity || m_pSkipEnt1 == pServerEntity || m_pSkipEnt2 == pServerEntity)
+			return false;
+
+		return true;
+	}
+
+private:
+	IHandleEntity* m_pSkipEnt1;
+	IHandleEntity* m_pSkipEnt2;
+};
+
 
 class CTraceFilterSkipNPCsAndEntity : public CTraceFilter
 {

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -3964,7 +3964,7 @@ void VR::UpdateNonVRAimSolution(C_BasePlayer* localPlayer)
         Ray_t rayH;
 		CTraceFilterSkipSelf tracefilterSelf((IHandleEntity*)localPlayer, 0);
 		CTraceFilterSkipTwoEntities tracefilterTwo((IHandleEntity*)localPlayer, (IHandleEntity*)mountedUseEnt, 0);
-		ITraceFilter* pTraceFilter = mountedUseEnt ? static_cast<ITraceFilter*>(&tracefilterTwo) : static_cast<ITraceFilter*>(&tracefilterSelf);
+		CTraceFilter* pTraceFilter = mountedUseEnt ? static_cast<CTraceFilter*>(&tracefilterTwo) : static_cast<CTraceFilter*>(&tracefilterSelf);
         rayH.Init(eye, endEye);
         m_Game->m_EngineTrace->TraceRay(rayH, STANDARD_TRACE_MASK, pTraceFilter, &traceH);
 
@@ -4012,7 +4012,7 @@ void VR::UpdateNonVRAimSolution(C_BasePlayer* localPlayer)
     Ray_t rayP;
 	CTraceFilterSkipSelf tracefilterSelf((IHandleEntity*)localPlayer, 0);
 	CTraceFilterSkipTwoEntities tracefilterTwo((IHandleEntity*)localPlayer, (IHandleEntity*)mountedUseEnt, 0);
-	ITraceFilter* pTraceFilter = mountedUseEnt ? static_cast<ITraceFilter*>(&tracefilterTwo) : static_cast<ITraceFilter*>(&tracefilterSelf);
+	CTraceFilter* pTraceFilter = mountedUseEnt ? static_cast<CTraceFilter*>(&tracefilterTwo) : static_cast<CTraceFilter*>(&tracefilterSelf);
     rayP.Init(origin, target);
     m_Game->m_EngineTrace->TraceRay(rayP, STANDARD_TRACE_MASK, pTraceFilter, &traceP);
 
@@ -4109,7 +4109,7 @@ bool VR::UpdateFriendlyFireAimHit(C_BasePlayer* localPlayer)
     Ray_t ray;
 	CTraceFilterSkipSelf tracefilterSelf((IHandleEntity*)localPlayer, 0);
 	CTraceFilterSkipTwoEntities tracefilterTwo((IHandleEntity*)localPlayer, (IHandleEntity*)mountedUseEnt, 0);
-	ITraceFilter* pTraceFilter = mountedUseEnt ? static_cast<ITraceFilter*>(&tracefilterTwo) : static_cast<ITraceFilter*>(&tracefilterSelf);
+	CTraceFilter* pTraceFilter = mountedUseEnt ? static_cast<CTraceFilter*>(&tracefilterTwo) : static_cast<CTraceFilter*>(&tracefilterSelf);
     ray.Init(origin, end);
     m_Game->m_EngineTrace->TraceRay(ray, STANDARD_TRACE_MASK, pTraceFilter, &trace);
 
@@ -4170,11 +4170,11 @@ bool VR::UpdateFriendlyFireAimHit(C_BasePlayer* localPlayer)
             Ray_t ray2;
 			// If we're on a mounted gun, also skip the mounted gun entity itself so we can "see through"
 			// both the teammate and the turret when checking what's behind them.
-            CTraceFilterSkipTwoEntities tracefilter2((IHandleEntity*)localPlayer, (IHandleEntity*)hitEnt, 0);
+			CTraceFilterSkipTwoEntities tracefilter2((IHandleEntity*)localPlayer, (IHandleEntity*)hitEnt, 0);
 			CTraceFilterSkipThreeEntities tracefilter3((IHandleEntity*)localPlayer, (IHandleEntity*)hitEnt, (IHandleEntity*)mountedUseEnt, 0);
-			ITraceFilter* pTraceFilter2 = (mountedUseEnt && mountedUseEnt != hitEnt)
-				? static_cast<ITraceFilter*>(&tracefilter3)
-				: static_cast<ITraceFilter*>(&tracefilter2);
+			CTraceFilter* pTraceFilter2 = (mountedUseEnt && mountedUseEnt != hitEnt)
+				? static_cast<CTraceFilter*>(&tracefilter3)
+				: static_cast<CTraceFilter*>(&tracefilter2);
             ray2.Init(origin, end);
             m_Game->m_EngineTrace->TraceRay(ray2, STANDARD_TRACE_MASK, pTraceFilter2, &trace2);
 
@@ -4386,7 +4386,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
 			C_BaseEntity* mountedUseEnt = GetMountedGunUseEntity(localPlayer);
             CTraceFilterSkipSelf tracefilterSelf((IHandleEntity*)localPlayer, 0);
             CTraceFilterSkipTwoEntities tracefilterTwo((IHandleEntity*)localPlayer, (IHandleEntity*)mountedUseEnt, 0);
-            ITraceFilter* pTraceFilter = mountedUseEnt ? static_cast<ITraceFilter*>(&tracefilterTwo) : static_cast<ITraceFilter*>(&tracefilterSelf);
+            CTraceFilter* pTraceFilter = mountedUseEnt ? static_cast<CTraceFilter*>(&tracefilterTwo) : static_cast<CTraceFilter*>(&tracefilterSelf);
 
             ray.Init(origin, target);
             m_Game->m_EngineTrace->TraceRay(ray, STANDARD_TRACE_MASK, pTraceFilter, &trace);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -585,6 +585,13 @@ public:
 	static constexpr int kCarryAttackerOffset = 0x2714; // DT_TerrorPlayer::m_carryAttacker
 	static constexpr int kPounceAttackerOffset = 0x272C; // DT_TerrorPlayer::m_pounceAttacker
 	static constexpr int kJockeyAttackerOffset = 0x274C; // DT_TerrorPlayer::m_jockeyAttacker
+	// Mounted gun (fixed machine-gun / turret) support:
+	// When the player is using a mounted gun, their aim ray can intersect the gun/base itself,
+	// causing the aim line + third-person convergence point to jitter wildly.
+	// We treat the mounted-gun entity as "transparent" for aim traces by skipping the current use-entity.
+	// NOTE: These offsets can change between game builds.
+	static constexpr int kUsingMountedGunOffset = 0x1EBA;  // DT_TerrorPlayer::m_usingMountedGun
+	static constexpr int kUseEntityHandleOffset = 0x1480;  // DT_BasePlayer::m_hUseEntity
 	bool m_SpecialInfectedArrowEnabled = false;
 	bool m_SpecialInfectedDebug = false;
 	float m_SpecialInfectedArrowSize = 12.0f;
@@ -864,6 +871,10 @@ public:
 	// ticks and latch suppression until the user releases attack.
 	bool ShouldSuppressPrimaryFire(const CUserCmd* cmd, C_BasePlayer* localPlayer);
 	bool UpdateFriendlyFireAimHit(C_BasePlayer* localPlayer);
+	// Mounted gun helper: returns the entity the player is currently "using" (turret/mounted gun) if any.
+	// Used to skip that entity in aim-related traces so the aim line doesn't collide with the gun platform.
+	bool IsUsingMountedGun(const C_BasePlayer* localPlayer) const;
+	C_BaseEntity* GetMountedGunUseEntity(C_BasePlayer* localPlayer) const;
 	bool m_EncodeVRUsercmd = true;
 	void UpdateAimingLaser(C_BasePlayer* localPlayer);
 	bool ShouldShowAimLine(C_WeaponCSBase* weapon) const;


### PR DESCRIPTION
### Motivation
- Aim rays can intersect mounted guns/turrets the player is currently using, causing the aim line and third-person convergence point to jitter.
- Friendly-fire heuristics need to "see through" teammates and also ignore the mounted gun entity when present so back-traces find the attacker behind a pinned teammate.
- Offsets for these fields are engine-dependent, so the change adds helpers but keeps offset usage localized and documented.

### Description
- Added mounted-gun netvar offsets `kUsingMountedGunOffset` and `kUseEntityHandleOffset` and helper declarations `IsUsingMountedGun` and `GetMountedGunUseEntity` in `vr.h`.
- Implemented `IsUsingMountedGun` and `GetMountedGunUseEntity` in `vr.cpp` to read the use flag and resolve the `m_hUseEntity` handle via the client entity list.
- Added a new trace filter `CTraceFilterSkipThreeEntities` in `sdk/trace.h` to allow skipping up to three entities in a single ray trace.
- Updated multiple aim- and convergence-related traces in `vr.cpp` (e.g. `UpdateNonVRAimSolution`, `UpdateFriendlyFireAimHit`, `UpdateAimingLaser`) to detect the mounted-use entity and select a trace filter that skips the local player and mounted gun when present.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69785bf1591c8321b292b9dd3daf42e5)