### PR TITLE
Unify HUD overlays into a single OpenVR overlay handle

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -65,8 +65,7 @@ public:
 	vr::IVRCompositor* m_Compositor = nullptr;
 
 	vr::VROverlayHandle_t m_MainMenuHandle;
-	vr::VROverlayHandle_t m_HUDTopHandle;
-	std::array<vr::VROverlayHandle_t, 4> m_HUDBottomHandles{};
+	vr::VROverlayHandle_t m_HUDHandle;
 	// Gun-mounted scope overlay (render-to-texture lens)
 	vr::VROverlayHandle_t m_ScopeHandle = vr::k_ulOverlayHandleInvalid;
 	// Rear mirror overlay (off-hand)


### PR DESCRIPTION
### Motivation
- Simplify HUD overlay management by replacing separate top and multiple bottom overlays with a single overlay handle to reduce duplicated logic and maintenance surface.
- Make input, visibility, transform, and texture handling consistent by targeting one HUD overlay instead of several overlays and loops.

### Description
- Replaced `m_HUDTopHandle` and `m_HUDBottomHandles` with a single `m_HUDHandle` member in `L4D2VR/vr.h` and removed the array-based bottom overlays.
- Updated initialization to create one HUD overlay (`"HUDOverlayKey"`) and configured input method, mouse scale, and scroll flags for `m_HUDHandle` in `L4D2VR/vr.cpp`.
- Consolidated HUD show/hide and texture application paths by removing bottom-overlay loops and switching calls in `SubmitVRTextures`, `RepositionOverlays`, `ProcessMenuInput`, and `ProcessInput` to use `m_HUDHandle` (including renaming helper lambdas to `showHud`/`hideHud`).
- Removed redundant per-overlay loops and related logic that managed multiple HUD handles, simplifying overlay interaction checks and transform updates.

### Testing
- Searched the codebase for old symbols with `rg` (e.g. `HUDTopHandle|HUDBottomHandles|HUDHandle`) to verify references were updated; search found only the new `m_HUDHandle` usages and no remaining `m_HUDTopHandle`/`m_HUDBottomHandles` occurrences, and the search succeeded.
- Inspected modified regions with `sed`/`nl` and reviewed the `git diff` output to confirm the intended replacements and removal of looped logic; these inspections succeeded. 
- Committed the changes and verified the working tree diff/stat to confirm the patch was applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995469fbc988321a87902a5563ebfde)