### PR TITLE
Enhance hand HUD overlay controls and temp-health handling

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -488,6 +488,17 @@ public:
 	float m_LeftWristHudBgAlpha = 0.85f;
 	float m_RightAmmoHudBgAlpha = 0.70f;
 
+	// Hand HUD overall overlay alpha (0..1). Applied via IVROverlay::SetOverlayAlpha.
+	float m_LeftWristHudAlpha = 1.0f;
+	float m_RightAmmoHudAlpha = 1.0f;
+
+	// Left wrist HUD: battery label font scale (1..4) for DrawText5x7.
+	int   m_LeftWristHudBatteryTextScale = 1;
+
+	// Hand HUD: client-side temp health (m_healthBuffer) decay rate (HP per second).
+	// L4D2 default is ~0.27, but servers can override; expose as config for now.
+	float m_HandHudTempHealthDecayRate = 0.27f;
+
 	// ----------------------------
 	// Hand HUD overlays (SteamVR overlays, raw textures)
 	// ----------------------------
@@ -519,6 +530,20 @@ public:
 	int m_LeftWristHudTexH = 128;
 	int m_RightAmmoHudTexW = 256;
 	int m_RightAmmoHudTexH = 128;
+	// Hand HUD temp-health decay state (per player index).
+	// We only get m_healthBuffer (amount) + m_healthBufferTime (start time).
+	// The engine computes the decayed remaining value at draw time; we replicate that using wall-clock.
+	struct TempHealthDecayState
+	{
+		float rawBuffer = 0.0f;
+		float rawBufferTime = 0.0f;
+		std::chrono::steady_clock::time_point wallStart{};
+		float lastRemaining = 0.0f;
+		bool initialized = false;
+	};
+	static constexpr size_t kHandHudPlayerSlots = 65; // Source MAX_PLAYERS (incl. 1..64)
+	std::array<TempHealthDecayState, kHandHudPlayerSlots> m_HandHudTempHealthStates{};
+
 	// Cached values (avoid redrawing every frame)
 	int  m_LastHudHealth = -9999;
 	int  m_LastHudTempHealth = -9999;
@@ -700,6 +725,8 @@ public:
 	static constexpr int kHealthOffset = 0xEC;               // DT_BasePlayer::m_iHealth
 	static constexpr int kAmmoArrayOffset = 0xF24;            // DT_BasePlayer::m_iAmmo (int array)
 	static constexpr int kHealthBufferOffset = 0x1FAC;        // DT_TerrorPlayer::m_healthBuffer (temporary HP)
+	static constexpr int kHealthBufferTimeOffset = 0x1FB0;    // DT_TerrorPlayer::m_healthBufferTime
+	static constexpr int kSurvivorCharacterOffset = 0x1C8C;  // DT_TerrorPlayer::m_survivorCharacter
 	static constexpr int kIsOnThirdStrikeOffset = 0x1EC0;     // DT_TerrorPlayer::m_bIsOnThirdStrike
 	static constexpr int kIsHangingFromLedgeOffset = 0x25EC;  // DT_TerrorPlayer::m_isHangingFromLedge
 	// Weapon netvars (from offsets.txt)

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -488,9 +488,10 @@ public:
 	float m_LeftWristHudBgAlpha = 0.85f;
 	float m_RightAmmoHudBgAlpha = 0.70f;
 
-	// Right ammo HUD: crop the displayed overlay to the left part of the texture.
-	// 1.0 = full texture width, ~0.33 = compact left-third view.
-	float m_RightAmmoHudUVMaxU = 0.34f;
+	// Right ammo HUD: maximum visible width fraction (U max).
+	// The HUD auto-computes a tight width for current ammo text and then clamps to this value.
+	// 1.0 = no clamp (recommended).
+	float m_RightAmmoHudUVMaxU = 1.0f;
 
 	// Hand HUD overall overlay alpha (0..1). Applied via IVROverlay::SetOverlayAlpha.
 	float m_LeftWristHudAlpha = 1.0f;
