### PR TITLE
Hand HUD: overlay alpha, temp-health decay, battery scale & rendering improvements

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -488,6 +488,17 @@ public:
 	float m_LeftWristHudBgAlpha = 0.85f;
 	float m_RightAmmoHudBgAlpha = 0.70f;
 
+	// Hand HUD overall overlay alpha (0..1). Applied via IVROverlay::SetOverlayAlpha.
+	float m_LeftWristHudAlpha = 1.0f;
+	float m_RightAmmoHudAlpha = 1.0f;
+
+	// Left wrist HUD: battery label font scale (1..4) for DrawText5x7.
+	int   m_LeftWristHudBatteryTextScale = 1;
+
+	// Hand HUD: client-side temp health (m_healthBuffer) decay rate (HP per second).
+	// L4D2 default is ~0.27, but servers can override; expose as config for now.
+	float m_HandHudTempHealthDecayRate = 0.27f;
+
 	// ----------------------------
 	// Hand HUD overlays (SteamVR overlays, raw textures)
 	// ----------------------------
@@ -519,6 +530,20 @@ public:
 	int m_LeftWristHudTexH = 128;
 	int m_RightAmmoHudTexW = 256;
 	int m_RightAmmoHudTexH = 128;
+	// Hand HUD temp-health decay state (per player index).
+	// We only get m_healthBuffer (amount) + m_healthBufferTime (start time).
+	// The engine computes the decayed remaining value at draw time; we replicate that using wall-clock.
+	struct TempHealthDecayState
+	{
+		float rawBuffer = 0.0f;
+		float rawBufferTime = 0.0f;
+		std::chrono::steady_clock::time_point wallStart{};
+		float lastRemaining = 0.0f;
+		bool initialized = false;
+	};
+	static constexpr size_t kHandHudPlayerSlots = 65; // Source MAX_PLAYERS (incl. 1..64)
+	std::array<TempHealthDecayState, kHandHudPlayerSlots> m_HandHudTempHealthStates{};
+
 	// Cached values (avoid redrawing every frame)
 	int  m_LastHudHealth = -9999;
 	int  m_LastHudTempHealth = -9999;
@@ -700,6 +725,8 @@ public:
 	static constexpr int kHealthOffset = 0xEC;               // DT_BasePlayer::m_iHealth
 	static constexpr int kAmmoArrayOffset = 0xF24;            // DT_BasePlayer::m_iAmmo (int array)
 	static constexpr int kHealthBufferOffset = 0x1FAC;        // DT_TerrorPlayer::m_healthBuffer (temporary HP)
+	static constexpr int kHealthBufferTimeOffset = 0x1FB0;    // DT_TerrorPlayer::m_healthBufferTime
+	static constexpr int kSurvivorCharacterOffset = 0x1C8C;  // DT_TerrorPlayer::m_survivorCharacter
 	static constexpr int kIsOnThirdStrikeOffset = 0x1EC0;     // DT_TerrorPlayer::m_bIsOnThirdStrike
 	static constexpr int kIsHangingFromLedgeOffset = 0x25EC;  // DT_TerrorPlayer::m_isHangingFromLedge
 	// Weapon netvars (from offsets.txt)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -493,7 +493,7 @@ public:
 	float m_RightAmmoHudAlpha = 1.0f;
 
 	// Left wrist HUD: battery label font scale (1..4) for DrawText5x7.
-	int   m_LeftWristHudBatteryTextScale = 1;
+	int   m_LeftWristHudBatteryTextScale = 2;
 
 	// Hand HUD: client-side temp health (m_healthBuffer) decay rate (HP per second).
 	// L4D2 default is ~0.27, but servers can override; expose as config for now.
@@ -528,7 +528,7 @@ public:
 	std::vector<uint8_t> m_RightAmmoHudPixels{};
 	int m_LeftWristHudTexW = 256;
 	int m_LeftWristHudTexH = 128;
-	int m_RightAmmoHudTexW = 256;
+	int m_RightAmmoHudTexW = 192;
 	int m_RightAmmoHudTexH = 128;
 	// Hand HUD temp-health decay state (per player index).
 	// We only get m_healthBuffer (amount) + m_healthBufferTime (start time).

--- a/L4D2VR/vr/vr_lifecycle.inl
+++ b/L4D2VR/vr/vr_lifecycle.inl
@@ -2011,7 +2011,7 @@ void VR::UpdateHandHudOverlays()
                 std::snprintf(hpBuf, sizeof(hpBuf), "%d+%d", hp, tempHP);
             else
                 std::snprintf(hpBuf, sizeof(hpBuf), "%d", hp);
