### PR TITLE
Improve hand HUD buffering and auto-fit right ammo HUD width

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -488,6 +488,11 @@ public:
 	float m_LeftWristHudBgAlpha = 0.85f;
 	float m_RightAmmoHudBgAlpha = 0.70f;
 
+	// Right ammo HUD: maximum visible width fraction (U max).
+	// The HUD now auto-computes a tight width that fits the ammo string and then clamps to this value.
+	// 1.0 = no clamp (recommended).
+	float m_RightAmmoHudUVMaxU = 1.0f;
+
 	// ----------------------------
 	// Hand HUD overlays (SteamVR overlays, raw textures)
 	// ----------------------------
@@ -513,8 +518,11 @@ public:
 
 	float m_HandHudMaxHz = 30.0f;
 	std::chrono::steady_clock::time_point m_LastHandHudUpdateTime{};
-	std::vector<uint8_t> m_LeftWristHudPixels{};
-	std::vector<uint8_t> m_RightAmmoHudPixels{};
+	// Double-buffered pixel storage to avoid flicker/tearing when SteamVR reads the same buffer we are updating.
+	std::array<std::vector<uint8_t>, 2> m_LeftWristHudPixels{};
+	std::array<std::vector<uint8_t>, 2> m_RightAmmoHudPixels{};
+	uint8_t m_LeftWristHudPixelsFront = 0;
+	uint8_t m_RightAmmoHudPixelsFront = 0;
 	int m_LeftWristHudTexW = 256;
 	int m_LeftWristHudTexH = 128;
 	int m_RightAmmoHudTexW = 256;


### PR DESCRIPTION
### Motivation
- Reduce flicker/tearing when SteamVR reads hand HUD overlay textures while the code is updating them.
- Make the right-hand ammo HUD tightly frame the ammo string and avoid visual "zooming" or clipping when cropping the overlay texture.

### Description
- Add a configurable `m_RightAmmoHudUVMaxU` (default `1.0f`) to cap the auto-computed visible width for the right ammo HUD.
- Replace single pixel buffers with double-buffered arrays and add front-buffer indices for both left wrist and right ammo HUDs, and update the upload path to render into the back buffer then flip the front index.
- Auto-compute a tight visible width from seven-seg digit metrics, clamp it by `m_RightAmmoHudUVMaxU`, apply matching `vr::VRTextureBounds_t.uMax` and scale the overlay quad width by the same factor, and draw HUD elements within the computed visible width.
- Explicitly set the right ammo HUD texel aspect to `1.0f` (square texels) to avoid per-texel distortion.

### Testing
- Ran whitespace/diff/style checks after the changes and they reported no issues.
- Performed repository symbol searches to confirm updated fields and usages were present.
- No compile-time or runtime automated tests were executed during this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999c53b86208321b0acca1ae655e874)