### PR TITLE
Add configurable toggle for third-person render-center camera deltas

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -910,6 +910,10 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		Vector camCenter = baseCenter + (fwd * (-eyeZ));
 		if (m_VR->m_ThirdPersonVRCameraOffset > 0.0f)
 			camCenter = camCenter + (fwd * (-m_VR->m_ThirdPersonVRCameraOffset));
+		// Expose the actual VR render camera center used for third-person this frame.
+		// This includes HMD-aim yaw and any VR camera offsets, and is used to keep aim line and overlays aligned.
+		if (m_VR->m_ThirdPersonUseRenderCenterDeltas)
+			m_VR->m_ThirdPersonRenderCenter = camCenter;
 		leftOrigin = camCenter + (right * (-(ipd * 0.5f)));
 		rightOrigin = camCenter + (right * (+(ipd * 0.5f)));
 	}
@@ -918,6 +922,9 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		// Normal VR first-person
 		leftOrigin = m_VR->GetViewOriginLeft();
 		rightOrigin = m_VR->GetViewOriginRight();
+		// Keep this sane even in 1P (unused there, but prevents stale deltas if 3P toggles).
+		if (m_VR->m_ThirdPersonUseRenderCenterDeltas)
+			m_VR->m_ThirdPersonRenderCenter = m_VR->m_SetupOrigin;
 	}
 
 	leftEyeView.origin = leftOrigin;

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -741,7 +741,8 @@ void VR::SubmitVRTextures()
                 VectorNormalize(dir);
 
                 Vector rayStart = m_RightControllerPosAbs;
-                Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+                const Vector& camBase = (m_ThirdPersonUseRenderCenterDeltas ? m_ThirdPersonRenderCenter : m_ThirdPersonViewOrigin);
+                Vector camDelta = camBase - m_SetupOrigin;
                 if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
                     rayStart += camDelta;
 
@@ -4113,7 +4114,8 @@ void VR::UpdateNonVRAimSolution(C_BasePlayer* localPlayer)
     VectorNormalize(direction);
 
     Vector originBase = m_RightControllerPosAbs;
-    Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+    const Vector& camBase = (m_ThirdPersonUseRenderCenterDeltas ? m_ThirdPersonRenderCenter : m_ThirdPersonViewOrigin);
+    Vector camDelta = camBase - m_SetupOrigin;
     if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
         originBase += camDelta;
 
@@ -4216,7 +4218,8 @@ bool VR::UpdateFriendlyFireAimHit(C_BasePlayer* localPlayer)
     VectorNormalize(gunDir);
 
     Vector gunOriginBase = gunOrigin;
-    Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+    const Vector& camBase = (m_ThirdPersonUseRenderCenterDeltas ? m_ThirdPersonRenderCenter : m_ThirdPersonViewOrigin);
+    Vector camDelta = camBase - m_SetupOrigin;
     if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
         gunOriginBase += camDelta;
 
@@ -4540,7 +4543,8 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
             + (m_HmdRight * (anchor.y * m_VRScale))
             + (m_HmdUp * (anchor.z * m_VRScale));
     }
-    Vector camDelta = m_ThirdPersonViewOrigin - m_SetupOrigin;
+    const Vector& camBase = (m_ThirdPersonUseRenderCenterDeltas ? m_ThirdPersonRenderCenter : m_ThirdPersonViewOrigin);
+    Vector camDelta = camBase - m_SetupOrigin;
     if (m_IsThirdPersonCamera && camDelta.LengthSqr() > (5.0f * 5.0f))
         originBase += camDelta;
 
@@ -5795,6 +5799,7 @@ void VR::ParseConfigFile()
     m_ThirdPersonCameraSmoothing = std::clamp(getFloat("ThirdPersonCameraSmoothing", m_ThirdPersonCameraSmoothing), 0.0f, 0.99f);
     m_ThirdPersonMapLoadCooldownMs = std::max(0, getInt("ThirdPersonMapLoadCooldownMs", m_ThirdPersonMapLoadCooldownMs));
     m_ThirdPersonRenderOnCustomWalk = getBool("ThirdPersonRenderOnCustomWalk", m_ThirdPersonRenderOnCustomWalk);
+    m_ThirdPersonUseRenderCenterDeltas = getBool("ThirdPersonUseRenderCenterDeltas", m_ThirdPersonUseRenderCenterDeltas);
     m_HideArms = getBool("HideArms", m_HideArms);
     m_HudDistance = getFloat("HudDistance", m_HudDistance);
     m_HudSize = getFloat("HudSize", m_HudSize);

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -155,6 +155,12 @@ public:
 	int m_ThirdPersonHoldFrames = 0;
 	Vector m_ThirdPersonViewOrigin = { 0,0,0 };
 	QAngle m_ThirdPersonViewAngles = { 0,0,0 };
+	// Center of the actual VR render camera used this frame (HMD-aimed 3P camera center).
+	// Used to keep aim line / overlays in sync when third-person camera is smoothed.
+	Vector m_ThirdPersonRenderCenter = { 0,0,0 };
+	// If true, use m_ThirdPersonRenderCenter as the base for camera deltas.
+	// If false, keep legacy behavior using m_ThirdPersonViewOrigin.
+	bool m_ThirdPersonUseRenderCenterDeltas = false;
 	bool m_ThirdPersonPoseInitialized = false;
 	float m_ThirdPersonCameraSmoothing = 0.85f;
 	float m_ThirdPersonVRCameraOffset = 80.0f;


### PR DESCRIPTION
### Motivation
- Provide a way to base third-person camera deltas on the actual rendered VR camera center so aim lines and overlays remain aligned when the third-person camera is smoothed. 
- Make this behavior configurable so existing legacy behavior remains the default and can be enabled explicitly.

### Description
- Add `m_ThirdPersonRenderCenter` and the config-driven toggle `m_ThirdPersonUseRenderCenterDeltas` to `VR` state in `L4D2VR/vr.h` with explanatory comments. 
- Update camera-delta calculations in `L4D2VR/vr.cpp` to compute a `camBase` reference that chooses between `m_ThirdPersonRenderCenter` and `m_ThirdPersonViewOrigin` (used in `SubmitVRTextures`, `UpdateNonVRAimSolution`, `UpdateFriendlyFireAimHit`, and `UpdateAimingLaser`).
- Wire `ThirdPersonUseRenderCenterDeltas` into `ParseConfigFile()` so the toggle can be read from config. 
- Change `L4D2VR/hooks.cpp` so `m_ThirdPersonRenderCenter` is written only when the toggle is enabled and reset in first-person to avoid stale deltas.

### Testing
- Ran a repository check with `git diff --check` which reported no problems. 
- Verified the new symbol names and updated sites with `rg`/code searches to confirm replacements and hook changes were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69869d35e6148321a556d70c87e441b7)