### PR TITLE
Add controller-anchored hand HUD overlays (wrist + ammo)

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -2,6 +2,7 @@
 #include <Windows.h>
 #include "openvr.h"
 #include "vector.h"
+#include <cstdint>
 #include <array>
 #include <chrono>
 #include <algorithm>
@@ -71,6 +72,10 @@ public:
 	vr::VROverlayHandle_t m_ScopeHandle = vr::k_ulOverlayHandleInvalid;
 	// Rear mirror overlay (off-hand)
 	vr::VROverlayHandle_t m_RearMirrorHandle = vr::k_ulOverlayHandleInvalid;
+	// Hand HUD overlays (raw, controller-anchored)
+	vr::VROverlayHandle_t m_LeftWristHudHandle = vr::k_ulOverlayHandleInvalid;
+	vr::VROverlayHandle_t m_RightAmmoHudHandle = vr::k_ulOverlayHandleInvalid;
+
 
 	float m_HorizontalOffsetLeft;
 	float m_VerticalOffsetLeft;
@@ -479,6 +484,45 @@ public:
 	bool m_HudToggleState = false;
 	std::chrono::steady_clock::time_point m_HudChatVisibleUntil{};
 
+	// ----------------------------
+	// Hand HUD overlays (SteamVR overlays, raw textures)
+	// ----------------------------
+	bool  m_LeftWristHudEnabled = false;
+	float m_LeftWristHudWidthMeters = 0.11f;
+	float m_LeftWristHudXOffset = -0.02f;
+	float m_LeftWristHudYOffset = 0.02f;
+	float m_LeftWristHudZOffset = 0.07f;
+	QAngle m_LeftWristHudAngleOffset = { -45.0f, 0.0f, 90.0f };
+
+	bool  m_RightAmmoHudEnabled = false;
+	float m_RightAmmoHudWidthMeters = 0.12f;
+	float m_RightAmmoHudXOffset = 0.02f;
+	float m_RightAmmoHudYOffset = 0.00f;
+	float m_RightAmmoHudZOffset = 0.09f;
+	QAngle m_RightAmmoHudAngleOffset = { 0.0f, 0.0f, 0.0f };
+
+	float m_HandHudMaxHz = 30.0f;
+	std::chrono::steady_clock::time_point m_LastHandHudUpdateTime{};
+	std::vector<uint8_t> m_LeftWristHudPixels{};
+	std::vector<uint8_t> m_RightAmmoHudPixels{};
+	int m_LeftWristHudTexW = 256;
+	int m_LeftWristHudTexH = 128;
+	int m_RightAmmoHudTexW = 256;
+	int m_RightAmmoHudTexH = 128;
+	// Cached values (avoid redrawing every frame)
+	int  m_LastHudHealth = -9999;
+	int  m_LastHudTempHealth = -9999;
+	int  m_LastHudThrowable = -1;
+	int  m_LastHudMedItem = -1;
+	int  m_LastHudPillItem = -1;
+	bool m_LastHudIncap = false;
+	bool m_LastHudLedge = false;
+	bool m_LastHudThirdStrike = false;
+	int  m_LastHudClip = -9999;
+	int  m_LastHudReserve = -9999;
+	int  m_LastHudUpg = -9999;
+	int  m_LastHudUpgBits = 0;
+
 	float m_ControllerSmoothing = 0.0f;
 	bool m_ControllerSmoothingInitialized = false;
 	float m_HeadSmoothing = 0.0f;
@@ -636,6 +680,18 @@ public:
 	static constexpr int kTeamNumOffset = 0xE4; // DT_BaseEntity::m_iTeamNum
 	static constexpr int kObserverModeOffset = 0x1450; // C_BasePlayer::m_iObserverMode
 	static constexpr int kObserverTargetOffset = 0x1454; // C_BasePlayer::m_hObserverTarget
