### PR TITLE
Add aim-line teammate hint to left wrist HUD

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -561,6 +561,9 @@ public:
 	bool m_LastHudIncap = false;
 	bool m_LastHudLedge = false;
 	bool m_LastHudThirdStrike = false;
+	bool m_LastHudAimTargetVisible = false;
+	int  m_LastHudAimTargetIndex = -1;
+	int  m_LastHudAimTargetPct = -1;
 	int  m_LastHudClip = -9999;
 	int  m_LastHudReserve = -9999;
 	int  m_LastHudUpg = -9999;
@@ -748,6 +751,17 @@ public:
 	vr::VRActionHandle_t m_ActionFriendlyFireBlockToggle;
 	bool m_BlockFireOnFriendlyAimEnabled = false; // toggled by SteamVR binding
 	bool m_AimLineHitsFriendly = false;           // updated from a ray trace (aim ray)
+
+	// Aim-line teammate HUD hint (left wrist HUD):
+	// - When the aim line stays on a teammate for >= 2 seconds, show "Name:XX%".
+	// - After aim leaves teammates, keep the last shown target for 5 seconds.
+	int m_AimTeammateCandidateIndex = -1;
+	std::chrono::steady_clock::time_point m_AimTeammateCandidateSince{};
+	int m_AimTeammateDisplayIndex = -1;
+	std::chrono::steady_clock::time_point m_AimTeammateDisplayUntil{};
+	int m_AimTeammateLastRawIndex = -1;
+	std::chrono::steady_clock::time_point m_AimTeammateLastRawTime{};
+
 	std::chrono::steady_clock::time_point m_LastFriendlyFireGuardLogTime{};
 	// Latch suppression while attack is held (prevents flicker causing intermittent firing).
 	bool m_FriendlyFireGuardLatched = false;
@@ -1094,6 +1108,8 @@ public:
 	// ticks and latch suppression until the user releases attack.
 	bool ShouldSuppressPrimaryFire(const CUserCmd* cmd, C_BasePlayer* localPlayer);
 	bool UpdateFriendlyFireAimHit(C_BasePlayer* localPlayer);
+	void UpdateAimTeammateHudTarget(C_BasePlayer* localPlayer, const Vector& start, const Vector& end, bool aimLineActive);
+	bool GetAimTeammateHudInfo(int& outPlayerIndex, int& outPercent, char* outName, size_t outNameSize);
 	// Mounted gun helper: returns the entity the player is currently "using" (turret/mounted gun) if any.
 	// Used to skip that entity in aim-related traces so the aim line doesn't collide with the gun platform.
 	bool IsUsingMountedGun(const C_BasePlayer* localPlayer) const;

--- a/L4D2VR/vr/vr_aiming.inl
+++ b/L4D2VR/vr/vr_aiming.inl
@@ -452,6 +452,8 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
         // Even when the aim line is hidden/disabled, still run the friendly-fire guard trace
         // if the user toggled it on.
         UpdateFriendlyFireAimHit(localPlayer);
+        // Aim-line teammate HUD hint is only meaningful while the aim line is active.
+        UpdateAimTeammateHudTarget(localPlayer, Vector{}, Vector{}, false);
 
         return;
     }
@@ -460,6 +462,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     if (!canDraw)
     {
         UpdateFriendlyFireAimHit(localPlayer);
+        UpdateAimTeammateHudTarget(localPlayer, Vector{}, Vector{}, false);
 
         return;
     }
