### PR TITLE
Add decoupled 1:1 roomscale camera chase controls

### DIFF
--- a/L4D2VR/hooks/hooks_createmove.inl
+++ b/L4D2VR/hooks/hooks_createmove.inl
@@ -212,6 +212,9 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 			walkNy = ny;
 			walkMaxSpeed = maxSpeed;
 
+			// Track thumbstick locomotion state (used to disable 1:1 roomscale when requested).
+			m_VR->m_PushingThumbstick = (fabsf(nx) > 0.0001f) || (fabsf(ny) > 0.0001f);
+
 			// VR-aware servers: we can apply movement directly in cmd space.
 			// Non-VR servers: we will re-base movement later after overriding cmd->viewangles.
 			if (!treatServerAsNonVR)
@@ -247,6 +250,10 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 			if (nx > 0.5f)      cmd->buttons |= (1 << 10);
 			else if (nx < -0.5f)cmd->buttons |= (1 << 9);
 
+		}
+		else
+		{
+			m_VR->m_PushingThumbstick = false;
 		}
 
 		// ② ★ 非 VR 服务器：把“右手手柄朝向”塞给服务器用的视角

--- a/L4D2VR/hooks/hooks_createmove.inl
+++ b/L4D2VR/hooks/hooks_createmove.inl
@@ -666,6 +666,13 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 				(void*)(uintptr_t)m_Game->m_Offsets->ProcessUsercmds.address,
 				(void*)(uintptr_t)m_Game->m_Offsets->ReadUserCmd.address);
 		}
+		// Detect any locomotion input (keyboard WASD, thumbstick, etc.).
+		// Used to disable 1:1 roomscale movement/camera decoupling while actively moving via controls.
+		const float fm = cmd ? cmd->forwardmove : 0.0f;
+		const float sm = cmd ? cmd->sidemove : 0.0f;
+		const float um = cmd ? cmd->upmove : 0.0f;
+		m_VR->m_LocomotionActive = (fabsf(fm) > 0.5f) || (fabsf(sm) > 0.5f) || (fabsf(um) > 0.5f) || m_VR->m_PushingThumbstick;
+
 		m_VR->EncodeRoomscale1To1Move(cmd);
 	}
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -565,6 +565,8 @@ public:
 	float m_Roomscale1To1ChaseHysteresisMeters = 0.05f;
 	float m_Roomscale1To1MinApplyMeters = 0.02f;
 	bool m_Roomscale1To1ChaseActive = false;
+	// After control locomotion stops, keep 1:1 chase/apply paused for a few cmds to avoid stop-time pullback.
+	int m_Roomscale1To1LocomotionCooldownCmds = 0;
 
 	Vector m_Roomscale1To1PrevCorrectedAbs = {};
 	// Accumulate sub-centimeter HMD deltas so slow walking/leaning still produces movement.

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -305,6 +305,9 @@ public:
 
 	bool m_PressedTurn = false;
 	bool m_PushingThumbstick = false;
+	// Any locomotion (keyboard WASD, thumbstick, etc.) detected in the current CreateMove.
+	// Used to avoid conflicts with 1:1 roomscale movement/camera decoupling.
+	bool m_LocomotionActive = false;
 	bool m_CrouchToggleActive = false;
 	bool m_VoiceRecordActive = false;
 	bool m_QuickTurnTriggered = false;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -551,6 +551,18 @@ public:
 	bool m_Roomscale1To1Movement = true;
 	float m_Roomscale1To1MaxStepMeters = 0.35f;
 
