### PR TITLE
Fix mat_queue_mode=2 HUD VGUI capture gate

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -2574,6 +2574,8 @@ void Hooks::dVGui_Paint(void* ecx, void* edx, int mode)
 	if (!m_VR->m_CreatedVRTextures)
 		return hkVgui_Paint.fOriginal(ecx, mode);
 	bool matQueueMode2 = false;
+	if (m_Game && m_Game->m_MaterialSystem)
+		matQueueMode2 = (m_Game->m_MaterialSystem->GetThreadMode() == MATERIAL_QUEUED_THREADED);
 	// Diagnostic mode: completely skip VGUI paint to remove HUD/UI from the scene.
 	if (m_VR->m_DisableHudRendering)
 		return;


### PR DESCRIPTION
### Motivation
- Ensure the multicore HUD capture path (`HudCaptureViaVGuiPaint`) is actually used when the engine is running in `mat_queue_mode=2` by correctly detecting `MATERIAL_QUEUED_THREADED` in `Hooks::dVGui_Paint`.

### Description
- Read `m_Game->m_MaterialSystem->GetThreadMode()` into `matQueueMode2` and gate the VGUI->`vrHUD` redirection on that value, implemented in `L4D2VR/hooks.cpp` inside `Hooks::dVGui_Paint`.

### Testing
- Verified the change via `git diff`/commit and created a commit (`Fix mat_queue_mode=2 HUD VGUI capture gate`) which updated `L4D2VR/hooks.cpp`; commit succeeded. 
- Attempted an automated build with `msbuild l4d2vr.sln /t:Build /p:Configuration=Release` but the environment lacks `msbuild`, so build validation failed in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb1aea8b483219b5003ae79d90ba2)