@@ -528,8 +529,11 @@ public:
 
 	float m_HandHudMaxHz = 30.0f;
 	std::chrono::steady_clock::time_point m_LastHandHudUpdateTime{};
-	std::vector<uint8_t> m_LeftWristHudPixels{};
-	std::vector<uint8_t> m_RightAmmoHudPixels{};
+	// Double-buffered pixel storage to avoid flicker/tearing while compositor reads prior frame.
+	std::array<std::vector<uint8_t>, 2> m_LeftWristHudPixels{};
+	std::array<std::vector<uint8_t>, 2> m_RightAmmoHudPixels{};
+	uint8_t m_LeftWristHudPixelsFront = 0;
+	uint8_t m_RightAmmoHudPixelsFront = 0;
 	int m_LeftWristHudTexW = 256;
 	int m_LeftWristHudTexH = 128;
 	int m_RightAmmoHudTexW = 256;

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -488,6 +488,10 @@ public:
 	float m_LeftWristHudBgAlpha = 0.85f;
 	float m_RightAmmoHudBgAlpha = 0.70f;
 
+	// Right ammo HUD: crop the displayed overlay to the left part of the texture.
+	// 1.0 = full texture width, ~0.33 = compact left-third view.
+	float m_RightAmmoHudUVMaxU = 0.34f;
+
 	// Hand HUD overall overlay alpha (0..1). Applied via IVROverlay::SetOverlayAlpha.
 	float m_LeftWristHudAlpha = 1.0f;
 	float m_RightAmmoHudAlpha = 1.0f;

--- a/L4D2VR/vr/vr_lifecycle.inl
+++ b/L4D2VR/vr/vr_lifecycle.inl
@@ -1823,6 +1823,70 @@ void VR::UpdateHandHudOverlays()
 
     const bool throttle = ShouldThrottle(m_LastHandHudUpdateTime, m_HandHudMaxHz);
 