+	// Roomscale 1:1 movement (ForceNonVRServerMovement=false):
+	// - Camera stays 1:1 with the HMD at render rate (no tick-rate stepping).
+	// - The player entity is only pulled/teleported when the camera drifts too far away.
+	// - Roomscale is optionally disabled while thumbstick locomotion is active to avoid conflicts.
+	bool m_Roomscale1To1DecoupleCamera = true;
+	bool m_Roomscale1To1UseCameraDistanceChase = true;
+	bool m_Roomscale1To1DisableWhileThumbstick = true;
+	float m_Roomscale1To1AllowedCameraDriftMeters = 0.25f;
+	float m_Roomscale1To1ChaseHysteresisMeters = 0.05f;
+	float m_Roomscale1To1MinApplyMeters = 0.02f;
+	bool m_Roomscale1To1ChaseActive = false;
+
 	Vector m_Roomscale1To1PrevCorrectedAbs = {};
 	// Accumulate sub-centimeter HMD deltas so slow walking/leaning still produces movement.
 	// This is in *meters* in the same corrected space as m_HmdPosCorrectedPrev.

--- a/L4D2VR/vr/vr_roomscale_prediction.inl
+++ b/L4D2VR/vr/vr_roomscale_prediction.inl
@@ -100,14 +100,10 @@ void VR::EncodeRoomscale1To1Move(CUserCmd* cmd)
         m_Roomscale1To1PrevCorrectedAbs = m_HmdPosCorrectedPrev;
         m_Roomscale1To1PrevValid = true;
 
-        // Chase mode must not fight normal locomotion (keyboard/thumbstick).
-        // When the engine is already moving the player, any camera/player drift here is expected.
-        // If we chase at the same time, it manifests as a tiny "pull back" every time you move.
-        const bool anyLocomotionNow =
-            (fabsf(cmd->forwardmove) > 0.5f) ||
-            (fabsf(cmd->sidemove) > 0.5f) ||
-            (fabsf(cmd->upmove) > 0.5f) ||
-            m_PushingThumbstick;
+        // Chase mode should not fight normal locomotion (keyboard/thumbstick).
+        // While locomotion is active, the engine is already moving the player and third-person camera
+        // can introduce intentional camera/player offsets. So disable chase and reset state.
+        const bool anyLocomotionNow = m_LocomotionActive || (fabsf(cmd->forwardmove) > 0.5f) || (fabsf(cmd->sidemove) > 0.5f) || (fabsf(cmd->upmove) > 0.5f);
         if (anyLocomotionNow)
         {
             m_Roomscale1To1ChaseActive = false;

--- a/L4D2VR/vr/vr_roomscale_prediction.inl
+++ b/L4D2VR/vr/vr_roomscale_prediction.inl
@@ -79,6 +79,17 @@ void VR::EncodeRoomscale1To1Move(CUserCmd* cmd)
         m_Roomscale1To1PrevValid = true;
         m_Roomscale1To1AccumMeters = Vector(0.0f, 0.0f, 0.0f);
         m_Roomscale1To1ChaseActive = false;
+        m_Roomscale1To1LocomotionCooldownCmds = 8;
+        return;
+    }
+
+    if (m_Roomscale1To1LocomotionCooldownCmds > 0)
+    {
+        --m_Roomscale1To1LocomotionCooldownCmds;
+        m_Roomscale1To1PrevCorrectedAbs = m_HmdPosCorrectedPrev;
+        m_Roomscale1To1PrevValid = true;
+        m_Roomscale1To1AccumMeters = Vector(0.0f, 0.0f, 0.0f);
+        m_Roomscale1To1ChaseActive = false;
         return;
     }
 
@@ -94,6 +105,8 @@ void VR::EncodeRoomscale1To1Move(CUserCmd* cmd)
         m_Roomscale1To1PrevValid = true;
         m_Roomscale1To1AccumMeters = Vector(0.0f, 0.0f, 0.0f);
         m_Roomscale1To1ChaseActive = false;
+        if (locomotionBlock)
+            m_Roomscale1To1LocomotionCooldownCmds = 8;
         return;
     }
 
@@ -290,7 +303,8 @@ void VR::OnPredictionRunCommand(CUserCmd* cmd)
         (fabsf(cmd->sidemove) > 0.5f) ||
         (fabsf(cmd->upmove) > 0.5f) ||
         m_LocomotionActive ||
