### PR TITLE
Add chat-driven HUD auto-show via game events

### DIFF
--- a/L4D2VR/game.cpp
+++ b/L4D2VR/game.cpp
@@ -111,6 +111,15 @@ Game::Game()
     if (!m_DebugOverlay)
         m_DebugOverlay = static_cast<IVDebugOverlay*>(TryInterfaceNoError("engine.dll", "VDebugOverlay003"));
 
+    // Game events (used for lightweight chat detection / HUD auto-show, etc.)
+    m_GameEventManager = static_cast<IGameEventManager2*>(TryInterfaceNoError("engine.dll", "GAMEEVENTSMANAGER002"));
+    if (!m_GameEventManager)
+        m_GameEventManager = static_cast<IGameEventManager2*>(TryInterfaceNoError("engine.dll", "GAMEEVENTSMANAGER003"));
+    if (!m_GameEventManager)
+        m_GameEventManager = static_cast<IGameEventManager2*>(TryInterfaceNoError("engine.dll", "GAMEEVENTSMANAGER001"));
+    if (m_GameEventManager)
+        Game::logMsg("[VR] GameEventManager available.");
+
     m_Offsets = new Offsets();
     m_VR = new VR(this);
 

--- a/L4D2VR/game.h
+++ b/L4D2VR/game.h
@@ -19,6 +19,7 @@ class IModelRender;
 class IMaterial;
 class IInput;
 class ISurface;
+class IGameEventManager2;
 class C_BaseEntity;
 class C_BasePlayer;
 struct model_t;
@@ -59,9 +60,10 @@ public:
     IBaseClientDLL* m_BaseClientDll = nullptr;
     IModelInfo* m_ModelInfo = nullptr;
     IModelRender* m_ModelRender = nullptr;
-    IInput* m_VguiInput = nullptr;
-    ISurface* m_VguiSurface = nullptr;
-    IVDebugOverlay* m_DebugOverlay = nullptr;
+	IInput* m_VguiInput = nullptr;
+	ISurface* m_VguiSurface = nullptr;
+	IVDebugOverlay* m_DebugOverlay = nullptr;
+	IGameEventManager2* m_GameEventManager = nullptr;
 
     // === Module Base Addresses ===
     uintptr_t m_BaseEngine = 0;

--- a/L4D2VR/sdk/sdk.h
+++ b/L4D2VR/sdk/sdk.h
@@ -18,6 +18,50 @@ struct PositionAngle
 	QAngle angle;
 };
 
+// === Game Events (client-side chat detection, etc.) ===
+// Minimal Source-style interfaces (enough for AddListener + player_say text).
+class IGameEvent
+{
+public:
+	virtual ~IGameEvent() {}
+	virtual const char* GetName() const = 0;
+	virtual bool IsReliable() const = 0;
+	virtual bool IsLocal() const = 0;
+	virtual bool IsEmpty(const char* keyName = nullptr) = 0;
+	virtual bool GetBool(const char* keyName = nullptr, bool defaultValue = false) = 0;
+	virtual int GetInt(const char* keyName = nullptr, int defaultValue = 0) = 0;
+	virtual float GetFloat(const char* keyName = nullptr, float defaultValue = 0.0f) = 0;
+	virtual const char* GetString(const char* keyName = nullptr, const char* defaultValue = "") = 0;
+	virtual void SetBool(const char* keyName, bool value) = 0;
+	virtual void SetInt(const char* keyName, int value) = 0;
+	virtual void SetFloat(const char* keyName, float value) = 0;
+	virtual void SetString(const char* keyName, const char* value) = 0;
+};
+
+class IGameEventListener2
+{
+public:
+	virtual ~IGameEventListener2() {}
+	virtual void FireGameEvent(IGameEvent* event) = 0;
+	virtual int GetEventDebugID(void) = 0;
+};
+
+class IGameEventManager2
+{
+public:
+	virtual ~IGameEventManager2() {}
+	virtual int LoadEventsFromFile(const char* filename) = 0;
+	virtual void Reset() = 0;
+	virtual bool AddListener(IGameEventListener2* listener, const char* name, bool bServerSide) = 0;
+	virtual bool FindListener(IGameEventListener2* listener, const char* name) = 0;
+	virtual void RemoveListener(IGameEventListener2* listener) = 0;
+	virtual IGameEvent* CreateEvent(const char* name, bool bForce = false) = 0;
+	virtual bool FireEvent(IGameEvent* event, bool bDontBroadcast = false) = 0;
+	virtual bool FireEventClientSide(IGameEvent* event) = 0;
+	virtual IGameEvent* DuplicateEvent(IGameEvent* event) = 0;
+	virtual void FreeEvent(IGameEvent* event) = 0;
+};
+
 class IClientEntityList
 {
 public:

--- a/L4D2VR/vr.cpp
+++ b/L4D2VR/vr.cpp
@@ -440,7 +440,10 @@ void VR::RegisterChatEventListener()
     if (m_ChatEventListenerRegistered)
         return;
     if (!m_Game || !m_Game->m_GameEventManager)
+    {
+        Game::logMsg("[VR][ChatEvent] GameEventManager unavailable; chat listener not registered.");
         return;
+    }
 
     // Allocate once and keep for the life of the process.
     m_ChatEventListener = new VRChatAutoHudListener(this);
@@ -452,16 +455,21 @@ void VR::RegisterChatEventListener()
 
     if (!ok)
     {
+        Game::logMsg("[VR][ChatEvent] Failed to register player_say listeners.");
         delete m_ChatEventListener;
         m_ChatEventListener = nullptr;
         return;
     }
 
     m_ChatEventListenerRegistered = true;
+    Game::logMsg("[VR][ChatEvent] Registered player_say listeners.");
 }
 
