### PR TITLE
Fix HUD VGUI pass detection with multicore rendering

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -2530,7 +2530,16 @@ void Hooks::dVGui_Paint(void* ecx, void* edx, int mode)
 	if (m_VR->m_SuppressHudCapture)
 		return;
 
-	if (m_PushedHud)
+	bool paintingHudTarget = false;
+	if (m_Game && m_Game->m_MaterialSystem)
+	{
+		IMatRenderContext* renderContext = m_Game->m_MaterialSystem->GetRenderContext();
+		// mat_queue_mode=2 can route VGUI paint through a different hook thread than Push/Pop.
+		// Detect HUD pass by the active RT as a fallback to avoid black HUD clears with no panel draw.
+		paintingHudTarget = renderContext && renderContext->GetRenderTarget() == m_VR->m_HUDTexture;
+	}
+
+	if (m_PushedHud || paintingHudTarget)
 		mode = PAINT_UIPANELS | PAINT_INGAMEPANELS;
 
 	hkVgui_Paint.fOriginal(ecx, mode);


### PR DESCRIPTION
### Motivation
- In `mat_queue_mode=2` (multicore rendering) the hook callbacks for Push/Pop and VGUI paint can run on different threads which can leave the HUD render target cleared but without the panel draw calls, producing a black HUD area. 
- Relying solely on the `m_PushedHud` thread-local flag is therefore insufficient to robustly detect the HUD/VGUI paint pass under multicore conditions.

### Description
- Update `Hooks::dVGui_Paint` in `L4D2VR/hooks.cpp` to add a fallback detection that checks whether the current render target is the HUD texture (`m_VR->m_HUDTexture`) as reported by the material system render context. 
- Combine the new `paintingHudTarget` boolean with the existing `m_PushedHud` check so that VGUI paint will be routed to UI/ingame panels when either condition is true. 
- Add a short comment explaining that this fallback is needed because `mat_queue_mode=2` can route VGUI paint through a different hook thread than Push/Pop. 
- Keep existing guards for `m_DisableHudRendering` and `m_SuppressHudCapture` unchanged to preserve diagnostic and offscreen-pass behavior.

### Testing
- Performed targeted symbol searches to confirm relevant hooks and state (`rg` searches for HUD/hook symbols) which returned the expected locations. 
- Inspected the modified region of `L4D2VR/hooks.cpp` to verify the inserted logic and comments (`sed`/`nl` file inspection and diff view) and confirmed the diff contains the intended changes. 
- No automated build or runtime tests were executed because the project requires a Windows/MSVC toolchain not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c82e46c7c83219270b4439d24f1fd)