### PR TITLE
Handle mouse-mode exception in auto mat_queue_mode switching

### DIFF
--- a/L4D2VR/config.txt
+++ b/L4D2VR/config.txt
@@ -6,6 +6,7 @@ SnapTurnAngle=45.0
 LeftHanded=false
 AntiAliasing=2
 ForceNonVRServerMovement=false
+AutoMatQueueMode=false
 
 HudDistance=1.3
 HudSize=1.8

--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -368,6 +368,13 @@ public:
 	// Debug: log Virtual Address Space (VAS) stats at key allocation points.
 	bool m_DebugVASLog = false;
 
+	// Auto mat_queue_mode management for multicore rendering.
+	// When enabled, the mod will keep mat_queue_mode=1 in menus/loading/pause/scoreboard,
+	// and switch to mat_queue_mode=2 once fully in-game.
+	bool m_AutoMatQueueMode = false;
+	int  m_AutoMatQueueModeLastRequested = -999;
+	std::chrono::steady_clock::time_point m_AutoMatQueueModeLastCmdTime{};
+
 	bool m_IsVREnabled = false;
 	bool m_IsInitialized = false;
 	std::atomic<bool> m_RenderedNewFrame{ false };
@@ -1110,6 +1117,8 @@ public:
 	int SetActionManifest(const char* fileName);
 	void InstallApplicationManifest(const char* fileName);
 	void Update();
+	// Auto switch mat_queue_mode based on game/menu/pause/scoreboard state (when enabled in config).
+	void UpdateAutoMatQueueMode();
 	void CreateVRTextures();
 	void EnsureOpticsRTTTextures();
 	void LogVAS(const char* tag);

--- a/L4D2VR/vr/vr_lifecycle.inl
+++ b/L4D2VR/vr/vr_lifecycle.inl
@@ -571,6 +571,105 @@ void VR::InstallApplicationManifest(const char* fileName)
 }
 
 
