### PR TITLE
Hide Mouse Mode child options when MouseMode is disabled

### DIFF
--- a/L4D2VRConfigTool/src/Options.cpp
+++ b/L4D2VRConfigTool/src/Options.cpp
@@ -142,6 +142,21 @@ static int GetInt(const std::string& key, int defVal)
     return defVal;
 }
 
+static bool GetBool(const std::string& key, bool defVal)
+{
+    return ParseBool(GetStr(key), defVal);
+}
+
+static bool IsOptionVisible(const Option& opt)
+{
+    // Hide Mouse Mode child settings until the mode is enabled,
+    // so the panel stays compact for controller-first users.
+    if (std::strncmp(opt.key, "MouseMode", 9) == 0 && std::strcmp(opt.key, "MouseModeEnabled") != 0)
+        return GetBool("MouseModeEnabled", false);
+
+    return true;
+}
+
 static ImVec4 ParseColorString(const std::string& s, const ImVec4& defVal)
 {
     if (s.empty()) return defVal;
@@ -1461,7 +1476,7 @@ void DrawOptionsUI()
     for (int i = 0; i < g_OptionCount; ++i)
     {
         const Option& opt = g_Options[i];
-        if (!OptionMatchesFilter(opt))
+        if (!IsOptionVisible(opt) || !OptionMatchesFilter(opt))
             continue;
 
         std::string key = opt.key;


### PR DESCRIPTION
### Motivation
- Avoid showing many mouse-mode-specific settings when `MouseModeEnabled` is off so the options panel stays compact and relevant.

### Description
- Added a `GetBool(const std::string&, bool)` helper that returns a parsed boolean from `g_Values` via `ParseBool(GetStr(...))`.
- Added `IsOptionVisible(const Option&)` which hides options whose key starts with `MouseMode` except for `MouseModeEnabled` itself.
- Updated `DrawOptionsUI()` to call `IsOptionVisible()` before `OptionMatchesFilter()` and skip rendering invisible options.

### Testing
- Reviewed the produced diff and inspected `L4D2VRConfigTool/src/Options.cpp` to confirm the new helpers and the updated visibility check were inserted correctly (diff/file inspection succeeded).
- No automated build or unit tests were executed in this Linux environment because the project uses Visual Studio/MSBuild tooling not available here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aa0fd2c2083219f1a6bff71eb77c0)