+    // Compute decayed temp HP from (m_healthBuffer, m_healthBufferTime) using wall-clock time.
+    // The engine does: max(0, healthBuffer - decayRate * (curtime - healthBufferTime)).
+    // We don't have gpGlobals->curtime here, so we approximate with steady_clock since the
+    // last observed (bufferTime/buffer) update.
+    auto computeDecayedTempHP = [&](int entIndex, const unsigned char* entBase) -> int
+    {
+        if (!entBase)
+            return 0;
+
+        const float raw = std::max(0.0f, *reinterpret_cast<const float*>(entBase + kHealthBufferOffset));
+        const float rawTime = *reinterpret_cast<const float*>(entBase + kHealthBufferTimeOffset);
+        if (raw <= 0.0f)
+            return 0;
+
+        const int slot = std::max(0, std::min((int)m_HandHudTempHealthStates.size() - 1, entIndex));
+        TempHealthDecayState& st = m_HandHudTempHealthStates[(size_t)slot];
+
+        const auto now = std::chrono::steady_clock::now();
+
+        const bool newDoseOrReset = (!st.initialized)
+            || (std::fabs(rawTime - st.rawBufferTime) > 0.0001f)
+            || (raw > st.rawBuffer + 0.01f)
+            || (raw < st.rawBuffer - 0.01f);
+
+        if (newDoseOrReset)
+        {
+            st.rawBuffer = raw;
+            st.rawBufferTime = rawTime;
+            st.wallStart = now;
+            st.lastRemaining = raw;
+            st.initialized = true;
+        }
+
+        // Freeze decay while paused.
+        if (m_Game && m_Game->m_EngineClient && m_Game->m_EngineClient->IsPaused())
+        {
+            st.wallStart = now;
+            return (int)std::round(std::max(0.0f, st.lastRemaining));
+        }
+
+        const float elapsed = std::chrono::duration<float>(now - st.wallStart).count();
+        const float decayRate = std::max(0.0f, m_HandHudTempHealthDecayRate);
+        const float remaining = std::max(0.0f, st.rawBuffer - decayRate * elapsed);
+        st.lastRemaining = remaining;
+        return (int)std::round(remaining);
+    };
+
+    auto survivorNameFromCharacter = [&](int survivorChar) -> const char*
+    {
+        // L4D2 SurvivorCharacter enum (common ordering).
+        switch (survivorChar)
+        {
+        case 0: return "NICK";
+        case 1: return "ROCHELLE";
+        case 2: return "COACH";
+        case 3: return "ELLIS";
+        case 4: return "BILL";
+        case 5: return "ZOEY";
+        case 6: return "FRANCIS";
+        case 7: return "LOUIS";
+        default: return nullptr;
+        }
+    };
+
     auto buildRel = [&](float xOff, float yOff, float zOff, const QAngle& ang) -> vr::HmdMatrix34_t
     {
         const float deg2rad = 3.14159265358979323846f / 180.0f;
@@ -1878,12 +1942,13 @@ void VR::UpdateHandHudOverlays()
         vr::HmdMatrix34_t rel = buildRel(m_LeftWristHudXOffset, m_LeftWristHudYOffset, m_LeftWristHudZOffset, m_LeftWristHudAngleOffset);
         vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(m_LeftWristHudHandle, offHandIndex, &rel);
         vr::VROverlay()->SetOverlayWidthInMeters(m_LeftWristHudHandle, std::max(0.01f, m_LeftWristHudWidthMeters));
-        vr::VROverlay()->SetOverlayTexelAspect(m_LeftWristHudHandle, (float)m_LeftWristHudTexW / (float)m_LeftWristHudTexH);
+        // Texel aspect is per-texel pixel aspect, not texture aspect ratio. Our pixels are square.
+        vr::VROverlay()->SetOverlayTexelAspect(m_LeftWristHudHandle, 1.0f);
         vr::VROverlay()->SetOverlayCurvature(m_LeftWristHudHandle, std::max(0.0f, m_LeftWristHudCurvature));
+        vr::VROverlay()->SetOverlayAlpha(m_LeftWristHudHandle, std::max(0.0f, std::min(1.0f, m_LeftWristHudAlpha)));
 
         const int hp = *reinterpret_cast<const int*>(pBase + kHealthOffset);
-        const float tempHPf = *reinterpret_cast<const float*>(pBase + kHealthBufferOffset);
-        const int tempHP = (int)std::max(0.0f, std::round(tempHPf));
+        const int tempHP = computeDecayedTempHP(playerIndex, pBase);
         const bool incap = (*reinterpret_cast<const unsigned char*>(pBase + kIsIncapacitatedOffset)) != 0;
         const bool ledge = (*reinterpret_cast<const unsigned char*>(pBase + kIsHangingFromLedgeOffset)) != 0;
         const bool third = (*reinterpret_cast<const unsigned char*>(pBase + kIsOnThirdStrikeOffset)) != 0;
@@ -1952,7 +2017,8 @@ void VR::UpdateHandHudOverlays()
             {
                 char batBuf[64];
                 std::snprintf(batBuf, sizeof(batBuf), "LC:%d%% RC:%d%%", battL, battR);
-                DrawText5x7(s, 18, 54, batBuf, { 200, 200, 200, 230 }, 2);
+                const int battScale = std::max(1, std::min(4, m_LeftWristHudBatteryTextScale));
+                DrawText5x7(s, 18, 54, batBuf, { 200, 200, 200, 230 }, battScale);
             }
 
             int dotX = w - 62;
@@ -1985,8 +2051,7 @@ void VR::UpdateHandHudOverlays()
                     if (team != 2) continue;
 
                     const int thp = *reinterpret_cast<const int*>(pb + kHealthOffset);
-                    const float tbuf = *reinterpret_cast<const float*>(pb + kHealthBufferOffset);
-                    const int ttmp = (int)std::max(0.0f, std::round(tbuf));
+                    const int ttmp = computeDecayedTempHP(i, pb);
 
                     char nameBuf[16] = { 0 };
                     player_info_t info{};
@@ -2000,10 +2065,22 @@ void VR::UpdateHandHudOverlays()
                             nameBuf[n] = ch;
                         }
                         nameBuf[n] = 0;
