### PR TITLE
Adjust VR-aware viewangle handling for action-driven hand aim

### DIFF
--- a/L4D2VR/hooks/hooks_createmove.inl
+++ b/L4D2VR/hooks/hooks_createmove.inl
@@ -481,8 +481,14 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 
 		}
 		else {
-			// VR-aware servers: ensure cmd->viewangles matches HMD.
+			// VR-aware servers: default cmd->viewangles follows the HMD.
 			// Otherwise forward/sidemove get interpreted in the wrong basis (push forward -> strafe).
+			//
+			// However, some vanilla server interactions (IN_USE traces, throwables, etc.) still
+			// rely purely on cmd->viewangles. When ForceNonVRServerMovement=false we still want
+			// those to be driven by the right-hand aim, without making locomotion suddenly follow
+			// the hand. So: temporarily aim cmd->viewangles from the right hand for those actions,
+			// and re-project movement so world-direction stays the same.
 			Vector hmdAng = m_VR->GetViewAngle();
 			QAngle view(hmdAng.x, hmdAng.y, hmdAng.z);
 			if (m_VR->m_MouseModeEnabled)
@@ -498,7 +504,55 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 			while (view.y > 180.f)  view.y -= 360.f;
 			while (view.y < -180.f) view.y += 360.f;
 			view.z = 0.f;
-			cmd->viewangles = view;
+
+			bool useHandAim = false;
+			if (!m_VR->m_MouseModeEnabled)
+			{
+				const bool useDown = (cmd->buttons & (1 << 5)) != 0;      // IN_USE
+				const bool attackDown = (cmd->buttons & (1 << 0)) != 0;   // IN_ATTACK
+				const bool attack2Down = (cmd->buttons & (1 << 11)) != 0; // IN_ATTACK2
+
+				const int lpIdxAim = (m_Game && m_Game->m_EngineClient) ? m_Game->m_EngineClient->GetLocalPlayer() : -1;
+				C_BasePlayer* lpAim = (lpIdxAim > 0) ? (C_BasePlayer*)m_Game->GetClientEntity(lpIdxAim) : nullptr;
+				C_WeaponCSBase* wpnAim = lpAim ? (C_WeaponCSBase*)lpAim->GetActiveWeapon() : nullptr;
+
+				const bool isThrowable = m_VR->IsThrowableWeapon(wpnAim);
+				// m_iCurrentUseAction: healing/giving pack/reviving/etc. These actions also use viewangles to pick a target.
+				const bool doingUseAction = lpAim ? (ReadNetvar<int>(lpAim, 0x1ba8) != 0) : false;
+
+				useHandAim =
+					useDown ||
+					(isThrowable && (attackDown || attack2Down)) ||
+					(doingUseAction && attackDown);
+			}
+
+			if (useHandAim)
+			{
+				QAngle hand = m_VR->GetRightControllerAbsAngle();
+				if (hand.x > 89.f)  hand.x = 89.f;
+				if (hand.x < -89.f) hand.x = -89.f;
+				while (hand.y > 180.f)  hand.y -= 360.f;
+				while (hand.y < -180.f) hand.y += 360.f;
+				hand.z = 0.f;
+
+				// Preserve world movement direction while we temporarily change cmd yaw basis.
+				QAngle viewYawOnly(0.f, view.y, 0.f);
+				Vector viewForward, viewRight, viewUp;
+				QAngle::AngleVectors(viewYawOnly, &viewForward, &viewRight, &viewUp);
+				Vector worldMove = viewForward * cmd->forwardmove + viewRight * cmd->sidemove;
+
+				QAngle handYawOnly(0.f, hand.y, 0.f);
+				Vector handForward, handRight, handUp;
+				QAngle::AngleVectors(handYawOnly, &handForward, &handRight, &handUp);
+				cmd->forwardmove = DotProduct(worldMove, handForward);
+				cmd->sidemove = DotProduct(worldMove, handRight);
+
+				cmd->viewangles = hand;
+			}
+			else
+			{
+				cmd->viewangles = view;
+			}
 		}
 	}
 
@@ -698,4 +752,3 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 	}
 	return result;
 }
-

--- a/L4D2VR/vr/vr_aiming.inl
+++ b/L4D2VR/vr/vr_aiming.inl
@@ -561,8 +561,6 @@ void VR::UpdateAimingLaser(C_BasePlayer* localPlayer)
         Vector pitchSource = direction;
         if (useMouse && !eyeDir.IsZero())
             pitchSource = eyeDir;
-        else if (!m_ForceNonVRServerMovement && !m_HmdForward.IsZero())
-            pitchSource = m_HmdForward;
 
         DrawThrowArc(origin, direction, pitchSource);
         return;


### PR DESCRIPTION
### Motivation
- Ensure HMD remains the default source for `cmd->viewangles` on VR-aware servers while enabling correct target selection for legacy server interactions that still read `cmd->viewangles`.
- Avoid making locomotion follow the right-hand when temporarily using hand aim for interactions, preserving player movement feel.
- Make throwable-aim guidance follow the current aim direction rather than falling back to the HMD forward vector.

### Description
- Modify `L4D2VR/hooks/hooks_createmove.inl` to keep HMD as the default `cmd->viewangles` but detect interaction-driven cases (`IN_USE`, throwable attacks, and active use-actions via `m_iCurrentUseAction`) and temporarily override aim with the right-hand controller angle.
- When hand-aim override is active, reproject `cmd->forwardmove` and `cmd->sidemove` from the original HMD/view yaw into the hand yaw basis so world-space locomotion direction is preserved, then set `cmd->viewangles` to the hand angle; otherwise set `cmd->viewangles` to the HMD-derived view.
- Respect mouse mode by skipping hand-aim overrides when `m_VR->m_MouseModeEnabled` is active.
- Update `L4D2VR/vr/vr_aiming.inl` to remove the throwable arc pitch fallback to `m_HmdForward`, so the throw arc pitch is derived only from the current `direction`/mouse `eyeDir` behavior.
- Files changed: `L4D2VR/hooks/hooks_createmove.inl`, `L4D2VR/vr/vr_aiming.inl`.

### Testing
- Ran `git -C /workspace/l4d2vr diff --check` and it completed without reported whitespace or diff issues (success).
- Ran `git -C /workspace/l4d2vr status --short` to verify the two modified files show staged changes (success).
- Committed the patch with `git -C /workspace/l4d2vr commit -m "Adjust VR-aware viewangle hand-aim overrides"` and verified the commit via `git -C /workspace/l4d2vr show --stat --oneline -1` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699aac9db3f883219ca00160bbb49d07)