### PR TITLE
Stabilize VR camera/viewmodel with per-render-frame snapshot

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -563,6 +563,26 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		return hkRenderView.fOriginal(ecx, setup, hudViewSetup, nClearFlags, whatToDraw);
 	}
 
+	// Keep a consistent pose/state snapshot across both eyes and viewmodel (important for mat_queue_mode=2).
+	struct RenderFrameSnapshotGuard
+	{
+		VR* vr = nullptr;
+		bool active = false;
+		RenderFrameSnapshotGuard(VR* v) : vr(v)
+		{
+			if (vr && vr->m_IsVREnabled)
+			{
+				vr->BeginRenderFrameSnapshot();
+				active = true;
+			}
+		}
+		~RenderFrameSnapshotGuard()
+		{
+			if (active)
+				vr->EndRenderFrameSnapshot();
+		}
+	} renderFrameSnapshotGuard(m_VR);
+
 	// ------------------------------
 	// Third-person camera fix:
 	// If engine is in third-person, setup.origin is a shoulder camera,
@@ -900,14 +920,21 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		// Render from the engine-provided third-person camera (setup.origin),
 		// but aim the camera with the HMD so head look still works in third-person.
 		QAngle camAng(viewAngles.x, viewAngles.y, viewAngles.z);
-		if (m_VR->m_HmdForward.IsZero())
+		const VR::RenderFrameSnapshot* snap = m_VR->GetActiveRenderFrameSnapshot();
+		const Vector hmdForward = snap ? snap->hmdForward : m_VR->m_HmdForward;
+		if (hmdForward.IsZero())
 			camAng = engineCamAngles;
 
 		Vector fwd, right, up;
 		QAngle::AngleVectors(camAng, &fwd, &right, &up);
 
-		const float ipd = (m_VR->m_Ipd * m_VR->m_IpdScale * m_VR->m_VRScale);
-		const float eyeZ = (m_VR->m_EyeZ * m_VR->m_VRScale);
+		const VR::RenderFrameSnapshot* snapParams = m_VR->GetActiveRenderFrameSnapshot();
+		const float vrScale = snapParams ? snapParams->vrScale : m_VR->m_VRScale;
+		const float ipdRaw = snapParams ? snapParams->ipd : m_VR->m_Ipd;
+		const float ipdScale = snapParams ? snapParams->ipdScale : m_VR->m_IpdScale;
+		const float eyeZRaw = snapParams ? snapParams->eyeZ : m_VR->m_EyeZ;
+		const float ipd = (ipdRaw * ipdScale * vrScale);
+		const float eyeZ = (eyeZRaw * vrScale);
 
 		// Treat camera origin as "head center", apply SteamVR eye-to-head offsets.
 		// If we're forcing third-person (state) while the engine is in first-person, use HMD position to synthesize a stable 3p camera.
@@ -919,11 +946,17 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 		if (stateWantsThirdPerson)
 		{
 			// Dead/observer camera must follow engine view, not HMD position.
-			baseCenter = stateIsDeadOrObserver ? engineCamOrigin : m_VR->GetHmdPosAbsSnapshot();
+			{
+				const VR::RenderFrameSnapshot* snapCenter = m_VR->GetActiveRenderFrameSnapshot();
+				baseCenter = stateIsDeadOrObserver ? engineCamOrigin : (snapCenter ? snapCenter->hmdPosAbs : m_VR->m_HmdPosAbs);
+			}
 		}
 		else
 		{
-			baseCenter = (engineThirdPersonNow || customWalkThirdPersonNow) ? engineCamOrigin : m_VR->GetHmdPosAbsSnapshot();
+			{
+				const VR::RenderFrameSnapshot* snapCenter = m_VR->GetActiveRenderFrameSnapshot();
+				baseCenter = (engineThirdPersonNow || customWalkThirdPersonNow) ? engineCamOrigin : (snapCenter ? snapCenter->hmdPosAbs : m_VR->m_HmdPosAbs);
+			}
 		}
 		Vector camCenter = baseCenter + (fwd * (-eyeZ));
 		if (m_VR->m_ThirdPersonVRCameraOffset > 0.0f)