+                        if (nameBuf[0] == 0)
+                        {
+                            const int survivorChar = *reinterpret_cast<const int*>(pb + kSurvivorCharacterOffset);
+                            const char* sname = survivorNameFromCharacter(survivorChar);
+                            if (sname && sname[0])
+                                std::snprintf(nameBuf, sizeof(nameBuf), "%s", sname);
+                        }
                     }
                     else
                     {
-                        std::snprintf(nameBuf, sizeof(nameBuf), "P%d", i);
+                        const int survivorChar = *reinterpret_cast<const int*>(pb + kSurvivorCharacterOffset);
+                        const char* sname = survivorNameFromCharacter(survivorChar);
+                        if (sname && sname[0])
+                            std::snprintf(nameBuf, sizeof(nameBuf), "%s", sname);
+                        else
+                            std::snprintf(nameBuf, sizeof(nameBuf), "P%d", i);
                     }
 
                     const int y0 = 18 + row * 18;
@@ -2069,7 +2146,9 @@ void VR::UpdateHandHudOverlays()
         vr::HmdMatrix34_t rel = buildRel(m_RightAmmoHudXOffset, m_RightAmmoHudYOffset, m_RightAmmoHudZOffset, m_RightAmmoHudAngleOffset);
         vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(m_RightAmmoHudHandle, gunHandIndex, &rel);
         vr::VROverlay()->SetOverlayWidthInMeters(m_RightAmmoHudHandle, std::max(0.01f, m_RightAmmoHudWidthMeters));
-        vr::VROverlay()->SetOverlayTexelAspect(m_RightAmmoHudHandle, (float)m_RightAmmoHudTexW / (float)m_RightAmmoHudTexH);
+        vr::VROverlay()->SetOverlayAlpha(m_RightAmmoHudHandle, std::max(0.0f, std::min(1.0f, m_RightAmmoHudAlpha)));
+        // Texel aspect is per-texel pixel aspect, not texture aspect ratio. Our pixels are square.
+        vr::VROverlay()->SetOverlayTexelAspect(m_RightAmmoHudHandle, 1.0f);
 
         int clip = 0;
         int reserve = 0;
@@ -2160,7 +2239,7 @@ void VR::UpdateHandHudOverlays()
             const Rgba clipColor = clipLow ? Rgba{ 255, 80, 80, 255 } : Rgba{ 240, 240, 240, 255 };
             const Rgba resColor = resLow ? Rgba{ 255, 80, 80, 230 } : Rgba{ 200, 200, 200, 230 };
 
-            const SevenSegStyle clipSt{ 14, 4, 2, 6 };
+            const SevenSegStyle clipSt{ 12, 3, 2, 4 };
             Draw7SegInt(s, 18, 24, std::max(0, clip), clipSt, clipColor);
 
             DrawText5x7(s, 18, 88, "/", { 200, 200, 200, 220 }, 3);
@@ -2170,7 +2249,7 @@ void VR::UpdateHandHudOverlays()
             }
             else
             {
-                const SevenSegStyle resSt{ 9, 2, 2, 4 };
+                const SevenSegStyle resSt{ 8, 2, 2, 3 };
                 Draw7SegInt(s, 32, 86, std::max(0, reserve), resSt, resColor);
             }
 

--- a/L4D2VR/vr/vr_viewmodel_config.inl
+++ b/L4D2VR/vr/vr_viewmodel_config.inl
@@ -798,6 +798,9 @@ void VR::ParseConfigFile()
     m_LeftWristHudBgAlpha = std::clamp(getFloat("LeftWristHudBgAlpha", m_LeftWristHudBgAlpha), 0.0f, 1.0f);
     m_RightAmmoHudBgAlpha = std::clamp(getFloat("RightAmmoHudBgAlpha", m_RightAmmoHudBgAlpha), 0.0f, 1.0f);
 
