### PR TITLE
Harden VR compositor submit pacing for queued rendering mode

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -1150,6 +1150,9 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	// Restore engine angles immediately after our stereo render.
 	m_Game->m_EngineClient->SetViewAngles(prevEngineAngles);
 	m_VR->m_RenderedNewFrame = true;
+	// Mark a fresh stereo frame ready for submit (submit happens from VR::Update()).
+	m_VR->m_RenderPoseSerial = m_VR->m_PoseSerial;
+	m_VR->m_SubmitPending = true;
 }
 
 bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime, CUserCmd* cmd)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -289,6 +289,19 @@ public:
 	bool m_IsVREnabled = false;
 	bool m_IsInitialized = false;
 	bool m_RenderedNewFrame = false;
+	// ---- Compositor pacing (mat_queue_mode=2 hardening) ----
+	// Two-phase frame loop:
+	//  1) Update() calls WaitGetPoses() to start a new pose cycle (m_PoseSerial++).
+	//  2) RenderView renders with those poses, then marks m_SubmitPending.
+	//  3) The next Update() submits exactly once, WITHOUT another WaitGetPoses in-between.
+	uint64_t m_PoseSerial = 0;
+	uint64_t m_RenderPoseSerial = 0;
+	uint64_t m_LastSubmittedPoseSerial = 0;
+	bool m_SubmitPending = false;
+	bool m_WasInGamePrev = false;
+	std::chrono::steady_clock::time_point m_SkipSubmitUntil{};
+	std::chrono::steady_clock::time_point m_SubmitCooldownEnd{};
+	std::chrono::steady_clock::time_point m_LastSubmitLog{};
 	bool m_RenderedHud = false;
 	bool m_CreatedVRTextures = false;
 	// Used by extra offscreen passes (scope RTT): prevents HUD hooks from hijacking RT stack


### PR DESCRIPTION
### Motivation
- Prevent compositor deadlocks/stalls and noisy logging when running with queued/threaded rendering (`mat_queue_mode=2`) by enforcing a strict two-phase pose→render→submit flow.

### Description
- Add compositor pacing state to `VR` in `vr.h` including `m_PoseSerial`, `m_RenderPoseSerial`, `m_LastSubmittedPoseSerial`, `m_SubmitPending`, map-entry skip timers and cooldown/log timestamps.
- Mark stereo render completion in `hooks.cpp` (`dRenderView`) by copying `m_PoseSerial` to `m_RenderPoseSerial` and setting `m_SubmitPending` so submits happen from `VR::Update()`.
- Update `VR::Update()` in `vr.cpp` to skip submits briefly on map entry, continue menu/loading submits when not in-game, and submit exactly once per rendered pose serial in-game with cooldown and throttled stall logging.
- Harden `VR::SubmitVRTextures()` to deduplicate per-eye submits and treat `VRCompositorError_AlreadySubmitted` as non-fatal for that eye, and suppress `AlreadySubmitted` noise in `LogCompositorError()`.
- Increment `m_PoseSerial` on successful `WaitGetPoses()` in `UpdatePosesAndActions()` to pair pose acquisition with subsequent render/submit.

### Testing
- No automated build or unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd32749c883218a24f85b1e6a656e)