### PR TITLE
Handle in-eye observer target switching in tracking

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -577,6 +577,7 @@ public:
 	static constexpr int kLifeStateOffset = 0x147;
 	static constexpr int kTeamNumOffset = 0xE4; // DT_BaseEntity::m_iTeamNum
 	static constexpr int kObserverModeOffset = 0x1450; // C_BasePlayer::m_iObserverMode
+	static constexpr int kObserverTargetOffset = 0x1454; // C_BasePlayer::m_hObserverTarget
 
 
 	// Aim-line friendly-fire guard (client-side fire suppression)
@@ -615,6 +616,10 @@ public:
 	// the user can still manually change spectator mode afterwards.
 	std::chrono::steady_clock::time_point m_ObserverLastFreeCamAttempt{};
 	int m_ObserverFreeCamAttemptCount = 0;
+	// Observer in-eye (obsMode 4) target switch: auto ResetPosition to re-align anchors.
+	int m_ObserverInEyeTargetPrev = 0;
+	bool m_ObserverInEyeWasActivePrev = false;
+	bool m_ResetPositionAfterObserverTargetSwitchPending = false;
 	// CTerrorPlayer netvars (from offsets.txt). These are used for a special-case in the
 	// friendly-fire aim guard: if the aim ray hits a teammate who is currently pinned/
 	// controlled, we allow a "see-through" trace to hit the attacker behind them.


### PR DESCRIPTION
### Motivation
- Prevent anchor/viewmodel drift when a client is spectating in-eye (observer mode 4) and the spectated target changes.
- Reuse observer state reads so spectator-related code uses the actual viewed player instead of the local player.

### Description
- Add `kObserverTargetOffset` and persistent fields `m_ObserverInEyeTargetPrev`, `m_ObserverInEyeWasActivePrev`, and `m_ResetPositionAfterObserverTargetSwitchPending` to track in-eye observer state and pending resets in `vr.h`.
- In `UpdateTracking()` compute shared observer state and resolve a `viewPlayer` from `m_hObserverTarget` when in in-eye observer mode, and fall back to `localPlayer` otherwise.
- Use `viewPlayer` for melee/weapon/viewmodel/eye/abs-origin reads so the tracking logic follows the actual spectated player.
- Disable roomscale while spectating in-eye and set a one-shot `ResetPosition()` when the in-eye observer target changes to re-align anchors and prevent stickiness.

### Testing
- Ran `git diff --check` to validate the workspace diff and found no issues (check passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940ef49e248321ae88aa0ad4a68f91)