+    // Right ammo HUD: crop ratio (U max). Removes unused blank area on the right.
+    m_RightAmmoHudUVMaxU = std::clamp(getFloat("RightAmmoHudUVMaxU", m_RightAmmoHudUVMaxU), 0.05f, 1.0f);
+
     // Hand HUD overall overlay alpha (0..1)
     m_LeftWristHudAlpha = std::clamp(getFloat("LeftWristHudAlpha", m_LeftWristHudAlpha), 0.0f, 1.0f);
     m_RightAmmoHudAlpha = std::clamp(getFloat("RightAmmoHudAlpha", m_RightAmmoHudAlpha), 0.0f, 1.0f);

--- a/L4D2VR/vr/vr_viewmodel_config.inl
+++ b/L4D2VR/vr/vr_viewmodel_config.inl
@@ -798,6 +798,16 @@ void VR::ParseConfigFile()
     m_LeftWristHudBgAlpha = std::clamp(getFloat("LeftWristHudBgAlpha", m_LeftWristHudBgAlpha), 0.0f, 1.0f);
     m_RightAmmoHudBgAlpha = std::clamp(getFloat("RightAmmoHudBgAlpha", m_RightAmmoHudBgAlpha), 0.0f, 1.0f);
 
+    // Hand HUD overall overlay alpha (0..1)
+    m_LeftWristHudAlpha = std::clamp(getFloat("LeftWristHudAlpha", m_LeftWristHudAlpha), 0.0f, 1.0f);
+    m_RightAmmoHudAlpha = std::clamp(getFloat("RightAmmoHudAlpha", m_RightAmmoHudAlpha), 0.0f, 1.0f);
+
+    // Left wrist HUD: battery label font scale (1..4)
+    m_LeftWristHudBatteryTextScale = std::clamp(getInt("LeftWristHudBatteryTextScale", m_LeftWristHudBatteryTextScale), 1, 4);
+
+    // Hand HUD temp health decay (HP per second)
+    m_HandHudTempHealthDecayRate = std::max(0.0f, getFloat("HandHudTempHealthDecayRate", m_HandHudTempHealthDecayRate));
+
     // Hand HUD overlays (SteamVR overlay, raw)
     m_LeftWristHudEnabled = getBool("LeftWristHudEnabled", m_LeftWristHudEnabled);
     m_LeftWristHudWidthMeters = std::clamp(getFloat("LeftWristHudWidthMeters", m_LeftWristHudWidthMeters), 0.01f, 1.0f);

--- a/L4D2VR/vr/vr_viewmodel_config.inl
+++ b/L4D2VR/vr/vr_viewmodel_config.inl
@@ -798,7 +798,7 @@ void VR::ParseConfigFile()
     m_LeftWristHudBgAlpha = std::clamp(getFloat("LeftWristHudBgAlpha", m_LeftWristHudBgAlpha), 0.0f, 1.0f);
     m_RightAmmoHudBgAlpha = std::clamp(getFloat("RightAmmoHudBgAlpha", m_RightAmmoHudBgAlpha), 0.0f, 1.0f);
 
