### PR TITLE
Fix double-duck camera stepping with dynamic HMD baseline

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -94,6 +94,12 @@ public:
 	Vector m_HmdUp;
 
 	Vector m_HmdPosLocalInWorld = { 0,0,0 };
+	// HMD height baseline (Source units). We apply tracked Z as a *delta* from this baseline
+	// so Source eye-height changes (e.g. crouch) don't stack with real-life crouching.
+	float m_HmdHeightBaselineUnits = 64.0f;
+	bool m_HmdHeightBaselineInitialized = false;
+	bool m_DuckStatePrev = false;
+	bool m_DuckStatePrevInitialized = false;
 
 	Vector m_LeftControllerForward;
 	Vector m_LeftControllerRight;
@@ -582,6 +588,8 @@ public:
 	static constexpr int kTeamNumOffset = 0xE4; // DT_BaseEntity::m_iTeamNum
 	static constexpr int kObserverModeOffset = 0x1450; // C_BasePlayer::m_iObserverMode
 	static constexpr int kObserverTargetOffset = 0x1454; // C_BasePlayer::m_hObserverTarget
+	static constexpr int kFlagsOffset = 0xF0; // DT_BasePlayer::m_fFlags
+	static constexpr int kFlagDuckingBit = (1 << 1); // FL_DUCKING
 
 
 	// Aim-line friendly-fire guard (client-side fire suppression)


### PR DESCRIPTION
### Motivation

- Prevent camera height "steps" when real-life crouching stacks with in-game ducking by treating tracked HMD Z as a delta from a dynamic baseline instead of an absolute offset.
- Ensure the tracked-height baseline and duck-state sampling are reinitialized on player pointer loss and on manual resets to avoid stale references across reconnects/map loads.

### Description

- Added baseline and duck-state fields to `VR`: `m_HmdHeightBaselineUnits`, `m_HmdHeightBaselineInitialized`, `m_DuckStatePrev`, and `m_DuckStatePrevInitialized` in `L4D2VR/vr.h`.
- Added player flag offsets/constants `kFlagsOffset` and `kFlagDuckingBit` to read crouch state from entity memory.
- In `VR::UpdateTracking()` initialized the baseline from tracked HMD Z and detect duck/unduck edges by reading `m_fFlags`; on duck-state transitions the baseline is adjusted by the engine eye-height delta to keep the view continuous.
- Replaced hardcoded `64` eye-height offsets with `m_HmdHeightBaselineUnits` in absolute HMD position calculations (including wall-clip correction path).
- Reset baseline/duck sampling when the local player pointer is lost and rebaseline in `VR::ResetPosition()`; MSVC-safe memory access uses structured exception handling (`__try/__except`) when reading flags.

### Testing

- Ran `git diff --check` to validate no whitespace or diff issues and it succeeded.
- Checked repository status with `git status --short` to confirm modified files and it succeeded.
- Verified current branch and most recent commit with branch/log checks and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953b566c7c8321b2c0fa73d3a74b65)