### PR TITLE
Add timing-aligned render-thread aim line mode

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -1047,6 +1047,9 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	leftEyeView.origin = leftOrigin;
 	leftEyeView.angles = viewAngles;
 
+	// Aim line timing-aligned draw: render-thread path to minimize trails when moving.
+	m_VR->RenderThreadDrawAimingLaser(localPlayer);
+
 	// --- IMPORTANT: avoid "dragging/ghosting" when turning with thumbstick ---
 	// Do NOT permanently overwrite engine viewangles. Only set them during our stereo renders,
 	// then restore, so the engine's view history/interp isn't corrupted.

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -204,6 +204,10 @@ public:
 	bool m_AimLineEnabled = true;
 	bool m_AimLineConfigEnabled = true;
 	bool m_AimLineOnlyWhenLaserSight = false;
+	// If true, prefer render-time temporal alignment over persistence.
+	// Aim line / throw arc are drawn on the render thread after camera origins are finalized,
+	// and we use a shorter overlay lifetime to minimize positional trails when moving.
+	bool m_AimLineTimingAligned = false;
 	bool m_ScopeForcingAimLine = false;
 	bool m_MeleeAimLineEnabled = true;
 	// Mounted gun (minigun/.50cal) state.
@@ -933,6 +937,9 @@ public:
 	C_BaseEntity* GetMountedGunUseEntity(C_BasePlayer* localPlayer) const;
 	bool m_EncodeVRUsercmd = true;
 	void UpdateAimingLaser(C_BasePlayer* localPlayer);
+	// Render-thread draw path for aim helpers when AimLineTimingAligned is enabled.
+	// This draws during Hooks::dRenderView after third-person camera decisions to reduce ghosting/trailing.
+	void RenderThreadDrawAimingLaser(C_BasePlayer* localPlayer);
 	bool ShouldShowAimLine(C_WeaponCSBase* weapon) const;
 	bool IsThrowableWeapon(C_WeaponCSBase* weapon) const;
 	bool ShouldDrawAimLine(C_WeaponCSBase* weapon) const;

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -663,6 +663,18 @@ Option g_Options[] =
         "false"
     },
     {
+        "AimLineTimingAligned",
+        OptionType::Bool,
+        { u8"Aim Assist", u8"辅助瞄准" },
+        { u8"Timing-Aligned Aim Line", u8"时序对齐优先" },
+        { u8"Draws the aim line on the render thread after camera origins are finalized, using a shorter lifetime.",
+          u8"在渲染线程、相机原点最终确定后绘制瞄准线，并使用更短的持续时间。" },
+        { u8"Reduces positional trailing/ghosting while moving, but may flicker if FPS is unstable.",
+          u8"可减少移动时的残影/拖影，但帧率不稳定时可能会轻微闪烁。" },
+        0.0f, 0.0f,
+        "false"
+    },
+    {
         "MeleeAimLineEnabled",
         OptionType::Bool,
         { u8"Aim Assist", u8"辅助瞄准" },


### PR DESCRIPTION
### Motivation
- Aim helpers (aim line and throw arc) can produce visible trailing/ghosting when camera origins move between game-thread updates and frame rendering, especially in third-person; the intent is to offer a mode that draws those helpers aligned with the final render-time camera.
- Provide a configurable option to prefer a render-thread, timing-aligned draw path that reduces positional trails while preserving existing game-thread caches and semantics.

### Description
- Added a new boolean state `m_AimLineTimingAligned` and declared `RenderThreadDrawAimingLaser(C_BasePlayer* localPlayer)` in `VR` (`L4D2VR/vr.h`) to support a render-thread draw path.
- Implemented `VR::RenderThreadDrawAimingLaser` in `L4D2VR/vr.cpp` that recomputes endpoints using the render-time camera decisions, safely uses cached throw-arc points when needed, and draws overlays with a one-frame-short lifetime when timing-aligned mode is enabled.
- Invoked the render-thread path from `Hooks::dRenderView` (`L4D2VR/hooks.cpp`) right after eye-view origins/angles are finalized so the aim helpers use the rendered camera center for minimal trailing.
- Updated game-thread drawing in `UpdateAimingLaser` to skip `DrawAimLine` / `DrawThrowArc` / cached-draws when `m_AimLineTimingAligned` is enabled, adjusted the overlay `duration` calculation in `DrawAimLine` for timing-aligned mode, added config parsing for `AimLineTimingAligned` in `ParseConfigFile`, and exposed the option (EN/CN) in the config tool (`L4D2VRConfigTool/src/Options.cpp`).

### Testing
- Ran `git diff --check` to validate whitespace and trivial diff issues, which succeeded.
- Ran `git status --short` to confirm the working tree state after changes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699421bc8088832196b04708bf585463)