### PR TITLE
Track third-person VR render camera center for aim/overlay alignment

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -910,6 +910,9 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		Vector camCenter = baseCenter + (fwd * (-eyeZ));
 		if (m_VR->m_ThirdPersonVRCameraOffset > 0.0f)
 			camCenter = camCenter + (fwd * (-m_VR->m_ThirdPersonVRCameraOffset));
+		// Expose the actual VR render camera center used for third-person this frame.
+		// This includes HMD-aim yaw and any VR camera offsets, and is used to keep aim line and overlays aligned.
+		m_VR->m_ThirdPersonRenderCenter = camCenter;
 		leftOrigin = camCenter + (right * (-(ipd * 0.5f)));
 		rightOrigin = camCenter + (right * (+(ipd * 0.5f)));
 	}
@@ -918,6 +921,8 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		// Normal VR first-person
 		leftOrigin = m_VR->GetViewOriginLeft();
 		rightOrigin = m_VR->GetViewOriginRight();
+		// Keep this sane even in 1P (unused there, but prevents stale deltas if 3P toggles).
+		m_VR->m_ThirdPersonRenderCenter = m_VR->m_SetupOrigin;
 	}
 
 	leftEyeView.origin = leftOrigin;

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -741,7 +741,7 @@ void VR::SubmitVRTextures()
                 VectorNormalize(dir);
 
                 Vector rayStart = m_RightControllerPosAbs;
-                Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+                Vector camDelta = m_ThirdPersonRenderCenter - m_SetupOrigin;
                 if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
                     rayStart += camDelta;
 
@@ -4113,7 +4113,7 @@ void VR::UpdateNonVRAimSolution(C_BasePlayer* localPlayer)
     VectorNormalize(direction);
 
     Vector originBase = m_RightControllerPosAbs;
-    Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+    Vector camDelta = m_ThirdPersonRenderCenter - m_SetupOrigin;
     if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
         originBase += camDelta;
 
@@ -4216,7 +4216,7 @@ bool VR::UpdateFriendlyFireAimHit(C_BasePlayer* localPlayer)
     VectorNormalize(gunDir);
 
     Vector gunOriginBase = gunOrigin;
-    Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+    Vector camDelta = m_ThirdPersonRenderCenter - m_SetupOrigin;
     if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
         gunOriginBase += camDelta;
 
@@ -4540,7 +4540,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
             + (m_HmdRight * (anchor.y * m_VRScale))
             + (m_HmdUp * (anchor.z * m_VRScale));
     }
-    Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+    Vector camDelta = m_ThirdPersonRenderCenter - m_SetupOrigin;
     if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
         originBase += camDelta;
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -155,6 +155,9 @@ public:
 	int m_ThirdPersonHoldFrames = 0;
 	Vector m_ThirdPersonViewOrigin = { 0,0,0 };
 	QAngle m_ThirdPersonViewAngles = { 0,0,0 };
+	// Center of the actual VR render camera used this frame (HMD-aimed 3P camera center).
+	// Used to keep aim line / overlays in sync when third-person camera is smoothed.
+	Vector m_ThirdPersonRenderCenter = { 0,0,0 };
 	bool m_ThirdPersonPoseInitialized = false;
 	float m_ThirdPersonCameraSmoothing = 0.85f;
 	float m_ThirdPersonVRCameraOffset = 80.0f;


### PR DESCRIPTION
### Motivation
- Ensure aim lines and overlays use the actual VR-rendered third-person camera position when the 3P camera is smoothed or HMD-aimed to avoid visual mismatches.
- Prevent stale camera deltas when toggling between first- and third-person views.

### Description
- Add `m_ThirdPersonRenderCenter` to `VR` state in `L4D2VR/vr.h` to store the frame's actual VR render camera center.
- Capture and expose the computed third-person `camCenter` during third-person setup in `L4D2VR/hooks.cpp`, and reset it to `m_SetupOrigin` in first-person to avoid stale offsets.
- Replace uses of `m_ThirdPersonViewOrigin` with `m_ThirdPersonRenderCenter` in `L4D2VR/vr.cpp` for aim-line, non-VR aim solution, friendly-fire aim checks, and weapon/throwing origin adjustments so calculations use the rendered camera frame.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982e59da7b48321ac9d17cd11aad275)