### PR TITLE
Lazy optics RTT allocation with optional VAS diagnostics

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -570,6 +570,10 @@ void __fastcall Hooks::dRenderView(void* ecx, void* edx, CViewSetup& setup, CVie
 	if (!m_VR->m_CreatedVRTextures)
 		m_VR->CreateVRTextures();
 
+	// Scope / rear-mirror RTTs may be created lazily (see LazyScopeRearMirrorRTT).
+	// Ensure they're available before any offscreen passes try to render into them.
+	m_VR->EnsureOpticsRTTTextures();
+
 	IMatRenderContext* rndrContext = m_Game->m_MaterialSystem->GetRenderContext();
 	if (!rndrContext)
 	{

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -286,6 +286,12 @@ public:
 	SharedTextureHolder m_VKRearMirror;
 	SharedTextureHolder m_VKBlankTexture;
 
+	// If enabled, scope / rear-mirror render-target textures are created only when the feature is enabled.
+	// This can save large chunks of 32-bit VAS when ScopeRTTSize/RearMirrorRTTSize are high.
+	bool m_LazyScopeRearMirrorRTT = true;
+	// Debug: log Virtual Address Space (VAS) stats at key allocation points.
+	bool m_DebugVASLog = false;
+
 	bool m_IsVREnabled = false;
 	bool m_IsInitialized = false;
 	bool m_RenderedNewFrame = false;
@@ -878,6 +884,8 @@ public:
 	void InstallApplicationManifest(const char* fileName);
 	void Update();
 	void CreateVRTextures();
+	void EnsureOpticsRTTTextures();
+	void LogVAS(const char* tag);
 	void HandleMissingRenderContext(const char* location);
 	void SubmitVRTextures();
 	void LogCompositorError(const char* action, vr::EVRCompositorError error);


### PR DESCRIPTION
### Motivation
- Reduce 32-bit virtual address space (VAS) pressure caused by always-allocating large scope/rear-mirror render-target textures (RTTs) when `ScopeRTTSize`/`RearMirrorRTTSize` are large. 
- Provide a lightweight diagnostic to inspect VAS usage during key allocation points to help debug OOM/fragmentation scenarios.

### Description
- Add two runtime flags in `VR`: `m_LazyScopeRearMirrorRTT` (defaults to `true`) to enable on-demand allocation of scope/rear-mirror RTTs, and `m_DebugVASLog` to enable VAS logging via `LogVAS` (files: `L4D2VR/vr.h`).
- Implement VAS snapshot helpers (`VASStats`, `QueryVASStats`, `BytesToMiB`) and `VR::LogVAS` that use `VirtualQuery` to report free/reserved/committed ranges (file: `L4D2VR/vr.cpp`).
- Change `VR::CreateVRTextures()` to skip pre-creating scope/rear-mirror RTTs unless `m_LazyScopeRearMirrorRTT` is disabled or the corresponding feature is enabled, and add `LogVAS` calls before/after allocation (file: `L4D2VR/vr.cpp`).
- Add `VR::EnsureOpticsRTTTextures()` to allocate scope/rear-mirror RTTs on-demand when they become required and log on-demand allocations; call this from the render-view hook so offscreen passes always find allocated targets (files: `L4D2VR/vr.cpp`, `L4D2VR/hooks.cpp`).
- Fix rear-mirror throttling bug by using the rear-mirror timing state (`m_LastRearMirrorRTTRenderTime`/`m_RearMirrorRTTMaxHz`) instead of scope timing state.
- Wire config parsing to read `DebugVASLog` and `LazyScopeRearMirrorRTT` and emit a one-time VAS log when debug logging is enabled (file: `L4D2VR/vr.cpp`).

### Testing
- Ran symbol/search verification with `rg` to confirm new symbols/usages (`LazyScopeRearMirrorRTT`, `DebugVASLog`, `EnsureOpticsRTTTextures`, `LogVAS`, `QueryVASStats`, modified `ShouldUpdateRearMirrorRTT`) and found expected occurrences (success).
- Ran `git diff --check` to validate whitespace/patch issues and received no warnings (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e50692508321826314da638d0545)