-    // Right ammo HUD: crop ratio (U max). Removes unused blank area on the right.
+    // Right ammo HUD U max clamp (auto-fit width is capped by this).
     m_RightAmmoHudUVMaxU = std::clamp(getFloat("RightAmmoHudUVMaxU", m_RightAmmoHudUVMaxU), 0.05f, 1.0f);
 
     // Hand HUD overall overlay alpha (0..1)

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -785,6 +785,18 @@ Option g_Options[] =
         "0.04"
     },
     {
+        "RightAmmoHudUVMaxU",
+        OptionType::Float,
+        { u8"HUD (Hand)", u8"HUD（手柄）" },
+        { u8"Ammo HUD Crop Width (U Max)", u8"弹药HUD裁剪宽度（U最大值）" },
+        { u8"Crops the right side of the ammo HUD overlay texture.",
+          u8"裁掉弹药HUD覆盖层纹理右侧的空白区域。" },
+        { u8"1.0 = full width, 0.33 = compact left-third view.",
+          u8"1.0为完整宽度，0.33为仅显示左侧三分之一（更紧凑）。" },
+        0.05f, 1.0f,
+        "0.34"
+    },
+    {
         "RightAmmoHudXOffset",
         OptionType::Float,
         { u8"HUD (Hand)", u8"HUD（手柄）" },

--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -788,13 +788,13 @@ Option g_Options[] =
         "RightAmmoHudUVMaxU",
         OptionType::Float,
         { u8"HUD (Hand)", u8"HUD（手柄）" },
-        { u8"Ammo HUD Crop Width (U Max)", u8"弹药HUD裁剪宽度（U最大值）" },
-        { u8"Crops the right side of the ammo HUD overlay texture.",
-          u8"裁掉弹药HUD覆盖层纹理右侧的空白区域。" },
-        { u8"1.0 = full width, 0.33 = compact left-third view.",
-          u8"1.0为完整宽度，0.33为仅显示左侧三分之一（更紧凑）。" },
+        { u8"Ammo HUD Max Width Fraction (U Max)", u8"弹药HUD最大宽度比例（U最大值）" },
+        { u8"Auto-fit ammo width, then clamp by this max U fraction.",
+          u8"先自动按内容收紧宽度，再用该U最大值做上限约束。" },
+        { u8"1.0 = no clamp (recommended). Lower values force narrower HUD.",
+          u8"1.0为不额外限制（推荐）；更小会强制更窄。" },
         0.05f, 1.0f,
-        "0.34"
+        "1.0"
     },
     {
         "RightAmmoHudXOffset",


### PR DESCRIPTION
### Motivation
- Expose additional runtime/config knobs to let overlays be tuned independently (alpha, battery font scale) and to make temporary health display behave more like the engine by accounting for decay. 
- Approximate engine-side temp-health decay on the client when `m_healthBufferTime` is available so the HUD reflects remaining temporary HP more accurately. 
- Improve overlay rendering correctness and usability (texel aspect, overlay alpha, teammate name fallbacks, and digit sizing). 

### Description
- Added new HUD configuration/state fields in `vr.h`: `m_LeftWristHudAlpha`, `m_RightAmmoHudAlpha`, `m_LeftWristHudBatteryTextScale`, `m_HandHudTempHealthDecayRate`, a `TempHealthDecayState` array, and netvar offsets `kHealthBufferTimeOffset` and `kSurvivorCharacterOffset`.
- Extended `ParseConfigFile()` in `vr_viewmodel_config.inl` to read/clamp the new settings (`LeftWristHudAlpha`, `RightAmmoHudAlpha`, `LeftWristHudBatteryTextScale`, `HandHudTempHealthDecayRate`).
- Implemented `computeDecayedTempHP` and `survivorNameFromCharacter` lambdas in `vr_lifecycle.inl` to: approximate decayed temp HP using wall-clock time with a per-player cache, freeze decay while paused, and provide survivor-character name fallbacks when player names are unavailable.
- Updated overlay rendering to apply per-overlay alpha via `IVROverlay::SetOverlayAlpha`, force texel aspect to `1.0f` for square pixels, use the configurable battery text scale in `DrawText5x7`, and tightened seven-segment digit styles for the ammo HUD.

### Testing
- Ran diff/whitespace checks (`git diff --check`) and static diff inspection with no issues reported (passed).
- Verified repository status and applied changes locally; no compile/run tests were executed as part of this PR (no build attempted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ae9dbd388321994a7b7e6bb8780c)