### PR TITLE
Fix hand HUD refresh and mouse-mode overlay anchoring

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -609,6 +609,8 @@ public:
 
 	float m_HandHudMaxHz = 30.0f;
 	std::chrono::steady_clock::time_point m_LastHandHudUpdateTime{};
+	// Force a periodic redraw even when cached values are unchanged, so battery/teammate bars can't get stuck.
+	std::chrono::steady_clock::time_point m_LastHandHudForceRedrawTime{};
 	// Double-buffered pixel storage to avoid flicker/tearing when SteamVR reads the same buffer we are updating.
 	std::array<std::vector<uint8_t>, 2> m_LeftWristHudPixels{};
 	std::array<std::vector<uint8_t>, 2> m_RightAmmoHudPixels{};


### PR DESCRIPTION
### Motivation
- Prevent wrist/ammo HUD elements from becoming visually stale (battery/teammate bars and similar) when cached values do not change and controllers are absent in mouse mode.
- Ensure HUD state is reset when leaving/entering gameplay contexts so overlays don't carry over stale session values.
- Provide a stable anchor for hand HUDs when controllers are not tracked by anchoring them to the HMD in mouse mode.

### Description
- Add a dedicated forced-redraw timestamp `m_LastHandHudForceRedrawTime` in `L4D2VR/vr.h` to drive periodic refreshes.
- Introduce a `resetHandHudState` lambda in `UpdateHandHudOverlays()` that clears all cached HUD values and per-player temp-health decay state and call it when not in-game, missing local player, or dead in `L4D2VR/vr/vr_lifecycle.inl`.
- Add mouse-mode HMD anchoring by computing an HMD-based overlay transform (convert anchor offsets, multiply HMD and relative matrices via `mul34`) and use `SetOverlayTransformAbsolute` when no controller poses are available.
- Implement a periodic (1s) `forceRedraw` check inside both left-wrist and right-ammo HUD update paths and advance `m_LastHandHudForceRedrawTime` only when a new texture is actually submitted.

### Testing
- Ran `git diff --check` which reported no issues and the changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a83e75dc083219e1f411da006f955)