--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -970,7 +970,8 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	else
 	{
 		// Normal VR first-person
-		m_VR->GetStereoViewOrigins(leftOrigin, rightOrigin);
+		leftOrigin = m_VR->GetViewOriginLeft();
+		rightOrigin = m_VR->GetViewOriginRight();
 		// Keep this sane even in 1P (unused there, but prevents stale deltas if 3P toggles).
 		m_VR->m_ThirdPersonRenderCenter = m_VR->m_SetupOrigin;
 	}

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -2812,38 +2812,64 @@ bool VR::CheckOverlayIntersectionForController(vr::VROverlayHandle_t overlayHand
 
 QAngle VR::GetRightControllerAbsAngle()
 {
+    if (const RenderFrameSnapshot* snap = GetActiveRenderFrameSnapshot())
+        return snap->rightControllerAngAbs;
     return m_RightControllerAngAbs;
 }
 
 Vector VR::GetRightControllerAbsPos()
 {
+    if (const RenderFrameSnapshot* snap = GetActiveRenderFrameSnapshot())
+        return snap->rightControllerPosAbs;
     return m_RightControllerPosAbs;
 }
 
 Vector VR::GetRecommendedViewmodelAbsPos()
 {
-    Vector viewmodelPos = GetRightControllerAbsPos();
-    if (m_MouseModeEnabled)
+    const RenderFrameSnapshot* snap = GetActiveRenderFrameSnapshot();
+
+    Vector viewmodelPos = snap ? snap->rightControllerPosAbs : m_RightControllerPosAbs;
+    const bool mouseModeEnabled = snap ? snap->mouseModeEnabled : m_MouseModeEnabled;
+
+    if (mouseModeEnabled)
     {
-        const Vector& anchor = IsMouseModeScopeActive() ? m_MouseModeScopedViewmodelAnchorOffset : m_MouseModeViewmodelAnchorOffset;
-        viewmodelPos = m_HmdPosAbs
-            + (m_HmdForward * (anchor.x * m_VRScale))
-            + (m_HmdRight * (anchor.y * m_VRScale))
-            + (m_HmdUp * (anchor.z * m_VRScale));
+        const bool mouseModeScopeActive = snap ? snap->mouseModeScopeActive : IsMouseModeScopeActive();
+        const Vector& anchor = mouseModeScopeActive
+            ? (snap ? snap->mouseModeScopedViewmodelAnchorOffset : m_MouseModeScopedViewmodelAnchorOffset)
+            : (snap ? snap->mouseModeViewmodelAnchorOffset : m_MouseModeViewmodelAnchorOffset);
+
+        const Vector hmdPos = snap ? snap->hmdPosAbs : m_HmdPosAbs;
+        const Vector hmdForward = snap ? snap->hmdForward : m_HmdForward;
+        const Vector hmdRight = snap ? snap->hmdRight : m_HmdRight;
+        const Vector hmdUp = snap ? snap->hmdUp : m_HmdUp;
+        const float vrScale = snap ? snap->vrScale : m_VRScale;
+
+        viewmodelPos = hmdPos
+            + (hmdForward * (anchor.x * vrScale))
+            + (hmdRight * (anchor.y * vrScale))
+            + (hmdUp * (anchor.z * vrScale));
     }
-    viewmodelPos -= m_ViewmodelForward * m_ViewmodelPosOffset.x;
-    viewmodelPos -= m_ViewmodelRight * m_ViewmodelPosOffset.y;
-    viewmodelPos -= m_ViewmodelUp * m_ViewmodelPosOffset.z;
+
+    const Vector vmForward = snap ? snap->viewmodelForward : m_ViewmodelForward;
+    const Vector vmRight = snap ? snap->viewmodelRight : m_ViewmodelRight;
+    const Vector vmUp = snap ? snap->viewmodelUp : m_ViewmodelUp;
+    const Vector vmOffset = snap ? snap->viewmodelPosOffset : m_ViewmodelPosOffset;
+
+    viewmodelPos -= vmForward * vmOffset.x;
+    viewmodelPos -= vmRight * vmOffset.y;
+    viewmodelPos -= vmUp * vmOffset.z;
 
     return viewmodelPos;
 }
 
 QAngle VR::GetRecommendedViewmodelAbsAngle()
 {
+    const RenderFrameSnapshot* snap = GetActiveRenderFrameSnapshot();
+    const Vector vmForward = snap ? snap->viewmodelForward : m_ViewmodelForward;
+    const Vector vmUp = snap ? snap->viewmodelUp : m_ViewmodelUp;
+
     QAngle result{};
-
-    QAngle::VectorAngles(m_ViewmodelForward, m_ViewmodelUp, result);
-
+    QAngle::VectorAngles(vmForward, vmUp, result);
     return result;
 }
 
@@ -5076,8 +5102,56 @@ void VR::GetAimLineColor(int& r, int& g, int& b, int& a) const
     a = m_AimLineColorA;
 }
 