+
+	// Common netvars (from offsets.txt) used by hand HUD overlays
+	static constexpr int kHealthOffset = 0xEC;               // DT_BasePlayer::m_iHealth
+	static constexpr int kAmmoArrayOffset = 0xF24;            // DT_BasePlayer::m_iAmmo (int array)
+	static constexpr int kHealthBufferOffset = 0x1FAC;        // DT_TerrorPlayer::m_healthBuffer (temporary HP)
+	static constexpr int kIsOnThirdStrikeOffset = 0x1EC0;     // DT_TerrorPlayer::m_bIsOnThirdStrike
+	static constexpr int kIsHangingFromLedgeOffset = 0x25EC;  // DT_TerrorPlayer::m_isHangingFromLedge
+	// Weapon netvars (from offsets.txt)
+	static constexpr int kClip1Offset = 0x984;                // DT_BaseCombatWeapon::m_iClip1
+	static constexpr int kPrimaryAmmoTypeOffset = 0x97C;       // DT_BaseCombatWeapon::m_iPrimaryAmmoType
+	static constexpr int kUpgradedPrimaryAmmoLoadedOffset = 0xCB8; // m_nUpgradedPrimaryAmmoLoaded
+	static constexpr int kUpgradeBitVecOffset = 0xCF0;         // m_upgradeBitVec (incendiary/explosive/laser bits)
 
 
 	// Aim-line friendly-fire guard (client-side fire suppression)
@@ -926,6 +982,7 @@ public:
 	void RepositionOverlays();
 	void UpdateRearMirrorOverlayTransform();
 	void UpdateScopeOverlayTransform();
+	void UpdateHandHudOverlays();
 	void GetPoses();
 	bool UpdatePosesAndActions();
 	void GetViewParameters();

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -501,6 +501,14 @@ public:
 	float m_RightAmmoHudZOffset = 0.09f;
 	QAngle m_RightAmmoHudAngleOffset = { 0.0f, 0.0f, 0.0f };
 
+	float m_LeftWristHudCurvature = 0.20f;
+	bool  m_LeftWristHudShowBattery = true;
+	bool  m_LeftWristHudShowTeammates = true;
+
+	bool  m_RightAmmoHudShowWeaponName = true;
+
+	float m_HandHudBlinkHz = 4.0f;
+
 	float m_HandHudMaxHz = 30.0f;
 	std::chrono::steady_clock::time_point m_LastHandHudUpdateTime{};
 	std::vector<uint8_t> m_LeftWristHudPixels{};
@@ -522,6 +530,13 @@ public:
 	int  m_LastHudReserve = -9999;
 	int  m_LastHudUpg = -9999;
 	int  m_LastHudUpgBits = 0;
+
+	int  m_LastHudBatteryOffHand = -1;
+	int  m_LastHudBatteryGunHand = -1;
+	unsigned int m_LastHudTeamHash = 0;
+	bool m_LastHudInReload = false;
+	int  m_LastHudBlinkPhase = -1;
+	int  m_LastHudWeaponId = -1;
 
 	float m_ControllerSmoothing = 0.0f;
 	bool m_ControllerSmoothingInitialized = false;
@@ -689,6 +704,8 @@ public:
 	static constexpr int kIsHangingFromLedgeOffset = 0x25EC;  // DT_TerrorPlayer::m_isHangingFromLedge
 	// Weapon netvars (from offsets.txt)
 	static constexpr int kClip1Offset = 0x984;                // DT_BaseCombatWeapon::m_iClip1
+	static constexpr int kInReloadOffset = 0x9BD;              // DT_BaseCombatWeapon::m_bInReload
+
 	static constexpr int kPrimaryAmmoTypeOffset = 0x97C;       // DT_BaseCombatWeapon::m_iPrimaryAmmoType
 	static constexpr int kUpgradedPrimaryAmmoLoadedOffset = 0xCB8; // m_nUpgradedPrimaryAmmoLoaded
 	static constexpr int kUpgradeBitVecOffset = 0xCF0;         // m_upgradeBitVec (incendiary/explosive/laser bits)

--- a/L4D2VR/vr/vr_viewmodel_config.inl
+++ b/L4D2VR/vr/vr_viewmodel_config.inl
@@ -806,6 +806,10 @@ void VR::ParseConfigFile()
         m_LeftWristHudAngleOffset = { ang.x, ang.y, ang.z };
     }
 
