### PR TITLE
Automatic mat_queue_mode switching based on VR state

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -6,6 +6,7 @@ SnapTurnAngle=45.0
 LeftHanded=false
 AntiAliasing=2
 ForceNonVRServerMovement=false
+AutoMatQueueMode=false
 
 HudDistance=1.3
 HudSize=1.8

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -371,7 +371,7 @@ public:
 	// Auto mat_queue_mode management for multicore rendering.
 	// When enabled, the mod will keep mat_queue_mode=1 in menus/loading/pause/scoreboard,
 	// and switch to mat_queue_mode=2 once fully in-game.
-	bool m_AutoMatQueueMode = false;
+	bool m_AutoMatQueueMode = true;
 	int  m_AutoMatQueueModeLastRequested = -999;
 	std::chrono::steady_clock::time_point m_AutoMatQueueModeLastCmdTime{};
 

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -368,6 +368,13 @@ public:
 	// Debug: log Virtual Address Space (VAS) stats at key allocation points.
 	bool m_DebugVASLog = false;
 
+	// Auto mat_queue_mode management for multicore rendering.
+	// When enabled, the mod will keep mat_queue_mode=1 in menus/loading/pause/scoreboard,
+	// and switch to mat_queue_mode=2 once fully in-game.
+	bool m_AutoMatQueueMode = false;
+	int  m_AutoMatQueueModeLastRequested = -999;
+	std::chrono::steady_clock::time_point m_AutoMatQueueModeLastCmdTime{};
+
 	bool m_IsVREnabled = false;
 	bool m_IsInitialized = false;
 	std::atomic<bool> m_RenderedNewFrame{ false };
@@ -1110,6 +1117,8 @@ public:
 	int SetActionManifest(const char* fileName);
 	void InstallApplicationManifest(const char* fileName);
 	void Update();
+	// Auto switch mat_queue_mode based on game/menu/pause/scoreboard state (when enabled in config).
+	void UpdateAutoMatQueueMode();
 	void CreateVRTextures();
 	void EnsureOpticsRTTTextures();
 	void LogVAS(const char* tag);

--- a/L4D2VR/vr/vr_viewmodel_config.inl
+++ b/L4D2VR/vr/vr_viewmodel_config.inl
@@ -941,6 +941,15 @@ void VR::ParseConfigFile()
     const bool prevVASLog = m_DebugVASLog;
     m_DebugVASLog = getBool("DebugVASLog", m_DebugVASLog);
     m_LazyScopeRearMirrorRTT = getBool("LazyScopeRearMirrorRTT", m_LazyScopeRearMirrorRTT);
+
+    const bool prevAutoMatQueueMode = m_AutoMatQueueMode;
+    m_AutoMatQueueMode = getBool("AutoMatQueueMode", m_AutoMatQueueMode);
+    if (m_AutoMatQueueMode != prevAutoMatQueueMode)
+    {
+        m_AutoMatQueueModeLastRequested = -999;
+        m_AutoMatQueueModeLastCmdTime = {};
+    }
+
     if (!prevVASLog && m_DebugVASLog)
         LogVAS("DebugVASLog enabled");
 


### PR DESCRIPTION
### Motivation
- Reduce UI artifacts caused by multicore rendering while keeping in-game performance by automatically toggling Source `mat_queue_mode` between UI-friendly and in-game modes.
- Provide a config-controlled, non-intrusive mechanism that switches to `mat_queue_mode 1` for menus/loading/pause/scoreboard/cursor and `mat_queue_mode 2` when fully in-game.

### Description
- Add `m_AutoMatQueueMode`, `m_AutoMatQueueModeLastRequested`, and `m_AutoMatQueueModeLastCmdTime` members to `VR` and declare `UpdateAutoMatQueueMode()` in the class interface. 
- Implement `VR::UpdateAutoMatQueueMode()` to choose the desired `mat_queue_mode` based on `IsInGame()`, loading state, pause state, cursor visibility and scoreboard input, send `ClientCmd_Unrestricted("mat_queue_mode N")`, throttle retries, and log state changes. 
- Call `UpdateAutoMatQueueMode()` from `VR::Update()` after pose/action polling and extend config parsing to read `AutoMatQueueMode` and reset the command-tracking state when toggled. 
- Add a default `AutoMatQueueMode=false` entry to `L4D2VR/config.txt` (UI option wiring not added in this repo). 

### Testing
- Ran repository-wide pattern checks with `rg "AutoMatQueueMode|UpdateAutoMatQueueMode"` to confirm new identifiers are present and they succeeded. 
- Verified the source changes with `git diff -- L4D2VR/vr.h L4D2VR/vr/vr_lifecycle.inl L4D2VR/vr/vr_viewmodel_config.inl L4D2VR/config.txt` and confirmed the intended diffs. 
- Confirmed working tree status with `git status --short` and commit hash reporting; no build or runtime tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6d11ac348321a54a16aeadde3e03)