+const VR::RenderFrameSnapshot* VR::GetActiveRenderFrameSnapshot() const
+{
+    if (m_RenderFrameSnapshotActive.load(std::memory_order_acquire))
+        return &m_RenderFrameSnapshot;
+    return nullptr;
+}
+
+void VR::BeginRenderFrameSnapshot()
+{
+    RenderFrameSnapshot snap{};
+
+    snap.hmdPosAbs = m_HmdPosAbs;
+    snap.hmdAngAbs = m_HmdAngAbs;
+    snap.hmdForward = m_HmdForward;
+    snap.hmdRight = m_HmdRight;
+    snap.hmdUp = m_HmdUp;
+
+    snap.vrScale = m_VRScale;
+    snap.ipd = m_Ipd;
+    snap.ipdScale = m_IpdScale;
+    snap.eyeZ = m_EyeZ;
+
+    snap.mouseModeEnabled = m_MouseModeEnabled;
+    snap.mouseModeScopeActive = IsMouseModeScopeActive();
+    snap.mouseModeViewmodelAnchorOffset = m_MouseModeViewmodelAnchorOffset;
+    snap.mouseModeScopedViewmodelAnchorOffset = m_MouseModeScopedViewmodelAnchorOffset;
+
+    snap.rightControllerPosAbs = m_RightControllerPosAbs;
+    snap.rightControllerAngAbs = m_RightControllerAngAbs;
+
+    snap.viewmodelForward = m_ViewmodelForward;
+    snap.viewmodelRight = m_ViewmodelRight;
+    snap.viewmodelUp = m_ViewmodelUp;
+    snap.viewmodelPosOffset = m_ViewmodelPosOffset;
+
+    // Write snapshot first, then publish active flag.
+    m_RenderFrameSnapshot = snap;
+    m_RenderFrameSnapshotActive.store(true, std::memory_order_release);
+}
+
+void VR::EndRenderFrameSnapshot()
+{
+    m_RenderFrameSnapshotActive.store(false, std::memory_order_release);
+}
+
 Vector VR::GetViewAngle()
 {
+    if (const RenderFrameSnapshot* snap = GetActiveRenderFrameSnapshot())
+        return Vector(snap->hmdAngAbs.x, snap->hmdAngAbs.y, snap->hmdAngAbs.z);
+
     return Vector(m_HmdAngAbs.x, m_HmdAngAbs.y, m_HmdAngAbs.z);
 }
 
@@ -5106,21 +5180,33 @@ float VR::GetMovementYawDeg()
 
 Vector VR::GetViewOriginLeft()
 {
-    Vector viewOriginLeft;
+    const RenderFrameSnapshot* snap = GetActiveRenderFrameSnapshot();
+    const Vector hmdPos = snap ? snap->hmdPosAbs : m_HmdPosAbs;
+    const Vector hmdForward = snap ? snap->hmdForward : m_HmdForward;
+    const Vector hmdRight = snap ? snap->hmdRight : m_HmdRight;
+    const float vrScale = snap ? snap->vrScale : m_VRScale;
+    const float eyeZ = snap ? snap->eyeZ : m_EyeZ;
+    const float ipd = snap ? snap->ipd : m_Ipd;
+    const float ipdScale = snap ? snap->ipdScale : m_IpdScale;
 
-    viewOriginLeft = m_HmdPosAbs + (m_HmdForward * (-(m_EyeZ * m_VRScale)));
-    viewOriginLeft = viewOriginLeft + (m_HmdRight * (-((m_Ipd * m_IpdScale * m_VRScale) / 2)));
-
+    Vector viewOriginLeft = hmdPos + (hmdForward * (-(eyeZ * vrScale)));
+    viewOriginLeft = viewOriginLeft + (hmdRight * (-((ipd * ipdScale * vrScale) / 2)));
     return viewOriginLeft;
 }
 
 Vector VR::GetViewOriginRight()
 {
-    Vector viewOriginRight;
+    const RenderFrameSnapshot* snap = GetActiveRenderFrameSnapshot();
+    const Vector hmdPos = snap ? snap->hmdPosAbs : m_HmdPosAbs;
+    const Vector hmdForward = snap ? snap->hmdForward : m_HmdForward;
+    const Vector hmdRight = snap ? snap->hmdRight : m_HmdRight;
+    const float vrScale = snap ? snap->vrScale : m_VRScale;
+    const float eyeZ = snap ? snap->eyeZ : m_EyeZ;
+    const float ipd = snap ? snap->ipd : m_Ipd;
+    const float ipdScale = snap ? snap->ipdScale : m_IpdScale;
 
-    viewOriginRight = m_HmdPosAbs + (m_HmdForward * (-(m_EyeZ * m_VRScale)));
-    viewOriginRight = viewOriginRight + (m_HmdRight * (m_Ipd * m_IpdScale * m_VRScale) / 2);
-
+    Vector viewOriginRight = hmdPos + (hmdForward * (-(eyeZ * vrScale)));
+    viewOriginRight = viewOriginRight + (hmdRight * ((ipd * ipdScale * vrScale) / 2));
     return viewOriginRight;
 }
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -294,6 +294,38 @@ public:
 	bool m_IsVREnabled = false;
 	bool m_IsInitialized = false;
 	bool m_RenderedNewFrame = false;