+    m_LeftWristHudCurvature = std::clamp(getFloat("LeftWristHudCurvature", m_LeftWristHudCurvature), 0.0f, 1.0f);
+    m_LeftWristHudShowBattery = getBool("LeftWristHudShowBattery", m_LeftWristHudShowBattery);
+    m_LeftWristHudShowTeammates = getBool("LeftWristHudShowTeammates", m_LeftWristHudShowTeammates);
+
     m_RightAmmoHudEnabled = getBool("RightAmmoHudEnabled", m_RightAmmoHudEnabled);
     m_RightAmmoHudWidthMeters = std::clamp(getFloat("RightAmmoHudWidthMeters", m_RightAmmoHudWidthMeters), 0.01f, 1.0f);
     m_RightAmmoHudXOffset = getFloat("RightAmmoHudXOffset", m_RightAmmoHudXOffset);
@@ -817,7 +821,10 @@ void VR::ParseConfigFile()
         m_RightAmmoHudAngleOffset = { ang.x, ang.y, ang.z };
     }
 
+    m_RightAmmoHudShowWeaponName = getBool("RightAmmoHudShowWeaponName", m_RightAmmoHudShowWeaponName);
+
     m_HandHudMaxHz = std::clamp(getFloat("HandHudMaxHz", m_HandHudMaxHz), 0.0f, 240.0f);
+    m_HandHudBlinkHz = std::clamp(getFloat("HandHudBlinkHz", m_HandHudBlinkHz), 0.0f, 30.0f);
     m_AntiAliasing = std::stol(userConfig["AntiAliasing"]);
     m_FixedHudYOffset = getFloat("FixedHudYOffset", m_FixedHudYOffset);
     m_FixedHudDistanceOffset = getFloat("FixedHudDistanceOffset", m_FixedHudDistanceOffset);

--- a/L4D2VR/vr/vr_viewmodel_config.inl
+++ b/L4D2VR/vr/vr_viewmodel_config.inl
@@ -793,6 +793,31 @@ void VR::ParseConfigFile()
     m_HudSize = getFloat("HudSize", m_HudSize);
     m_HudAlwaysVisible = getBool("HudAlwaysVisible", m_HudAlwaysVisible);
     m_HudToggleState = m_HudAlwaysVisible;
+
+    // Hand HUD overlays (SteamVR overlay, raw)
+    m_LeftWristHudEnabled = getBool("LeftWristHudEnabled", m_LeftWristHudEnabled);
+    m_LeftWristHudWidthMeters = std::clamp(getFloat("LeftWristHudWidthMeters", m_LeftWristHudWidthMeters), 0.01f, 1.0f);
+    m_LeftWristHudXOffset = getFloat("LeftWristHudXOffset", m_LeftWristHudXOffset);
+    m_LeftWristHudYOffset = getFloat("LeftWristHudYOffset", m_LeftWristHudYOffset);
+    m_LeftWristHudZOffset = getFloat("LeftWristHudZOffset", m_LeftWristHudZOffset);
+    {
+        const Vector def = { m_LeftWristHudAngleOffset.x, m_LeftWristHudAngleOffset.y, m_LeftWristHudAngleOffset.z };
+        const Vector ang = getVector3("LeftWristHudAngleOffset", def);
+        m_LeftWristHudAngleOffset = { ang.x, ang.y, ang.z };
+    }
+
+    m_RightAmmoHudEnabled = getBool("RightAmmoHudEnabled", m_RightAmmoHudEnabled);
+    m_RightAmmoHudWidthMeters = std::clamp(getFloat("RightAmmoHudWidthMeters", m_RightAmmoHudWidthMeters), 0.01f, 1.0f);
+    m_RightAmmoHudXOffset = getFloat("RightAmmoHudXOffset", m_RightAmmoHudXOffset);
+    m_RightAmmoHudYOffset = getFloat("RightAmmoHudYOffset", m_RightAmmoHudYOffset);
+    m_RightAmmoHudZOffset = getFloat("RightAmmoHudZOffset", m_RightAmmoHudZOffset);
+    {
+        const Vector def = { m_RightAmmoHudAngleOffset.x, m_RightAmmoHudAngleOffset.y, m_RightAmmoHudAngleOffset.z };
+        const Vector ang = getVector3("RightAmmoHudAngleOffset", def);
+        m_RightAmmoHudAngleOffset = { ang.x, ang.y, ang.z };
+    }
+
+    m_HandHudMaxHz = std::clamp(getFloat("HandHudMaxHz", m_HandHudMaxHz), 0.0f, 240.0f);
     m_AntiAliasing = std::stol(userConfig["AntiAliasing"]);
     m_FixedHudYOffset = getFloat("FixedHudYOffset", m_FixedHudYOffset);
     m_FixedHudDistanceOffset = getFloat("FixedHudDistanceOffset", m_FixedHudDistanceOffset);

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -625,6 +625,167 @@ Option g_Options[] =
         "true"
     },
 
