### PR TITLE
Add grenade launcher aim arc rendering and config

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -214,6 +214,7 @@ public:
 	std::array<Vector, THROW_ARC_SEGMENTS + 1> m_LastThrowArcPoints{};
 	bool m_HasThrowArc = false;
 	bool m_LastAimWasThrowable = false;
+	bool m_LastAimWasGrenadeLauncher = false;
 	float m_ThrowArcBaseDistance = 500.0f;
 	float m_ThrowArcMinDistance = 20.0f;
 	float m_ThrowArcMaxDistance = 2200.0f;
@@ -233,6 +234,19 @@ public:
 
 	std::chrono::steady_clock::time_point m_LastAimLineDrawTime{};
 	std::chrono::steady_clock::time_point m_LastThrowArcDrawTime{};
+
+	// Grenade launcher (M79) aim parabola (separate tuning from throwables)
+	std::array<Vector, THROW_ARC_SEGMENTS + 1> m_LastGrenadeLauncherArcPoints{};
+	bool m_HasGrenadeLauncherArc = false;
+	bool m_GrenadeLauncherArcEnabled = true;
+	float m_GrenadeLauncherArcBaseDistance = 1400.0f;
+	float m_GrenadeLauncherArcMinDistance = 50.0f;
+	float m_GrenadeLauncherArcMaxDistance = 6000.0f;
+	float m_GrenadeLauncherArcHeightRatio = 0.13f;
+	float m_GrenadeLauncherArcPitchScale = 3.0f;
+	float m_GrenadeLauncherArcLandingOffset = -40.0f;
+	float m_GrenadeLauncherArcMaxHz = 30.0f;
+	std::chrono::steady_clock::time_point m_LastGrenadeLauncherArcDrawTime{};
 	mutable std::unordered_map<int, std::chrono::steady_clock::time_point> m_LastSpecialInfectedOverlayTime{};
 	mutable std::unordered_map<int, std::chrono::steady_clock::time_point> m_LastSpecialInfectedTraceTime{};
 	mutable std::unordered_map<int, bool> m_LastSpecialInfectedTraceResult{};
@@ -922,6 +936,9 @@ public:
 	void DrawAimLine(const Vector& start, const Vector& end);
 	void DrawThrowArc(const Vector& origin, const Vector& forward, const Vector& pitchSource);
 	void DrawThrowArcFromCache(float duration);
+	float CalculateGrenadeLauncherArcDistance(const Vector& pitchSource, bool* clampedToMax = nullptr) const;
+	void DrawGrenadeLauncherArc(const Vector& origin, const Vector& forward, const Vector& pitchSource);
+	void DrawGrenadeLauncherArcFromCache(float duration);
 	void DrawLineWithThickness(const Vector& start, const Vector& end, float duration);
 	SpecialInfectedType GetSpecialInfectedType(const C_BaseEntity* entity) const;
 	SpecialInfectedType GetSpecialInfectedTypeFromModel(const std::string& modelName) const;


### PR DESCRIPTION
### Motivation
- Provide a separate, tunable aim-parabola visualization for the grenade launcher (M79) so its trajectory is rendered differently from throwable items.
- Keep existing friendly-fire guard behavior and aim-line persistence while supporting the new grenade-launcher arc.

### Description
- Added grenade-launcher state and tuning fields to `VR` (`m_LastGrenadeLauncherArcPoints`, `m_HasGrenadeLauncherArc`, tuning params, throttling timepoint, etc.) in `L4D2VR/vr.h`.
- Declared new helper methods in `L4D2VR/vr.h`: `CalculateGrenadeLauncherArcDistance`, `DrawGrenadeLauncherArc`, and `DrawGrenadeLauncherArcFromCache`.
- Implemented grenade-launcher detection and rendering flow in `L4D2VR/vr.cpp`, including aim caching (`m_LastAimWasGrenadeLauncher`), drawing the arc mesh into `m_LastGrenadeLauncherArcPoints`, and a cached draw path throttled by `m_GrenadeLauncherArcMaxHz`.
- Added a distance calculation helper `CalculateGrenadeLauncherArcDistance` and loaded grenade launcher config values in `ParseConfigFile` with bounds/clamping for the new tuning keys (e.g. `GrenadeLauncherArcBaseDistance`, `GrenadeLauncherArcHeightRatio`).

### Testing
- No automated tests were run for this change (no build/test executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ed68cf2548321b3d5713c1e7a1bb6)