+	// === Render-frame snapshot ===
+	// Snapshot pose/state at start of stereo RenderView to keep camera and viewmodel stable (mat_queue_mode=2).
+	struct RenderFrameSnapshot
+	{
+		Vector hmdPosAbs{ 0,0,0 };
+		QAngle hmdAngAbs{ 0,0,0 };
+		Vector hmdForward{ 0,0,0 };
+		Vector hmdRight{ 0,0,0 };
+		Vector hmdUp{ 0,0,0 };
+
+		float vrScale = 1.0f;
+		float ipd = 0.0f;
+		float ipdScale = 1.0f;
+		float eyeZ = 0.0f;
+
+		bool mouseModeEnabled = false;
+		bool mouseModeScopeActive = false;
+		Vector mouseModeViewmodelAnchorOffset{ 0,0,0 };
+		Vector mouseModeScopedViewmodelAnchorOffset{ 0,0,0 };
+
+		Vector rightControllerPosAbs{ 0,0,0 };
+		QAngle rightControllerAngAbs{ 0,0,0 };
+
+		Vector viewmodelForward{ 0,0,0 };
+		Vector viewmodelRight{ 0,0,0 };
+		Vector viewmodelUp{ 0,0,0 };
+		Vector viewmodelPosOffset{ 0,0,0 };
+	};
+
+	RenderFrameSnapshot m_RenderFrameSnapshot{};
+	std::atomic<bool> m_RenderFrameSnapshotActive{ false };
+
 	// === Frame pacing / submit gating ===
 	// mat_queue_mode=2 can reorder Update() vs RenderView(). If we Submit() before a new stereo frame
 	// is actually rendered, SteamVR gets "old texture + new pose" which looks like ghosting/judder.
@@ -905,6 +937,10 @@ public:
 	// Mouse-mode: compute the eye-center ray used for aiming (mouse pitch+yaw or HMD-based, optionally sensitivity-scaled).
 	void GetMouseModeEyeRay(Vector& eyeDirOut, QAngle* eyeAngOut = nullptr);
 	void UpdateTracking();
+	// Render-frame snapshot: call at the start/end of our stereo RenderView hook.
+	void BeginRenderFrameSnapshot();
+	void EndRenderFrameSnapshot();
+	const RenderFrameSnapshot* GetActiveRenderFrameSnapshot() const;
 	void UpdateMotionGestures(C_BasePlayer* localPlayer);
 	bool UpdateThirdPersonViewState(const Vector& cameraOrigin, const Vector& cameraAngles);
 	Vector GetViewAngle();


### PR DESCRIPTION
### Motivation
- Multicore rendering (`mat_queue_mode=2`) can read mutable tracking data at different times for left/right eye and viewmodel, causing ghosting/judder and unstable viewmodel placement; a single per-render-frame snapshot keeps all render math consistent.

### Description
- Added a `RenderFrameSnapshot` struct and storage (`m_RenderFrameSnapshot`, `m_RenderFrameSnapshotActive`) to `VR` that captures HMD pose/orientation, IPD/scale, mouse-mode anchors, controller pose, and viewmodel basis vectors at the start of stereo rendering (`L4D2VR/vr.h`).
- Implemented snapshot lifecycle APIs: `BeginRenderFrameSnapshot()`, `EndRenderFrameSnapshot()`, and `GetActiveRenderFrameSnapshot()` with atomic acquire/release semantics to publish fully-written snapshots (`L4D2VR/vr.cpp`).
- Updated VR helpers to prefer snapshot values when active for controller queries and view/viewmodel math: `GetRightControllerAbsAngle/Pos`, `GetRecommendedViewmodelAbsPos/Angle`, `GetViewAngle`, and `GetViewOriginLeft/Right` (`L4D2VR/vr.cpp`).
- Introduced an RAII `RenderFrameSnapshotGuard` in `Hooks::dRenderView` so the snapshot scope cleanly wraps stereo rendering and updated third-person stereo camera calculations to consume snapshot parameters when available (`L4D2VR/hooks.cpp`).

### Testing
- Ran `git diff --check` which produced no whitespace errors and `git status --short` to confirm only the intended files were modified, both succeeded.
- Performed repository symbol/usage checks via `rg` to verify new APIs and guard usage are present, which succeeded.
- Changes were committed locally; no build or runtime tests were run in this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f459004a8832196cb296a611f998c)