+
+    // HUD (Hand)
+    {
+        "LeftWristHudEnabled",
+        OptionType::Bool,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Enable Wrist HUD (Off-hand)", u8"启用腕表HUD（副手）" },
+        { u8"Shows a small wrist-style HUD on the off-hand controller using a SteamVR overlay.",
+          u8"在副手手柄上用SteamVR覆盖层显示一个腕表式小HUD。" },
+        { u8"Displays HP and quick item status (throwable/med/pills or adrenaline).",
+          u8"显示生命值与关键物品状态（投掷物/医疗槽/药片或肾上腺素）。" },
+        0.0f, 0.0f,
+        "false"
+    },
+    {
+        "LeftWristHudWidthMeters",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Wrist HUD Width (meters)", u8"腕表HUD宽度（米）" },
+        { u8"Physical width of the wrist HUD overlay quad (meters).",
+          u8"腕表HUD覆盖层平面的物理宽度（米）。" },
+        { u8"Bigger = easier to read, but can feel intrusive.",
+          u8"越大越容易看清，但也更显眼。" },
+        0.01f, 0.40f,
+        "0.11"
+    },
+    {
+        "LeftWristHudXOffset",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Wrist HUD X Offset", u8"腕表HUD X偏移" },
+        { u8"Overlay translation in controller local space (meters).",
+          u8"覆盖层在手柄本地坐标系中的平移（米）。" },
+        { u8"Uses the same axis convention as other overlay offsets (ScopeOverlay*).",
+          u8"与其他覆盖层偏移（ScopeOverlay*）使用相同坐标约定。" },
+        -0.25f, 0.25f,
+        "-0.02"
+    },
+    {
+        "LeftWristHudYOffset",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Wrist HUD Y Offset", u8"腕表HUD Y偏移" },
+        { u8"Overlay translation in controller local space (meters).",
+          u8"覆盖层在手柄本地坐标系中的平移（米）。" },
+        { u8"Uses the same axis convention as other overlay offsets (ScopeOverlay*).",
+          u8"与其他覆盖层偏移（ScopeOverlay*）使用相同坐标约定。" },
+        -0.25f, 0.25f,
+        "0.02"
+    },
+    {
+        "LeftWristHudZOffset",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Wrist HUD Z Offset", u8"腕表HUD Z偏移" },
+        { u8"Overlay translation in controller local space (meters).",
+          u8"覆盖层在手柄本地坐标系中的平移（米）。" },
+        { u8"Uses the same axis convention as other overlay offsets (ScopeOverlay*).",
+          u8"与其他覆盖层偏移（ScopeOverlay*）使用相同坐标约定。" },
+        -0.25f, 0.25f,
+        "0.07"
+    },
+    {
+        "LeftWristHudAngleOffset",
+        OptionType::Vec3,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Wrist HUD Angle Offset (pitch,yaw,roll)", u8"腕表HUD角度偏移 (俯仰,偏航,翻滚)" },
+        { u8"Additional rotation for the wrist HUD overlay (degrees).",
+          u8"腕表HUD覆盖层的额外旋转（度）。" },
+        { u8"Adjust so it faces your eyes naturally.",
+          u8"调到看起来像贴在手腕上、自然朝向眼睛即可。" },
+        -180.f, 180.f,
+        "-45,0,90"
+    },
+
+    {
+        "RightAmmoHudEnabled",
+        OptionType::Bool,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Enable Ammo HUD (Gun-hand)", u8"启用弹药HUD（持枪手）" },
+        { u8"Shows a compact ammo HUD on the gun-hand controller using a SteamVR overlay.",
+          u8"在持枪手手柄上用SteamVR覆盖层显示一个科技感弹药框。" },
+        { u8"Displays clip/reserve and upgraded ammo when available.",
+          u8"显示弹匣/备弹，并在有特殊子弹时显示剩余量。" },
+        0.0f, 0.0f,
+        "false"
+    },
+    {
+        "RightAmmoHudWidthMeters",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Ammo HUD Width (meters)", u8"弹药HUD宽度（米）" },
+        { u8"Physical width of the ammo HUD overlay quad (meters).",
+          u8"弹药HUD覆盖层平面的物理宽度（米）。" },
+        { u8"Increase if numbers are too small.",
+          u8"如果数字太小就调大。" },
+        0.01f, 0.50f,
+        "0.12"
+    },
+    {
+        "RightAmmoHudXOffset",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Ammo HUD X Offset", u8"弹药HUD X偏移" },
+        { u8"Overlay translation in controller local space (meters).",
+          u8"覆盖层在手柄本地坐标系中的平移（米）。" },
+        { u8"Uses the same axis convention as other overlay offsets (ScopeOverlay*).",
+          u8"与其他覆盖层偏移（ScopeOverlay*）使用相同坐标约定。" },
+        -0.25f, 0.25f,
+        "0.02"
+    },
+    {
+        "RightAmmoHudYOffset",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Ammo HUD Y Offset", u8"弹药HUD Y偏移" },
+        { u8"Overlay translation in controller local space (meters).",
+          u8"覆盖层在手柄本地坐标系中的平移（米）。" },
+        { u8"Uses the same axis convention as other overlay offsets (ScopeOverlay*).",
+          u8"与其他覆盖层偏移（ScopeOverlay*）使用相同坐标约定。" },
+        -0.25f, 0.25f,
+        "0.00"
+    },
+    {
+        "RightAmmoHudZOffset",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Ammo HUD Z Offset", u8"弹药HUD Z偏移" },
+        { u8"Overlay translation in controller local space (meters).",
+          u8"覆盖层在手柄本地坐标系中的平移（米）。" },
+        { u8"Uses the same axis convention as other overlay offsets (ScopeOverlay*).",
+          u8"与其他覆盖层偏移（ScopeOverlay*）使用相同坐标约定。" },
+        -0.25f, 0.25f,
+        "0.09"
+    },
+    {
+        "RightAmmoHudAngleOffset",
+        OptionType::Vec3,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Ammo HUD Angle Offset (pitch,yaw,roll)", u8"弹药HUD角度偏移 (俯仰,偏航,翻滚)" },
+        { u8"Additional rotation for the ammo HUD overlay (degrees).",
+          u8"弹药HUD覆盖层的额外旋转（度）。" },
+        { u8"Adjust so it sits like a weapon-side panel.",
+          u8"调到像贴在武器旁边的小屏幕即可。" },
+        -180.f, 180.f,
+        "0,0,0"
+    },
+
+    {
+        "HandHudMaxHz",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Hand HUD Update Rate (Hz)", u8"手柄HUD刷新率(Hz)" },
+        { u8"Maximum update rate for hand HUD overlays. 0 disables throttling.",
+          u8"手柄HUD的最大刷新率。0表示不限制。" },
+        { u8"30 is plenty; lower reduces CPU overhead.",
+          u8"30就足够了；更低可以减少CPU开销。" },
+        0.0f, 240.0f,
+        "30"
+    },
+
     // Hands / Debug
     {
         "HideArms",

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -652,6 +652,42 @@ Option g_Options[] =
         "0.11"
     },
     {
+        "LeftWristHudCurvature",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Wrist HUD Curvature", u8"腕表HUD弧度" },
+        { u8"Curves the wrist HUD overlay so it wraps like a watch face (SteamVR overlay curvature).",
+          u8"让腕表HUD覆盖层呈弧面，像手表表盘一样贴合（SteamVR覆盖层曲率）。" },
+        { u8"0 = flat. Typical values: 0.1~0.3.",
+          u8"0为平面。常用范围：0.1~0.3。" },
+        0.0f, 1.0f,
+        "0.20"
+    },
+    {
+        "LeftWristHudShowBattery",
+        OptionType::Bool,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Show Controller Battery", u8"显示手柄电量" },
+        { u8"Shows off-hand and gun-hand controller battery percentage on the wrist HUD.",
+          u8"在腕表HUD上显示副手与持枪手手柄电量。" },
+        { u8"Useful for long sessions.",
+          u8"长时间游戏很实用。" },
+        0.0f, 0.0f,
+        "true"
+    },
+    {
+        "LeftWristHudShowTeammates",
+        OptionType::Bool,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Show Teammate Mini HP Bars", u8"显示队友小血条" },
+        { u8"Shows up to 3 teammate HP bars on the wrist HUD.",
+          u8"在腕表HUD上显示最多3名队友的小血条。" },
+        { u8"Includes temp HP and a third-strike frame.",
+          u8"包含临时血，并在黑白时加边框提示。" },
+        0.0f, 0.0f,
+        "true"
+    },
+    {
         "LeftWristHudXOffset",
         OptionType::Float,
         { u8"HUD (Hand)", u8"HUD（手柄）" },
@@ -725,6 +761,18 @@ Option g_Options[] =
         "0.12"
     },
     {
+        "RightAmmoHudShowWeaponName",
+        OptionType::Bool,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Show Weapon Short Tag", u8"显示武器短标签" },
+        { u8"Shows a short weapon tag (AK/SCAR/GL...) on the ammo HUD.",
+          u8"在弹药HUD上显示武器短标签（AK/SCAR/GL等）。" },
+        { u8"Helps at-a-glance identification.",
+          u8"快速确认当前武器类型。" },
+        0.0f, 0.0f,
+        "true"
+    },
+    {
         "RightAmmoHudXOffset",
         OptionType::Float,
         { u8"HUD (Hand)", u8"HUD（手柄）" },
@@ -784,6 +832,18 @@ Option g_Options[] =
           u8"30就足够了；更低可以减少CPU开销。" },
         0.0f, 240.0f,
         "30"