-void VR::OnChatMessageReceived(const char* /*text*/)
+void VR::OnChatMessageReceived(const char* text)
 {
+    const char* safeText = text ? text : "";
+    Game::logMsg("[VR][ChatEvent] captured text: %s", safeText);
+
     // Only meaningful in-game, and only when the feature is enabled.
     if (!m_Game || !m_Game->m_EngineClient || !m_Game->m_EngineClient->IsInGame())
         return;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -912,7 +912,7 @@ public:
 	void GetPoseData(vr::TrackedDevicePose_t& poseRaw, TrackedDevicePoseData& poseOut);
 	// Chat->HUD auto-show support
 	void RegisterChatEventListener();
-	void OnChatMessageReceived(const char* text);
+	void OnChatMessageReceived(const char* eventName, const char* text);
 	void ParseConfigFile();
 	void LoadViewmodelAdjustments();
 	void SaveViewmodelAdjustments();

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -21,6 +21,7 @@ class CUserCmd;
 class IDirect3DTexture9;
 class IDirect3DSurface9;
 class ITexture;
+class IGameEventListener2;
 
 struct ViewmodelAdjustment
 {
@@ -468,6 +469,12 @@ public:
 	bool m_HudAlwaysVisible = false;
 	bool m_HudToggleState = false;
 	std::chrono::steady_clock::time_point m_HudChatVisibleUntil{};
+	// If > 0, receiving a chat message while HUD is hidden will temporarily show the HUD.
+	// Config: HudAutoShowOnChatSeconds (0 or false disables)
+	float m_HudAutoShowOnChatSeconds = 0.0f;
+	// GameEvent listener instance (player_say) for HUD auto-show-on-chat.
+	IGameEventListener2* m_ChatEventListener = nullptr;
+	bool m_ChatEventListenerRegistered = false;
 
 	float m_ControllerSmoothing = 0.0f;
 	bool m_ControllerSmoothingInitialized = false;
@@ -903,6 +910,9 @@ public:
 	bool GetAnalogActionData(vr::VRActionHandle_t& actionHandle, vr::InputAnalogActionData_t& analogDataOut);
 	void ResetPosition();
 	void GetPoseData(vr::TrackedDevicePose_t& poseRaw, TrackedDevicePoseData& poseOut);
+	// Chat->HUD auto-show support
+	void RegisterChatEventListener();
+	void OnChatMessageReceived(const char* text);
 	void ParseConfigFile();
 	void LoadViewmodelAdjustments();
 	void SaveViewmodelAdjustments();

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -538,6 +538,18 @@ Option g_Options[] =
         0.0f, 0.0f,
         "true"
     },
+    {
+        "HudAutoShowOnChatSeconds",
+        OptionType::Float,
+        { u8"HUD (Main)", u8"HUD（主界面）" },
+        { u8"Auto-show HUD on Chat (seconds)", u8"聊天自动显示HUD（秒）" },
+        { u8"When the HUD is hidden, receiving a chat message will temporarily show the HUD.",
+          u8"当HUD处于隐藏状态时，收到聊天消息会临时显示HUD。" },
+        { u8"Set 0 to disable (config.txt also accepts false/off).",
+          u8"设为 0 关闭（config.txt 也支持 false/off）。" },
+        0.0f, 30.0f,
+        "0"
+    },
 
     // Hands / Debug
     {


### PR DESCRIPTION
### Motivation
- Provide an option to temporarily show the VR HUD when a chat message arrives while the HUD is hidden. 
- Use minimal Source game-event APIs so the client can subscribe to `player_say`/`player_say_team` without depending on third-party headers. 

### Description
- Added minimal game-event interfaces (`IGameEvent`, `IGameEventListener2`, `IGameEventManager2`) in `L4D2VR/sdk/sdk.h` to allow subscribing to engine game events. 
- Wired `Game` to resolve `GAMEEVENTSMANAGER00x` from `engine.dll` and store it in `Game::m_GameEventManager` so listeners can be registered. 
- Implemented `VRChatAutoHudListener` and VR plumbing in `L4D2VR/vr.cpp` with `RegisterChatEventListener()` and `OnChatMessageReceived()` to register for `player_say`/`player_say_team` and extend HUD visibility. 
- Added VR state members (`m_HudAutoShowOnChatSeconds`, `m_ChatEventListener`, `m_ChatEventListenerRegistered`) and method declarations in `L4D2VR/vr.h`. 
- Parse `HudAutoShowOnChatSeconds` in `VR::ParseConfigFile()` supporting numeric seconds, `false/off/no` (disable), and `true/on/yes` (defaults to 3s), and exposed the option in the config UI at `L4D2VRConfigTool/src/Options.cpp` (float, `0..30`, default `0`).

### Testing
- Ran `git diff --check` to validate there are no patch/whitespace issues and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ccfe43608321b3df7f1e1cd78890)