### PR TITLE
Move SEH memory reads to file-scope helpers to fix MSVC C2712

### DIFF
--- a/L4D2VR/vr/vr_lifecycle.inl
+++ b/L4D2VR/vr/vr_lifecycle.inl
@@ -2,6 +2,24 @@
 
 namespace
 {
+    inline bool SafeReadU8(const unsigned char* base, int off, unsigned char& out)
+    {
+        __try { out = *reinterpret_cast<const unsigned char*>(base + off); return true; }
+        __except (EXCEPTION_EXECUTE_HANDLER) { out = 0; return false; }
+    }
+
+    inline bool SafeReadInt(const unsigned char* base, int off, int& out)
+    {
+        __try { out = *reinterpret_cast<const int*>(base + off); return true; }
+        __except (EXCEPTION_EXECUTE_HANDLER) { out = 0; return false; }
+    }
+
+    inline bool SafeReadFloat(const unsigned char* base, int off, float& out)
+    {
+        __try { out = *reinterpret_cast<const float*>(base + off); return true; }
+        __except (EXCEPTION_EXECUTE_HANDLER) { out = 0.0f; return false; }
+    }
+
     // NOTE: This file uses a tiny 5x7 glyph set for UI labels (LC/RC, item abbreviations, etc.).
     // For player names (teammates / aim target), we also support UTF-8 via a GDI fallback renderer
     // so Chinese/JP/KR/etc names can display correctly on the HUD overlay.
@@ -2322,8 +2340,8 @@ void VR::UpdateHandHudOverlays()
 
     const unsigned char* pBase = reinterpret_cast<const unsigned char*>(localPlayer);
     unsigned char lifeState = 0;
-    __try { lifeState = *reinterpret_cast<const unsigned char*>(pBase + kLifeStateOffset); }
-    __except (EXCEPTION_EXECUTE_HANDLER) { lifeState = 1; }
+    if (!SafeReadU8(pBase, kLifeStateOffset, lifeState))
+        lifeState = 1;
     if (lifeState != 0)
     {
         if (dbgTick)
@@ -2360,21 +2378,9 @@ void VR::UpdateHandHudOverlays()
 
     // Safe memory reads: UpdateHandHudOverlays can run on the present/render thread while the game
     // is loading/unloading, so client entity pointers may become invalid mid-frame.
-    auto TryReadU8 = [](const unsigned char* base, int off, unsigned char& out) -> bool
-    {
-        __try { out = *reinterpret_cast<const unsigned char*>(base + off); return true; }
-        __except (EXCEPTION_EXECUTE_HANDLER) { out = 0; return false; }
-    };
-    auto TryReadInt = [](const unsigned char* base, int off, int& out) -> bool
-    {
-        __try { out = *reinterpret_cast<const int*>(base + off); return true; }
-        __except (EXCEPTION_EXECUTE_HANDLER) { out = 0; return false; }
-    };
-    auto TryReadFloat = [](const unsigned char* base, int off, float& out) -> bool
-    {
-        __try { out = *reinterpret_cast<const float*>(base + off); return true; }
-        __except (EXCEPTION_EXECUTE_HANDLER) { out = 0.0f; return false; }
-    };
+    auto TryReadU8 = [](const unsigned char* base, int off, unsigned char& out) -> bool { return SafeReadU8(base, off, out); };
+    auto TryReadInt = [](const unsigned char* base, int off, int& out) -> bool { return SafeReadInt(base, off, out); };
+    auto TryReadFloat = [](const unsigned char* base, int off, float& out) -> bool { return SafeReadFloat(base, off, out); };
 
     // Compute decayed temp HP from (m_healthBuffer, m_healthBufferTime) using wall-clock time.
     // The engine does: max(0, healthBuffer - decayRate * (curtime - healthBufferTime)).
@@ -2799,7 +2805,7 @@ void VR::UpdateHandHudOverlays()
             {
                 m_LeftWristHudLastCrc = (uint32_t)crc;
                 {
-                    vr::EVROverlayError err = vr::VROverlayError_Unknown;
+                    vr::EVROverlayError err = vr::VROverlayError_None;
                     {
                         std::lock_guard<std::mutex> _lk(m_VROverlayMutex);
                         err = m_Overlay->SetOverlayRaw(m_LeftWristHudHandle, pixels.data(), (uint32_t)w, (uint32_t)h, 4);
@@ -3089,7 +3095,7 @@ void VR::UpdateHandHudOverlays()
             {
                 m_RightAmmoHudLastCrc = (uint32_t)crc;
                 {
-                    vr::EVROverlayError err = vr::VROverlayError_Unknown;
+                    vr::EVROverlayError err = vr::VROverlayError_None;
                     {
                         std::lock_guard<std::mutex> _lk(m_VROverlayMutex);
                         err = m_Overlay->SetOverlayRaw(m_RightAmmoHudHandle, pixels.data(), (uint32_t)w, (uint32_t)h, 4);


### PR DESCRIPTION
### Motivation
- MSVC emits C2712 when `__try`/`__except` appears inside a function that requires C++ object unwinding, and `VR::UpdateHandHudOverlays()` contained SEH blocks that triggered this error.

### Description
- Add file-scope helpers `SafeReadU8`, `SafeReadInt`, and `SafeReadFloat` that encapsulate the `__try`/`__except` guarded pointer reads.
- Replace the direct `__try`/`__except` read of `lifeState` in `VR::UpdateHandHudOverlays()` with `if (!SafeReadU8(...)) lifeState = 1;` to remove SEH from the function body.
- Replace the in-function SEH lambdas with thin lambdas that forward to the new `SafeRead*` helpers so `UpdateHandHudOverlays()` no longer contains `__try` blocks.
- Retain the previous overlay enum fix by initializing `vr::EVROverlayError` to `vr::VROverlayError_None` where applicable.

### Testing
- Ran `rg -n "__try|__except|SafeReadU8\(|TryReadU8" L4D2VR/vr/vr_lifecycle.inl` to confirm SEH blocks are contained in the new helpers and the function forwards to them, which succeeded.
- Verified the source changes with `git diff -- L4D2VR/vr/vr_lifecycle.inl` and inspected lines via `nl -ba L4D2VR/vr/vr_lifecycle.inl | sed -n '1,35p;2336,2390p'`, which matched the intended modifications.
- Committed the change to the branch and confirmed the commit was created; search-and-diff checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d96412b9c83218da1c4e6a13f1bef)