-            DrawText5x7(s, 18, 18, hpBuf, { 240, 240, 240, 255 }, 4);
+            DrawText5x7(s, 18, 20, hpBuf, { 240, 240, 240, 255 }, 3);
 
             if (m_LeftWristHudShowBattery && battL >= 0 && battR >= 0)
             {
@@ -2240,17 +2240,17 @@ void VR::UpdateHandHudOverlays()
             const Rgba resColor = resLow ? Rgba{ 255, 80, 80, 230 } : Rgba{ 200, 200, 200, 230 };
 
             const SevenSegStyle clipSt{ 12, 3, 2, 4 };
-            Draw7SegInt(s, 18, 24, std::max(0, clip), clipSt, clipColor);
+            Draw7SegInt(s, 16, 24, std::max(0, clip), clipSt, clipColor);
 
-            DrawText5x7(s, 18, 88, "/", { 200, 200, 200, 220 }, 3);
+            DrawText5x7(s, 92, 48, "/", { 200, 200, 200, 220 }, 3);
             if (pistolInfinite)
             {
-                DrawInfinity(s, 34, 90, 24, 10, { 240, 240, 240, 230 });
+                DrawInfinity(s, 112, 52, 24, 10, { 240, 240, 240, 230 });
             }
             else
             {
                 const SevenSegStyle resSt{ 8, 2, 2, 3 };
-                Draw7SegInt(s, 32, 86, std::max(0, reserve), resSt, resColor);
+                Draw7SegInt(s, 110, 44, std::max(0, reserve), resSt, resColor);
             }
 
             const bool hasInc = (upgBits & 1) != 0;

--- a/L4D2VR/vr/vr_viewmodel_config.inl
+++ b/L4D2VR/vr/vr_viewmodel_config.inl
@@ -798,6 +798,16 @@ void VR::ParseConfigFile()
     m_LeftWristHudBgAlpha = std::clamp(getFloat("LeftWristHudBgAlpha", m_LeftWristHudBgAlpha), 0.0f, 1.0f);
     m_RightAmmoHudBgAlpha = std::clamp(getFloat("RightAmmoHudBgAlpha", m_RightAmmoHudBgAlpha), 0.0f, 1.0f);
 
+    // Hand HUD overall overlay alpha (0..1)
+    m_LeftWristHudAlpha = std::clamp(getFloat("LeftWristHudAlpha", m_LeftWristHudAlpha), 0.0f, 1.0f);
+    m_RightAmmoHudAlpha = std::clamp(getFloat("RightAmmoHudAlpha", m_RightAmmoHudAlpha), 0.0f, 1.0f);
+
+    // Left wrist HUD: battery label font scale (1..4)
+    m_LeftWristHudBatteryTextScale = std::clamp(getInt("LeftWristHudBatteryTextScale", m_LeftWristHudBatteryTextScale), 1, 4);
+
+    // Hand HUD temp health decay (HP per second)
+    m_HandHudTempHealthDecayRate = std::max(0.0f, getFloat("HandHudTempHealthDecayRate", m_HandHudTempHealthDecayRate));
+
     // Hand HUD overlays (SteamVR overlay, raw)
     m_LeftWristHudEnabled = getBool("LeftWristHudEnabled", m_LeftWristHudEnabled);
     m_LeftWristHudWidthMeters = std::clamp(getFloat("LeftWristHudWidthMeters", m_LeftWristHudWidthMeters), 0.01f, 1.0f);


### PR DESCRIPTION
### Motivation
- Improve configurability and visual correctness of the hand HUD overlays and present accurate temporary health to the player and teammate rows.
- Make HUD overlays use correct texel aspect and allow per-overlay alpha and battery label scaling for better appearance and user tuning.

### Description
- Added new config/state fields: `m_LeftWristHudAlpha`, `m_RightAmmoHudAlpha`, `m_LeftWristHudBatteryTextScale`, and `m_HandHudTempHealthDecayRate`, and exposed them via `ParseConfigFile` with clamped/validated values.
- Implemented per-player temp-health decay tracking with `TempHealthDecayState` array and `computeDecayedTempHP` which derives decayed temp HP from `m_healthBuffer` + `m_healthBufferTime` using wall-clock time and the configurable decay rate.
- Applied overlay alpha with `IVROverlay::SetOverlayAlpha`, fixed texel aspect to `1.0f` (square pixels), used the battery text scale when drawing battery labels, and used the decayed temp HP for teammate rows.
- Added `survivorNameFromCharacter` fallback to show survivor-character names when player info is missing, and tightened seven-segment digit styles for the right-hand ammo HUD clip/reserve rendering.

### Testing
- Ran `git diff --check` which returned no problems and succeeded.
- Ran `git status --short` to verify working tree cleanliness which showed no outstanding changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999a5fe51c08321abd299de1eaee58c)