@@ -553,6 +556,7 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     {
         m_AimLineHitsFriendly = false;
         m_HasAimConvergePoint = false;
+        UpdateAimTeammateHudTarget(localPlayer, Vector{}, Vector{}, false);
 
         Vector pitchSource = direction;
         if (useMouse && !eyeDir.IsZero())
@@ -603,6 +607,9 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
     // This runs regardless of whether the line is actually drawn.
     UpdateFriendlyFireAimHit(localPlayer);
 
+    // Teammate info hint: track which teammate the aim line is resting on.
+    UpdateAimTeammateHudTarget(localPlayer, origin, target, true);
+
 
     m_AimLineStart = origin;
     m_AimLineEnd = target;
@@ -611,6 +618,171 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
 
     if (canDraw && allowAimLineDraw)
         DrawAimLine(origin, target);
+}
+
+void VR::UpdateAimTeammateHudTarget(C_BasePlayer* localPlayer, const Vector& start, const Vector& end, bool aimLineActive)
+{
+    using namespace std::chrono;
+    const auto now = steady_clock::now();
+
+    // Constants (as requested): 2s hold to show, 5s linger after leaving.
+    constexpr float kHoldSeconds = 2.0f;
+    constexpr float kLingerSeconds = 5.0f;
+    // Small stickiness to prevent hitbox-edge flicker from constantly resetting the timer.
+    constexpr float kStickinessSeconds = 0.15f;
+
+    if (!aimLineActive || !localPlayer || !m_Game || !m_Game->m_EngineTrace || !m_Game->m_ClientEntityList)
+    {
+        m_AimTeammateCandidateIndex = -1;
+        m_AimTeammateDisplayIndex = -1;
+        m_AimTeammateLastRawIndex = -1;
+        return;
+    }
+
+    int hitIdx = -1;
+    {
+        CGameTrace tr;
+        Ray_t ray;
+
+        // Skip self and the mounted-gun use entity (if any) so the ray doesn't collide with the turret base.
+        C_BaseEntity* mountedUseEnt = GetMountedGunUseEntity(localPlayer);
+        CTraceFilterSkipSelf filterSelf((IHandleEntity*)localPlayer, 0);
+        CTraceFilterSkipTwoEntities filterTwo((IHandleEntity*)localPlayer, (IHandleEntity*)mountedUseEnt, 0);
+        CTraceFilter* pFilter = mountedUseEnt ? static_cast<CTraceFilter*>(&filterTwo) : static_cast<CTraceFilter*>(&filterSelf);
+
+        ray.Init(start, end);
+        m_Game->m_EngineTrace->TraceRay(ray, STANDARD_TRACE_MASK, pFilter, &tr);
+
+        C_BaseEntity* hitEnt = reinterpret_cast<C_BaseEntity*>(tr.m_pEnt);
+        if (hitEnt && hitEnt != localPlayer)
+        {
+            const unsigned char* eb = reinterpret_cast<const unsigned char*>(hitEnt);
+            const unsigned char lifeState = *reinterpret_cast<const unsigned char*>(eb + kLifeStateOffset);
+            const int team = *reinterpret_cast<const int*>(eb + kTeamNumOffset);
+
+            if (lifeState == 0 && team == 2)
+            {
+                // Resolve to a player index by scanning the entity list (cheap: cap to 64).
+                const int hi = std::min(64, m_Game->m_ClientEntityList->GetHighestEntityIndex());
+                for (int i = 1; i <= hi; ++i)
+                {
+                    if (m_Game->GetClientEntity(i) == hitEnt)
+                    {
+                        hitIdx = i;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    if (hitIdx > 0)
+    {
+        m_AimTeammateLastRawIndex = hitIdx;
+        m_AimTeammateLastRawTime = now;
+    }
+    else if (m_AimTeammateLastRawIndex > 0)
+    {
+        const float dt = duration_cast<duration<float>>(now - m_AimTeammateLastRawTime).count();
+        if (dt <= kStickinessSeconds)
+            hitIdx = m_AimTeammateLastRawIndex;
+        else
+            m_AimTeammateLastRawIndex = -1;
+    }
+
+    // Leaving all teammates: keep last shown target for a short linger, then clear.
+    if (hitIdx <= 0)
+    {
+        m_AimTeammateCandidateIndex = -1;
+        if (m_AimTeammateDisplayIndex > 0)
+        {
+            if (now > m_AimTeammateDisplayUntil)
+                m_AimTeammateDisplayIndex = -1;
+        }
+        return;
+    }
+
+    // Aiming at some teammate.
+    if (hitIdx != m_AimTeammateCandidateIndex)
+    {
+        m_AimTeammateCandidateIndex = hitIdx;
+        m_AimTeammateCandidateSince = now;
+
+        // Avoid showing stale info for a different teammate while we begin the hold timer.
+        if (m_AimTeammateDisplayIndex != hitIdx)
+            m_AimTeammateDisplayIndex = -1;
+    }
+
+    // If we're already displaying this teammate, just keep the linger window refreshed.
+    if (m_AimTeammateDisplayIndex == hitIdx)
+    {
+        m_AimTeammateDisplayUntil = now + duration_cast<steady_clock::duration>(duration<float>(kLingerSeconds));
+        return;
+    }
+
+    const float held = duration_cast<duration<float>>(now - m_AimTeammateCandidateSince).count();
+    if (held >= kHoldSeconds)
+    {
+        m_AimTeammateDisplayIndex = hitIdx;
+        m_AimTeammateDisplayUntil = now + duration_cast<steady_clock::duration>(duration<float>(kLingerSeconds));
+    }
+}
+
+bool VR::GetAimTeammateHudInfo(int& outPlayerIndex, int& outPercent, char* outName, size_t outNameSize)
+{
+    if (!outName || outNameSize == 0)
+        return false;
+
+    outName[0] = 0;
+    outPlayerIndex = -1;
+    outPercent = 0;
+
+    const auto now = std::chrono::steady_clock::now();
+    if (m_AimTeammateDisplayIndex <= 0)
+        return false;
+    if (now > m_AimTeammateDisplayUntil)
+    {
+        m_AimTeammateDisplayIndex = -1;
+        return false;
+    }
+
+    if (!m_Game)
+        return false;
+
+    C_BasePlayer* p = (C_BasePlayer*)m_Game->GetClientEntity(m_AimTeammateDisplayIndex);
+    if (!p)
+        return false;
+
+    const unsigned char* pb = reinterpret_cast<const unsigned char*>(p);
+    const unsigned char lifeState = *reinterpret_cast<const unsigned char*>(pb + kLifeStateOffset);
+    const int team = *reinterpret_cast<const int*>(pb + kTeamNumOffset);
+    if (lifeState != 0 || team != 2)
+        return false;
+
+    const int hp = *reinterpret_cast<const int*>(pb + kHealthOffset);
+    const float tempHPf = *reinterpret_cast<const float*>(pb + kHealthBufferOffset);
+    const int tempHP = (int)std::max(0.0f, std::round(tempHPf));
+    const int eff = std::max(0, std::min(100, hp + tempHP));
+
+    // Name
+    if (m_Game->m_EngineClient)
+    {
+        player_info_t info{};
+        if (m_Game->m_EngineClient->GetPlayerInfo(m_AimTeammateDisplayIndex, &info))
+        {
+            size_t n = 0;
+            for (; n + 1 < outNameSize && info.name[n]; ++n)
+                outName[n] = info.name[n];
+            outName[n] = 0;
+        }
+    }
+
+    if (!outName[0])
+        std::snprintf(outName, outNameSize, "P%d", m_AimTeammateDisplayIndex);
+
+    outPlayerIndex = m_AimTeammateDisplayIndex;
+    outPercent = eff;
+    return true;
 }
 
 bool VR::IsWeaponLaserSightActive(C_WeaponCSBase* weapon) const
@@ -1074,4 +1246,3 @@ void VR::ResetSpecialInfectedWarningAction()
 }
 
 #endif
-

--- a/L4D2VR/vr/vr_lifecycle.inl
+++ b/L4D2VR/vr/vr_lifecycle.inl
@@ -1960,6 +1960,11 @@ void VR::UpdateHandHudOverlays()
         const bool ledge = (*reinterpret_cast<const unsigned char*>(pBase + kIsHangingFromLedgeOffset)) != 0;
         const bool third = (*reinterpret_cast<const unsigned char*>(pBase + kIsOnThirdStrikeOffset)) != 0;
 
+        int aimTargetIdx = -1;
+        int aimTargetPct = 0;
+        char aimTargetName[32] = { 0 };
+        const bool hasAimTarget = GetAimTeammateHudInfo(aimTargetIdx, aimTargetPct, aimTargetName, sizeof(aimTargetName));
+
         int battL = -1, battR = -1;
         bool battLCharging = false, battRCharging = false;
         if (m_LeftWristHudShowBattery)
@@ -1993,7 +1998,11 @@ void VR::UpdateHandHudOverlays()
             || (throwable != m_LastHudThrowable) || (medItem != m_LastHudMedItem) || (pillItem != m_LastHudPillItem)
             || (incap != m_LastHudIncap) || (ledge != m_LastHudLedge) || (third != m_LastHudThirdStrike);
 
-        if (!throttle && changed)
+        const bool aimChanged = (hasAimTarget != m_LastHudAimTargetVisible)
+            || (aimTargetIdx != m_LastHudAimTargetIndex)
+            || (aimTargetPct != m_LastHudAimTargetPct);
+
+        if (!throttle && (changed || aimChanged))
         {
             m_LastHudHealth = hp;
             m_LastHudTempHealth = tempHP;
@@ -2003,6 +2012,10 @@ void VR::UpdateHandHudOverlays()
             m_LastHudIncap = incap;
             m_LastHudLedge = ledge;
             m_LastHudThirdStrike = third;
+
+            m_LastHudAimTargetVisible = hasAimTarget;
+            m_LastHudAimTargetIndex = aimTargetIdx;
+            m_LastHudAimTargetPct = aimTargetPct;
 
             const int w = m_LeftWristHudTexW;
             const int h = m_LeftWristHudTexH;
@@ -2032,6 +2045,13 @@ void VR::UpdateHandHudOverlays()
                 std::snprintf(batBuf, sizeof(batBuf), "LC:%d%% RC:%d%%", battL, battR);
                 const int battScale = std::max(1, std::min(4, m_LeftWristHudBatteryTextScale));
                 DrawText5x7(s, 18, 54, batBuf, { 200, 200, 200, 230 }, battScale);
+            }
+
+            if (hasAimTarget)
+            {
+                char tgtBuf[64];
+                std::snprintf(tgtBuf, sizeof(tgtBuf), "%s:%d%%", aimTargetName, aimTargetPct);
+                DrawText5x7(s, 18, 72, tgtBuf, { 200, 200, 200, 230 }, 2);
             }
 
             int dotX = w - 62;

--- a/L4D2VR/vr/vr_lifecycle.inl
+++ b/L4D2VR/vr/vr_lifecycle.inl
@@ -2034,9 +2034,11 @@ void VR::UpdateHandHudOverlays()
 
             if (tempHP > 0)
             {
+                // Keep temp HP beside the main HP number (there is horizontal room),
+                // instead of pushing it below where it can clash with extra hint text.
                 char hpBuf[16];
                 std::snprintf(hpBuf, sizeof(hpBuf), "+%d", tempHP);
-                DrawText5x7(s, 18, 52, hpBuf, { 200, 200, 200, 230 }, 2);
+                DrawText5x7(s, 108, 26, hpBuf, { 200, 200, 200, 230 }, 2);
             }
 
             if (m_LeftWristHudShowBattery && battL >= 0 && battR >= 0)

--- a/L4D2VR/vr/vr_lifecycle.inl
+++ b/L4D2VR/vr/vr_lifecycle.inl
@@ -1962,7 +1962,7 @@ void VR::UpdateHandHudOverlays()
 
         int aimTargetIdx = -1;
         int aimTargetPct = 0;
-        char aimTargetName[32] = { 0 };
+        char aimTargetName[64] = { 0 };
         const bool hasAimTarget = GetAimTeammateHudInfo(aimTargetIdx, aimTargetPct, aimTargetName, sizeof(aimTargetName));
 
         int battL = -1, battR = -1;


### PR DESCRIPTION
### Motivation
- Provide a contextual HUD hint on the left wrist that shows which teammate the aim line is resting on and their effective health percentage, to make teammate-targeting/awareness clearer in VR.
- Avoid noisy flicker by requiring a short hold before showing the hint and a short linger after leaving the target.

### Description
- Added new VR state fields to track candidate/displayed aim targets and cached HUD values: `m_AimTeammate*` timers/indices and `m_LastHudAimTarget*` cached values in `VR` (`vr.h`).
- Implemented `UpdateAimTeammateHudTarget` to trace the aim ray (skipping self and mounted-gun entity), debounce hitbox edges with a small stickiness window, require a 2s hold before showing, and a 5s linger after leaving (in `vr_aiming.inl`).
- Added `GetAimTeammateHudInfo` to expose the displayed teammate index, effective health percent, and player name for HUD rendering (in `vr_aiming.inl`).
- Wired the new logic into the aiming and HUD pipeline: reset tracking when the aim line is inactive, update tracking while aim-line is active, and fetch/render `Name:XX%` on the left wrist HUD and include aim-target state in redraw invalidation (in `vr_aiming.inl` and `vr_lifecycle.inl`).

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch issues and it completed with no warnings (success).
- No compile or runtime tests were executed in this patch; integration should be validated by building the project and running in-game to confirm tracing, hold/linger timing, and HUD text rendering behave as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999cb4c00388321ab4ed4c76c3c1575)