### PR TITLE
Fix HandHUD recovery by destroying stale overlays before recreate

### DIFF
--- a/L4D2VR/vr/vr_lifecycle.inl
+++ b/L4D2VR/vr/vr_lifecycle.inl
@@ -3346,12 +3346,31 @@ after_right:
                 if (ov) m_Overlay = ov;
                 if (ov)
                 {
-                    // Hide any previous overlays (if the handles are still valid), then drop the handles.
-                    // We'll re-acquire handles via EnsureHandHudOverlayHandles (which is retry/rate-limited).
-                    if (m_LeftWristHudHandle != vr::k_ulOverlayHandleInvalid)
-                        ov->HideOverlay(m_LeftWristHudHandle);
-                    if (m_RightAmmoHudHandle != vr::k_ulOverlayHandleInvalid)
-                        ov->HideOverlay(m_RightAmmoHudHandle);
+                    // Hide and destroy any previous overlays before dropping the handles.
+                    // Some runtimes keep returning stale handles that continue to fail SetOverlayRaw(RequestFailed),
+                    // so a true destroy is required to force a clean recreation.
+                    auto hideDestroyByHandle = [&](vr::VROverlayHandle_t h)
+                    {
+                        if (h == vr::k_ulOverlayHandleInvalid)
+                            return;
+                        ov->HideOverlay(h);
+                        ov->DestroyOverlay(h);
+                    };
+
+                    auto hideDestroyByKey = [&](const char* key)
+                    {
+                        vr::VROverlayHandle_t found = vr::k_ulOverlayHandleInvalid;
+                        if (ov->FindOverlay(key, &found) == vr::VROverlayError_None && found != vr::k_ulOverlayHandleInvalid)
+                        {
+                            ov->HideOverlay(found);
+                            ov->DestroyOverlay(found);
+                        }
+                    };
+
+                    hideDestroyByHandle(m_LeftWristHudHandle);
+                    hideDestroyByHandle(m_RightAmmoHudHandle);
+                    hideDestroyByKey("LeftWristHudOverlayKey");
+                    hideDestroyByKey("RightAmmoHudOverlayKey");
 
                     m_LeftWristHudHandle = vr::k_ulOverlayHandleInvalid;
                     m_RightAmmoHudHandle = vr::k_ulOverlayHandleInvalid;


### PR DESCRIPTION
### Motivation
- Address persistent `SetOverlayRaw` failures (`VROverlayError_RequestFailed` / err=23) where the HandHUD overlay can become stuck due to stale overlay objects returned by some runtimes.
- Ensure recovery actually forces a clean recreation instead of only hiding and invalidating local handles, which can leave broken overlays present in the runtime.
- Limit scope to the HandHUD overlay recover path to minimize risk to other systems.

### Description
- Updated the HandHUD recovery block in `L4D2VR/vr/vr_lifecycle.inl` to hide and `DestroyOverlay` any stale overlays before dropping handles.
- Added two helper lambdas: one to hide+destroy by handle and one to find, hide and destroy by overlay key (`"LeftWristHudOverlayKey"` / `"RightAmmoHudOverlayKey"`).
- Preserved the existing re-acquire flow by continuing to call `EnsureHandHudOverlayHandles(true)` and then resetting cached state and counters.

### Testing
- Ran `git diff --check` to validate patch formatting and it succeeded.
- Verified the change touched only `L4D2VR/vr/vr_lifecycle.inl` and inspected the updated region, which succeeded.
- Committed the change on the feature branch and confirmed the new commit was created, with all verification steps passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699feff35a5c8321b91285563d54ac07)