-        m_PushingThumbstick;
+        m_PushingThumbstick ||
+        (m_Roomscale1To1LocomotionCooldownCmds > 0);
     if (controlLocomotionNow)
         return;
 

--- a/L4D2VR/vr/vr_roomscale_prediction.inl
+++ b/L4D2VR/vr/vr_roomscale_prediction.inl
@@ -100,6 +100,17 @@ void VR::EncodeRoomscale1To1Move(CUserCmd* cmd)
         m_Roomscale1To1PrevCorrectedAbs = m_HmdPosCorrectedPrev;
         m_Roomscale1To1PrevValid = true;
 
+        // Chase mode should not fight normal locomotion (keyboard/thumbstick).
+        // While locomotion is active, the engine is already moving the player and third-person camera
+        // can introduce intentional camera/player offsets. So disable chase and reset state.
+        const bool anyLocomotionNow = m_LocomotionActive || (fabsf(cmd->forwardmove) > 0.5f) || (fabsf(cmd->sidemove) > 0.5f) || (fabsf(cmd->upmove) > 0.5f);
+        if (anyLocomotionNow)
+        {
+            m_Roomscale1To1ChaseActive = false;
+            m_Roomscale1To1AccumMeters = Vector(0.0f, 0.0f, 0.0f);
+            return;
+        }
+
         Vector toCamU = m_SetupOriginToHMD;
         toCamU.z = 0.0f;
 

--- a/L4D2VR/vr/vr_roomscale_prediction.inl
+++ b/L4D2VR/vr/vr_roomscale_prediction.inl
@@ -100,10 +100,14 @@ void VR::EncodeRoomscale1To1Move(CUserCmd* cmd)
         m_Roomscale1To1PrevCorrectedAbs = m_HmdPosCorrectedPrev;
         m_Roomscale1To1PrevValid = true;
 
