### PR TITLE
Stabilize VR server-hook freshness decisions across CreateMove/WriteUsercmd

### DIFF
--- a/L4D2VR/hooks.cpp
+++ b/L4D2VR/hooks.cpp
@@ -396,6 +396,17 @@ namespace
 
 	static std::atomic<SteadyRep> g_ServerHookLastSeenRep{ 0 };
 
+	// CreateMove/WriteUsercmd consistency:
+	// serverHookFresh is used to decide whether to encode extra VR data into CUserCmd and whether
+	// to auto-force Non-VR server compatibility. If CreateMove and WriteUsercmd make that decision
+	// at different times (or from a noisy heartbeat), you can get a once-per-second "walk stutter"
+	// where one side thinks we're in VR-aware mode and the other doesn't.
+	//
+	// Cache the fresh/stale decision per command_number so both paths agree for the same cmd.
+	static std::atomic<int> g_ServerHookFreshCmdNum{ 0 };
+	static std::atomic<int> g_ServerHookFreshValue{ 0 }; // 0 = stale, 1 = fresh
+
+
 	// Auto-override ForceNonVRServerMovement while on a remote server (or server hooks not running).
 	// We save and restore the user's value when we re-enter a local listen-server context.
 	static bool g_ForceNonVRUserSaved = false;
@@ -406,6 +417,26 @@ namespace
 		Hooks::s_ServerUnderstandsVR.store(true, std::memory_order_relaxed);
 		g_ServerHookLastSeenRep.store(SteadyClock::now().time_since_epoch().count(), std::memory_order_relaxed);
 	}
+
+	static inline void CacheServerHookFreshForCmd(int cmdNum, bool fresh)
+	{
+		if (cmdNum <= 0)
+			return;
+		g_ServerHookFreshCmdNum.store(cmdNum, std::memory_order_relaxed);
+		g_ServerHookFreshValue.store(fresh ? 1 : 0, std::memory_order_relaxed);
+	}
+
+	static inline bool TryGetCachedServerHookFreshForCmd(int cmdNum, bool& outFresh)
+	{
+		if (cmdNum <= 0)
+			return false;
+		const int cachedNum = g_ServerHookFreshCmdNum.load(std::memory_order_relaxed);
+		if (cachedNum != cmdNum)
+			return false;
+		outFresh = (g_ServerHookFreshValue.load(std::memory_order_relaxed) != 0);
+		return true;
+	}
+
 
 	static inline bool IsServerHookFreshNow()
 	{

--- a/L4D2VR/hooks/hooks_combat_network.inl
+++ b/L4D2VR/hooks/hooks_combat_network.inl
@@ -364,7 +364,6 @@ int Hooks::dReadUsercmd(void* buf, CUserCmd* move, CUserCmd* from)
 	const bool hasValidPlayer = m_Game->IsValidPlayerIndex(i);
 	if (m_VR->m_EncodeVRUsercmd && move->tick_count < 0) // Signal for VR CUserCmd
 	{
-		MarkServerHookSeen();
 		move->tick_count *= -1;
 
 		if (move->command_number < 0)
@@ -440,8 +439,15 @@ int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 	// 只有（配置开启编码）且（本进程确实在跑服务器钩子＝能解码）且（未强制走非 VR 标准）时才编码
 	// Auto-fallback: if server-side VR decoding isn't running in this process (remote server or bad hooks),
 	// force Non-VR server compatibility mode.
-	const bool inGame = (m_Game && m_Game->m_EngineClient) ? m_Game->m_EngineClient->IsInGame() : false;
-	const bool serverHookFresh = inGame && IsServerHookFreshNow();
+	bool serverHookFresh = false;
+	bool haveCachedFresh = false;
+	if (to)
+		haveCachedFresh = TryGetCachedServerHookFreshForCmd(to->command_number, serverHookFresh);
+	if (!haveCachedFresh)
+	{
+		const bool inGame = (m_Game && m_Game->m_EngineClient) ? m_Game->m_EngineClient->IsInGame() : false;
+		serverHookFresh = inGame && IsServerHookFreshNow();
+	}
 	if (!serverHookFresh)
 		Hooks::s_ServerUnderstandsVR.store(false, std::memory_order_relaxed);
 	SyncForceNonVRRemoteOverride(m_VR, serverHookFresh);

--- a/L4D2VR/hooks/hooks_createmove.inl
+++ b/L4D2VR/hooks/hooks_createmove.inl
@@ -62,6 +62,18 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 				s_prevSpectatorLikeInitialized = false;
 			}
 		}