+    },
+    {
+        "HandHudBlinkHz",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Hand HUD Blink Rate (Hz)", u8"手柄HUD闪烁频率(Hz)" },
+        { u8"Blink frequency used for reload and low-ammo warnings.",
+          u8"用于装填中与缺弹警告的闪烁频率。" },
+        { u8"Set to 0 to disable blinking.",
+          u8"设为0可关闭闪烁。" },
+        0.0f, 30.0f,
+        "4"
     },
 
     // Hands / Debug


### PR DESCRIPTION
### Motivation

- Provide small, controller-anchored HUDs for VR: an off-hand wrist-style HUD showing HP/status/items and a gun-hand ammo HUD showing clip/reserve/upgraded ammo.
- Keep in-VR information glanceable without cluttering the main HUD or requiring in-world widgets.
- Make overlays configurable (size/offset/angle/update rate) and efficient by throttling and only redrawing on state change.

### Description

- Added overlay handles, per-overlay state, cached pixel buffers, texture sizes, cached HUD values and netvar offsets to `VR` state. (L4D2VR/vr.h)
- Implemented lightweight software rendering helpers and small bitmap/font/icon drawing utilities, created overlays during VR init, set input methods/flags, and added `UpdateHandHudOverlays()` which: gates by in-game/lifestate, anchors overlays to controller-tracked devices, throttles updates via `HandHudMaxHz`, computes and uploads raw RGBA textures with health/item and ammo panels, and shows/hides overlays. (L4D2VR/vr/vr_lifecycle.inl)
- Wired the per-frame update to call `UpdateHandHudOverlays()` from the main submit path and hid overlays on non-render paths. (L4D2VR/vr/vr_lifecycle.inl)
- Loaded new configuration keys in the VR config parser (`LeftWristHud*`, `RightAmmoHud*`, `HandHudMaxHz`) and clamped sensible ranges. (L4D2VR/vr/vr_viewmodel_config.inl)
- Added corresponding entries (EN/ZH text, ranges, defaults) to the config tool options so users can enable/tune the wrist and ammo HUDs. (L4D2VRConfigTool/src/Options.cpp)

### Testing

- Ran `git diff --check` to validate patch cleanliness and found no whitespace/patch errors (success).
- Ran `git status --short` to confirm modified files are tracked and included (success).
- Changes were committed to the local branch (`Add controller-anchored hand HUD overlays`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699955278cb0832199158ceea2b1d67a)