-        // Chase mode should not fight normal locomotion (keyboard/thumbstick).
-        // While locomotion is active, the engine is already moving the player and third-person camera
-        // can introduce intentional camera/player offsets. So disable chase and reset state.
-        const bool anyLocomotionNow = m_LocomotionActive || (fabsf(cmd->forwardmove) > 0.5f) || (fabsf(cmd->sidemove) > 0.5f) || (fabsf(cmd->upmove) > 0.5f);
+        // Chase mode must not fight normal locomotion (keyboard/thumbstick).
+        // When the engine is already moving the player, any camera/player drift here is expected.
+        // If we chase at the same time, it manifests as a tiny "pull back" every time you move.
+        const bool anyLocomotionNow =
+            (fabsf(cmd->forwardmove) > 0.5f) ||
+            (fabsf(cmd->sidemove) > 0.5f) ||
+            (fabsf(cmd->upmove) > 0.5f) ||
+            m_PushingThumbstick;
         if (anyLocomotionNow)
         {
             m_Roomscale1To1ChaseActive = false;

--- a/L4D2VR/vr/vr_roomscale_prediction.inl
+++ b/L4D2VR/vr/vr_roomscale_prediction.inl
@@ -62,13 +62,13 @@ void VR::EncodeRoomscale1To1Move(CUserCmd* cmd)
     cmd->buttons &= ~(int)kRSButtonsMask;
     cmd->weaponsubtype = 0;
 
-    const bool stickBlock = m_Roomscale1To1DisableWhileThumbstick && m_PushingThumbstick;
+    const bool locomotionBlock = m_Roomscale1To1DisableWhileThumbstick && m_LocomotionActive;
 
     // Not in 1:1 server-teleport mode: keep continuity for when it re-enables.
-    if (m_ForceNonVRServerMovement || stickBlock)
+    if (m_ForceNonVRServerMovement || locomotionBlock)
     {
         if (m_Roomscale1To1DebugLog && !ShouldThrottle(m_Roomscale1To1DebugLastEncode, m_Roomscale1To1DebugLogHz))
-            Game::logMsg("[VR][1to1][encode] skip (%s) cmd=%d", m_ForceNonVRServerMovement ? "ForceNonVRServerMovement=true" : "thumbstick", cmd->command_number);
+            Game::logMsg("[VR][1to1][encode] skip (%s) cmd=%d", m_ForceNonVRServerMovement ? "ForceNonVRServerMovement=true" : "locomotion", cmd->command_number);
 
         m_Roomscale1To1PrevCorrectedAbs = m_HmdPosCorrectedPrev;
         m_Roomscale1To1PrevValid = true;

--- a/L4D2VR/vr/vr_tracking.inl
+++ b/L4D2VR/vr/vr_tracking.inl
@@ -134,12 +134,11 @@ void VR::UpdateTracking()
     // Mounted gun (.50cal/minigun):
     // - Render hook forces first-person while mounted.
     // - When we exit the mounted gun, do a one-shot ResetPosition to re-align anchors.
-    {
-        const bool usingMountedGunNow = IsUsingMountedGun(localPlayer);
-        if (m_UsingMountedGunPrev && !usingMountedGunNow)
-            m_ResetPositionAfterMountedGunExitPending = true;
-        m_UsingMountedGunPrev = usingMountedGunNow;
-    }
+    const bool usingMountedGunNow = IsUsingMountedGun(localPlayer);
+    if (m_UsingMountedGunPrev && !usingMountedGunNow)
+        m_ResetPositionAfterMountedGunExitPending = true;
+    m_UsingMountedGunPrev = usingMountedGunNow;
+
     m_Game->m_IsMeleeWeaponActive = viewPlayer->IsMeleeWeaponActive();
 
     // Scope: only render/show when holding a firearm
@@ -390,10 +389,16 @@ void VR::UpdateTracking()
     // - 1:1 server roomscale (ForceNonVRServerMovement=false): optionally keep the camera fully decoupled from the tick-rate player origin
     //   so HMD motion stays smooth at headset refresh rate.
     const bool want1to1DecoupledCamera =
-        m_Roomscale1To1Movement && !m_ForceNonVRServerMovement && m_Roomscale1To1DecoupleCamera && !m_LocomotionActive;
+        m_Roomscale1To1Movement && !m_ForceNonVRServerMovement && m_Roomscale1To1DecoupleCamera && !m_LocomotionActive && !usingMountedGunNow;
 
     if (inEyeObserver)
     {
+        m_RoomscaleActive = false;
+    }
+    else if (usingMountedGunNow)
+    {
+        // Mounted guns force first-person render path; keep roomscale anchor coupled to avoid
+        // first/third-person render-path thrashing when decoupled camera mode is enabled.
         m_RoomscaleActive = false;
     }
     else if (want1to1DecoupledCamera)

--- a/L4D2VR/vr/vr_tracking.inl
+++ b/L4D2VR/vr/vr_tracking.inl
@@ -390,7 +390,7 @@ void VR::UpdateTracking()
     // - 1:1 server roomscale (ForceNonVRServerMovement=false): optionally keep the camera fully decoupled from the tick-rate player origin
     //   so HMD motion stays smooth at headset refresh rate.
     const bool want1to1DecoupledCamera =
-        m_Roomscale1To1Movement && !m_ForceNonVRServerMovement && m_Roomscale1To1DecoupleCamera && !m_PushingThumbstick;
+        m_Roomscale1To1Movement && !m_ForceNonVRServerMovement && m_Roomscale1To1DecoupleCamera && !m_LocomotionActive;
 
     if (inEyeObserver)
     {
@@ -413,12 +413,12 @@ void VR::UpdateTracking()
     // Keep the legacy "camera following" escape hatch, but never override the explicit 1:1 decoupled camera mode.
     if (!want1to1DecoupledCamera)
     {
-        if ((cameraFollowing < 0 && cameraDistance > 1) || (m_PushingThumbstick))
+        if ((cameraFollowing < 0 && cameraDistance > 1) || (m_LocomotionActive))
             m_RoomscaleActive = false;
     }
     else
     {
-        if (m_PushingThumbstick)
+        if (m_LocomotionActive)
             m_RoomscaleActive = false;
     }
 

--- a/L4D2VR/vr/vr_tracking.inl
+++ b/L4D2VR/vr/vr_tracking.inl
@@ -390,7 +390,7 @@ void VR::UpdateTracking()
     // - 1:1 server roomscale (ForceNonVRServerMovement=false): optionally keep the camera fully decoupled from the tick-rate player origin
     //   so HMD motion stays smooth at headset refresh rate.
     const bool want1to1DecoupledCamera =
-        m_Roomscale1To1Movement && !m_ForceNonVRServerMovement && m_Roomscale1To1DecoupleCamera && !m_LocomotionActive;
+        m_Roomscale1To1Movement && !m_ForceNonVRServerMovement && m_Roomscale1To1DecoupleCamera;
 
     if (inEyeObserver)
     {
@@ -413,17 +413,33 @@ void VR::UpdateTracking()
     // Keep the legacy "camera following" escape hatch, but never override the explicit 1:1 decoupled camera mode.
     if (!want1to1DecoupledCamera)
     {
-        if ((cameraFollowing < 0 && cameraDistance > 1) || (m_LocomotionActive))
-            m_RoomscaleActive = false;
-    }
-    else
-    {
-        if (m_LocomotionActive)
+        if ((cameraFollowing < 0 && cameraDistance > 1) || (m_PushingThumbstick))
             m_RoomscaleActive = false;
     }
 
-    if (!m_RoomscaleActive)
-        m_CameraAnchor += m_SetupOrigin - m_SetupOriginPrev;
+    if (want1to1DecoupledCamera && !inEyeObserver)
+    {
+        // Smooth locomotion at render rate:
+        // Local player origin advances at tick rate (e.g. 30Hz), which looks like "move-pause-move" on 90Hz+ HMDs.
+        // In 1:1 server roomscale mode we keep the camera anchored to the HMD (roomscaleActive=true) and advance the
+        // camera anchor using predicted velocity, then softly correct toward the tick origin to avoid long-term drift.
+        const float dt = std::max(0.0f, m_LastFrameDuration);
+        Vector vel = localPlayer ? localPlayer->m_vecVelocity : Vector(0, 0, 0);
+        vel.z = 0.0f;
+
+        if (dt > 0.0f)
+            m_CameraAnchor += vel * dt;
+
+        const float tau = 0.050f; // seconds
+        const float alpha = (dt > 0.0f) ? (1.0f - expf(-dt / std::max(0.0001f, tau))) : 1.0f;
+        m_CameraAnchor.x += (m_SetupOrigin.x - m_CameraAnchor.x) * alpha;
+        m_CameraAnchor.y += (m_SetupOrigin.y - m_CameraAnchor.y) * alpha;
+    }
+    else
+    {
+        if (!m_RoomscaleActive)
+            m_CameraAnchor += m_SetupOrigin - m_SetupOriginPrev;
+    }
 
     m_CameraAnchor.z = m_SetupOrigin.z + m_HeightOffset;
 

--- a/L4D2VR/vr/vr_viewmodel_config.inl
+++ b/L4D2VR/vr/vr_viewmodel_config.inl
@@ -994,6 +994,15 @@ void VR::ParseConfigFile()
     m_Roomscale1To1DebugLog = getBool("Roomscale1To1DebugLog", m_Roomscale1To1DebugLog);
     m_Roomscale1To1DebugLogHz = getFloat("Roomscale1To1DebugLogHz", m_Roomscale1To1DebugLogHz);
 
+    // 1:1 roomscale camera decoupling / chase
+    m_Roomscale1To1DecoupleCamera = getBool("Roomscale1To1DecoupleCamera", m_Roomscale1To1DecoupleCamera);
+    m_Roomscale1To1UseCameraDistanceChase = getBool("Roomscale1To1UseCameraDistanceChase", m_Roomscale1To1UseCameraDistanceChase);
+    m_Roomscale1To1DisableWhileThumbstick = getBool("Roomscale1To1DisableWhileThumbstick", m_Roomscale1To1DisableWhileThumbstick);
+    m_Roomscale1To1AllowedCameraDriftMeters = std::max(0.0f, getFloat("Roomscale1To1AllowedCameraDriftMeters", m_Roomscale1To1AllowedCameraDriftMeters));
+    m_Roomscale1To1ChaseHysteresisMeters = std::max(0.0f, getFloat("Roomscale1To1ChaseHysteresisMeters", m_Roomscale1To1ChaseHysteresisMeters));
+    m_Roomscale1To1MinApplyMeters = std::max(0.0f, getFloat("Roomscale1To1MinApplyMeters", m_Roomscale1To1MinApplyMeters));
+    m_Roomscale1To1ChaseActive = false;
+
     // Mouse mode (desktop-style aiming while staying in VR rendering)
     m_MouseModeEnabled = getBool("MouseModeEnabled", m_MouseModeEnabled);
     m_MouseModeAimFromHmd = getBool("MouseModeAimFromHmd", m_MouseModeAimFromHmd);

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -501,6 +501,92 @@ Option g_Options[] =
         0.0f, 0.0f,
         "false"
     },
+
+    // Movement / Roomscale
+    {
+        "Roomscale1To1Movement",
+        OptionType::Bool,
+        { u8"Movement / Roomscale", u8"移动 / 房间规模" },
+        { u8"Enable 1:1 Roomscale Server Movement", u8"启用 1:1 房间规模移动" },
+        { u8"When enabled (and ForceNonVRServerMovement=false), room-scale HMD translation is applied to the player entity on VR-aware servers.",
+          u8"开启后（且 ForceNonVRServerMovement=false），会在支持VR的服务器上把HMD的平面位移应用到玩家实体。" },
+        { u8"Disable on servers that don't run the VR plugin.",
+          u8"如果服务器不跑VR插件请关闭。" },
+        0.0f, 0.0f,
+        "true"
+    },
+    {
+        "Roomscale1To1DecoupleCamera",
+        OptionType::Bool,
+        { u8"Movement / Roomscale", u8"移动 / 房间规模" },
+        { u8"Decouple Camera From Tick Movement", u8"相机不跟随Tick位移" },
+        { u8"Keeps the VR camera 1:1 with the HMD at headset refresh rate, even when the player entity updates at tick rate.",
+          u8"即使玩家实体按tick更新，也让VR相机始终以头显刷新率做1:1渲染（避免步进感）。" },
+        { u8"Recommended for 90Hz+ headsets.",
+          u8"90Hz+头显建议开启。" },
+        0.0f, 0.0f,
+        "true"
+    },
+    {
+        "Roomscale1To1UseCameraDistanceChase",
+        OptionType::Bool,
+        { u8"Movement / Roomscale", u8"移动 / 房间规模" },
+        { u8"Move Player Only When Camera Drifts", u8"仅在相机偏离时移动人物" },
+        { u8"Instead of pushing the player every tick, only pull the player entity when the camera drifts beyond the allowed radius.",
+          u8"不再每个tick都推人物，而是当相机偏离超过允许半径时才拉人物。" },
+        { u8"Feels smoother on low-tick servers.",
+          u8"低tick（如30Hz）更顺滑。" },
+        0.0f, 0.0f,
+        "true"
+    },
+    {
+        "Roomscale1To1AllowedCameraDriftMeters",
+        OptionType::Float,
+        { u8"Movement / Roomscale", u8"移动 / 房间规模" },
+        { u8"Allowed Camera Drift (m)", u8"允许相机偏离距离（米）" },
+        { u8"Planar distance the camera can drift away from the player before the player is pulled/teleported.",
+          u8"相机在平面上允许偏离玩家的距离；超过后会拉/传送玩家。" },
+        { u8"Bigger = more leaning without moving; smaller = tighter tether.",
+          u8"越大越能自然探头；越小越紧。" },
+        0.0f, 1.0f,
+        "0.25"
+    },
+    {
+        "Roomscale1To1ChaseHysteresisMeters",
+        OptionType::Float,
+        { u8"Movement / Roomscale", u8"移动 / 房间规模" },
+        { u8"Chase Hysteresis (m)", u8"追随滞回（米）" },
+        { u8"Prevents oscillation around the drift threshold by adding a small stop margin.",
+          u8"通过增加停止边界避免在阈值附近抖动。" },
+        { u8"Try 0.03~0.08.",
+          u8"建议 0.03~0.08。" },
+        0.0f, 0.25f,
+        "0.05"
+    },
+    {
+        "Roomscale1To1MinApplyMeters",
+        OptionType::Float,
+        { u8"Movement / Roomscale", u8"移动 / 房间规模" },
+        { u8"Minimum Move Threshold (m)", u8"最小触发移动距离（米）" },
+        { u8"Ignores micro head jitter. Player won't move unless the required movement exceeds this threshold.",
+          u8"忽略头部微小抖动；小于该阈值不会触发人物移动。" },
+        { u8"Helps avoid conflicts with thumbstick locomotion.",
+          u8"可减少与摇杆移动冲突。" },
+        0.0f, 0.20f,
+        "0.02"
+    },
+    {
+        "Roomscale1To1DisableWhileThumbstick",
+        OptionType::Bool,
+        { u8"Movement / Roomscale", u8"移动 / 房间规模" },
+        { u8"Disable Roomscale While Thumbstick Moving", u8"摇杆移动时禁用房间规模" },
+        { u8"Disables 1:1 roomscale encoding while thumbstick locomotion is active to prevent movement conflicts.",
+          u8"摇杆移动时禁用1:1房间规模编码，避免移动冲突（人物会顿一下）。" },
+        { u8"Recommended if you use stick locomotion often.",
+          u8"经常用摇杆移动建议开启。" },
+        0.0f, 0.0f,
+        "true"
+    },
     // HUD (Main)
     {
         "HudDistance",


### PR DESCRIPTION
### Motivation

- Reduce visible tick-rate "stepping" on high-refresh HMDs by optionally keeping the VR camera 1:1 with the HMD while only pulling the player entity when the camera drifts too far.
- Avoid conflicts between thumbstick locomotion and roomscale encoding by making roomscale encoding suppressible while the stick is being used. 
- Expose tunable parameters (drift distance, hysteresis, min-apply, max step) so behavior can be adjusted for different headsets and server tick rates.

### Description

- Add new runtime state and config fields to `VR` for decoupled 1:1 camera/chase behavior, thumbstick suppression and thresholds (`L4D2VR/vr.h`).
- Expose new options in the config tool under `Movement / Roomscale` with EN/ZH labels and defaults (`L4D2VRConfigTool/src/Options.cpp`).
- Track thumbstick locomotion state in `CreateMove` by setting `m_PushingThumbstick` so roomscale logic can be blocked while the stick is active (`L4D2VR/hooks/hooks_createmove.inl`).
- Update tracking (`L4D2VR/vr/vr_tracking.inl`) to support an explicit 1:1 decoupled-camera mode while preserving the legacy standing-still and camera-following fallbacks.
- Rework the roomscale encode/predict path (`L4D2VR/vr/vr_roomscale_prediction.inl`) to: clear/repack the button payload safely, optionally block encoding during thumbstick use, implement camera-distance chase with hysteresis and a minimum-apply threshold, and keep the legacy per-tick delta behavior as a fallback.
- Wire the new settings into config parsing and reset chase runtime state on parse/load (`L4D2VR/vr/vr_viewmodel_config.inl`).

### Testing

- Ran `git diff --check` which reported no whitespace or index conflicts and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69991065318c83219fb45e08a3064bf7)