### PR TITLE
Add third-person aim line origin toggle

### DIFF
--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -742,7 +742,7 @@ void VR::SubmitVRTextures()
 
                 Vector rayStart = m_RightControllerPosAbs;
                 Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
-                if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
+                if (!m_ThirdPersonAimLineFollowController && m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
                     rayStart += camDelta;
 
                 rayStart = rayStart + dir * 2.0f;
@@ -4114,7 +4114,7 @@ void VR::UpdateNonVRAimSolution(C_BasePlayer* localPlayer)
 
     Vector originBase = m_RightControllerPosAbs;
     Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
-    if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
+    if (!m_ThirdPersonAimLineFollowController && m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
         originBase += camDelta;
 
     Vector origin = originBase + direction * 2.0f;
@@ -4217,7 +4217,7 @@ bool VR::UpdateFriendlyFireAimHit(C_BasePlayer* localPlayer)
 
     Vector gunOriginBase = gunOrigin;
     Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
-    if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
+    if (!m_ThirdPersonAimLineFollowController && m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
         gunOriginBase += camDelta;
 
     Vector gunStart = gunOriginBase + gunDir * 2.0f;
@@ -4541,7 +4541,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
             + (m_HmdUp * (anchor.z * m_VRScale));
     }
     Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
-    if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
+    if (!m_ThirdPersonAimLineFollowController && m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
         originBase += camDelta;
 
     Vector origin = originBase + direction * 2.0f;
@@ -5833,6 +5833,7 @@ void VR::ParseConfigFile()
     m_ViewmodelAdjustEnabled = getBool("ViewmodelAdjustEnabled", m_ViewmodelAdjustEnabled);
     m_AimLineThickness = std::max(0.0f, getFloat("AimLineThickness", m_AimLineThickness));
     m_AimLineEnabled = getBool("AimLineEnabled", m_AimLineEnabled);
+    m_ThirdPersonAimLineFollowController = getBool("ThirdPersonAimLineFollowController", m_ThirdPersonAimLineFollowController);
     m_AimLineConfigEnabled = m_AimLineEnabled;
     m_BlockFireOnFriendlyAimEnabled = getBool("BlockFireOnFriendlyAimEnabled", m_BlockFireOnFriendlyAimEnabled);
     m_AutoRepeatSemiAutoFire = getBool("AutoRepeatSemiAutoFire", m_AutoRepeatSemiAutoFire);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -200,6 +200,10 @@ public:
 	bool m_HasAimLine = false;
 	float m_AimLineThickness = 2.0f;
 	bool m_AimLineEnabled = true;
+	// Third-person aim line origin:
+	//  - false: translate the controller/gun origin into the rendered third-person camera frame (default, line stays near the player model).
+	//  - true : keep the origin in real controller space (behaves like first-person; may look "detached" from the model in third-person).
+	bool m_ThirdPersonAimLineFollowController = false;
 	bool m_AimLineConfigEnabled = true;
 	bool m_ScopeForcingAimLine = false;
 	bool m_MeleeAimLineEnabled = true;


### PR DESCRIPTION
### Motivation
- Add a configurable option to control whether third-person aim-line origins are translated into the rendered third-person camera frame or kept in real controller space to allow either a model-centered or first-person-like aim line behavior.

### Description
- Added a new boolean member `m_ThirdPersonAimLineFollowController` with explanatory comments and default `false` to `vr.h` to represent the new behavior toggle.
- Guarded existing third-person origin translations with `!m_ThirdPersonAimLineFollowController` so the code only applies the camera offset when the option is disabled in `vr.cpp` in the aim-line, non-VR aim, and friendly-fire checks.
- Loaded the new setting from the config via `getBool("ThirdPersonAimLineFollowController", ...)` in `ParseConfigFile` so the option is user-configurable at runtime.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981e22ebeb08321a8b2473b226bde6c)