+void VR::UpdateAutoMatQueueMode()
+{
+    // Mouse-mode (keyboard/mouse): do NOT auto-manage multicore.
+    // Only enforce a safe mat_queue_mode in the main menu.
+    if (m_MouseModeEnabled)
+    {
+        if (!m_IsVREnabled)
+            return;
+
+        if (!m_Game || !m_Game->m_EngineClient)
+            return;
+
+        const bool inGame = m_Game->m_EngineClient->IsInGame();
+        if (!inGame)
+        {
+            const int currentMode = m_Game->GetMatQueueMode();
+            // Accept 0 or 1; if it's anything else (e.g. 2), force 0.
+            if (currentMode != 0 && currentMode != 1)
+            {
+                const auto now = std::chrono::steady_clock::now();
+                const float secondsSinceCmd = (m_AutoMatQueueModeLastCmdTime.time_since_epoch().count() == 0)
+                    ? 9999.0f
+                    : std::chrono::duration<float>(now - m_AutoMatQueueModeLastCmdTime).count();
+
+                // Throttle retries to avoid spamming at menu.
+                if (m_AutoMatQueueModeLastRequested == 0 && secondsSinceCmd < 0.5f)
+                    return;
+
+                m_Game->ClientCmd_Unrestricted("mat_queue_mode 0");
+                m_AutoMatQueueModeLastRequested = 0;
+                m_AutoMatQueueModeLastCmdTime = now;
+
+                Game::logMsg("[VR] MouseMode menu: mat_queue_mode -> 0 (was %d)", currentMode);
+            }
+        }
+        return;
+    }
+
+    if (!m_AutoMatQueueMode)
+        return;
+
+    // Avoid changing engine threading mode when VR rendering is not active.
+    if (!m_IsVREnabled)
+        return;
+
+    if (!m_Game || !m_Game->m_EngineClient)
+        return;
+
+    const bool inGame = m_Game->m_EngineClient->IsInGame();
+    const bool paused = m_Game->m_EngineClient->IsPaused();
+    const bool cursorVisible = (m_Game->m_VguiSurface) ? m_Game->m_VguiSurface->IsCursorVisible() : false;
+    const bool scoreboardHeld = PressedDigitalAction(m_Scoreboard, false);
+
+    // "Loading map": IsInGame can be true while the client entities are not ready yet.
+    bool hasLocalPlayer = false;
+    if (inGame)
+    {
+        const int playerIndex = m_Game->m_EngineClient->GetLocalPlayer();
+        C_BasePlayer* localPlayer = (C_BasePlayer*)m_Game->GetClientEntity(playerIndex);
+        hasLocalPlayer = (localPlayer != nullptr);
+    }
+    const bool loadingMap = inGame && !hasLocalPlayer;
+
+    const int desiredMode = (!inGame || loadingMap || paused || cursorVisible || scoreboardHeld) ? 1 : 2;
+    const int currentMode = m_Game->GetMatQueueMode();
+
+    if (currentMode == desiredMode)
+    {
+        m_AutoMatQueueModeLastRequested = desiredMode;
+        return;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    const float secondsSinceCmd = (m_AutoMatQueueModeLastCmdTime.time_since_epoch().count() == 0)
+        ? 9999.0f
+        : std::chrono::duration<float>(now - m_AutoMatQueueModeLastCmdTime).count();
+
+    const bool isNewTarget = (m_AutoMatQueueModeLastRequested != desiredMode);
+
+    // Throttle retries to avoid spamming the command if the engine temporarily rejects changes (e.g., during level transitions).
+    if (m_AutoMatQueueModeLastRequested == desiredMode && secondsSinceCmd < 0.5f)
+        return;
+
+    std::string cmd = std::string("mat_queue_mode ") + std::to_string(desiredMode);
+    m_Game->ClientCmd_Unrestricted(cmd.c_str());
+
+    m_AutoMatQueueModeLastRequested = desiredMode;
+    m_AutoMatQueueModeLastCmdTime = now;
+
+    const char* reason = "in-game";
+    if (!inGame) reason = "menu";
+    else if (loadingMap) reason = "loading";
+    else if (paused) reason = "paused";
+    else if (scoreboardHeld) reason = "scoreboard";
+    else if (cursorVisible) reason = "cursor";
+    if (isNewTarget) Game::logMsg("[VR] AutoMatQueueMode -> mat_queue_mode %d (%s)", desiredMode, reason);
+}
+
+
 void VR::Update()
 {
     if (!m_IsInitialized || !m_Game->m_Initialized)
@@ -596,6 +695,8 @@ void VR::Update()
     SubmitVRTextures();
 
     bool posesValid = UpdatePosesAndActions();
+
+    UpdateAutoMatQueueMode();
 
     if (!posesValid)
     {

--- a/L4D2VR/vr/vr_viewmodel_config.inl
+++ b/L4D2VR/vr/vr_viewmodel_config.inl
@@ -941,6 +941,15 @@ void VR::ParseConfigFile()
     const bool prevVASLog = m_DebugVASLog;
     m_DebugVASLog = getBool("DebugVASLog", m_DebugVASLog);
     m_LazyScopeRearMirrorRTT = getBool("LazyScopeRearMirrorRTT", m_LazyScopeRearMirrorRTT);
+
+    const bool prevAutoMatQueueMode = m_AutoMatQueueMode;
+    m_AutoMatQueueMode = getBool("AutoMatQueueMode", m_AutoMatQueueMode);
+    if (m_AutoMatQueueMode != prevAutoMatQueueMode)
+    {
+        m_AutoMatQueueModeLastRequested = -999;
+        m_AutoMatQueueModeLastCmdTime = {};
+    }
+
     if (!prevVASLog && m_DebugVASLog)
         LogVAS("DebugVASLog enabled");
 


### PR DESCRIPTION
### Motivation
- Mouse-mode (keyboard/mouse) should not have the automatic multicore `mat_queue_mode` switching applied, but the menu/main-menu state still needs a safe `mat_queue_mode` to avoid UI/input issues.

### Description
- Added an early mouse-mode branch in `VR::UpdateAutoMatQueueMode()` that bypasses the normal auto-management and only enforces a menu safety rule when `m_MouseModeEnabled` is true.
- When in mouse mode and not `IsInGame()`, the code checks `GetMatQueueMode()` and forces `mat_queue_mode 0` if the current mode is neither `0` nor `1`, using a 0.5s retry throttle driven by `m_AutoMatQueueModeLastCmdTime` and `m_AutoMatQueueModeLastRequested` and emitting a `Game::logMsg()` entry on enforced changes.
- The change returns early for mouse mode so the existing non-mouse auto-switch behavior remains unchanged and localized to `VR::UpdateAutoMatQueueMode()`.

### Testing
- Ran an identifier search with `rg "m_MouseModeEnabled|UpdateAutoMatQueueMode\("` to confirm the function and field usages and the check succeeded.
- Inspected the modified source hunk with `sed`/`nl` to verify the inserted mouse-mode branch, throttle logic, and log line and the verification succeeded.
- No build or runtime tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6d11ac348321a54a16aeadde3e03)