+		// If server-side VR decoding isn't running in *this* process (i.e. remote server),
+		// auto-fallback to Non-VR server compatibility mode.
+		// IMPORTANT: do this BEFORE we branch on ForceNonVRServerMovement for this cmd,
+		// otherwise CreateMove can build a "VR-aware" cmd while WriteUsercmd sends a
+		// "Non-VR" cmd (or vice-versa), which shows up as periodic walk stutter.
+		const bool inGame = (m_Game && m_Game->m_EngineClient) ? m_Game->m_EngineClient->IsInGame() : false;
+		const bool serverHookFresh = inGame && IsServerHookFreshNow();
+		CacheServerHookFreshForCmd(cmd->command_number, serverHookFresh);
+		if (!serverHookFresh)
+			Hooks::s_ServerUnderstandsVR.store(false, std::memory_order_relaxed);
+		SyncForceNonVRRemoteOverride(m_VR, serverHookFresh);
+
 		const bool treatServerAsNonVR = m_VR->m_ForceNonVRServerMovement;
 
 		// Mouse mode: consume raw mouse deltas to drive body yaw and independent aim pitch.
@@ -703,17 +715,6 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 
 	if (m_VR)
 	{
-		// If server-side VR decoding isn't running in *this* process (i.e. remote server),
-		// auto-fallback to Non-VR server compatibility mode for the whole tick.
-		const bool inGame = (m_Game && m_Game->m_EngineClient) ? m_Game->m_EngineClient->IsInGame() : false;
-		const bool serverHookFresh = inGame && IsServerHookFreshNow();
-		if (!serverHookFresh)
-			Hooks::s_ServerUnderstandsVR.store(false, std::memory_order_relaxed);
-		SyncForceNonVRRemoteOverride(m_VR, serverHookFresh);
-
-		// Debug: show whether the server-side hook is actually running in this process.
-		// For listen-server play, Hooks::dProcessUsercmds should get hit and flip s_ServerUnderstandsVR to true.
-		// If this stays false while in-game, then the ProcessUsercmds/ReadUsercmd offsets or hook installation are wrong.
 		// Detect any locomotion input (keyboard WASD, thumbstick, etc.).
 		// Used by roomscale anchoring and other movement-conflict avoidance.
 		const float fm = cmd ? cmd->forwardmove : 0.0f;


### PR DESCRIPTION
### Motivation
- CreateMove and WriteUsercmd could disagree about whether the server-side VR hook is "fresh" for the same `command_number`, which can cause periodic walk stutter when the heartbeat is noisy or the two paths sample freshness at different times.
- The change ensures both paths use a consistent freshness decision per command so encoding/Non-VR fallbacks remain synchronized.

### Description
- Add a per-command cache (`g_ServerHookFreshCmdNum` / `g_ServerHookFreshValue`) and helper functions `CacheServerHookFreshForCmd` / `TryGetCachedServerHookFreshForCmd` in `hooks.cpp` to store/read `serverHookFresh` by `command_number`.
- Evaluate freshness early in `Hooks::dCreateMove` and call `CacheServerHookFreshForCmd(cmd->command_number, serverHookFresh)`, then apply `SyncForceNonVRRemoteOverride` before branching on `m_ForceNonVRServerMovement` so the CreateMove path builds consistent CUserCmds.
- Update `Hooks::dWriteUsercmd` to prefer the cached per-command freshness (via `TryGetCachedServerHookFreshForCmd`) and fall back to the live heartbeat only when no cache is available.
- Stop treating decoding of VR payload in `Hooks::dReadUsercmd` as a heartbeat signal by removing the `MarkServerHookSeen()` call there, and remove the redundant freshness/override block later in `dCreateMove`.

### Testing
- Ran `git diff --check` to validate no whitespace or patch issues, which succeeded.
- Ran `git status --short` to confirm the intended files were staged/modified, which showed the three updated files.
- Committed the change (`Stabilize VR server-hook freshness per command`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b07f13fd48321b5eb802b3aae3076)