### PR TITLE
Config menu save componentEditIndex state by spec.key

### DIFF
--- a/L4D2VR/vr_config_overlay_embedded.inl
+++ b/L4D2VR/vr_config_overlay_embedded.inl
@@ -592,6 +592,7 @@ namespace
         uint32_t hoverSelectionSuppressedUntilMs = 0;
         std::string componentEditKey;
         int componentEditIndex = 0;
+        std::unordered_map<std::string, int> componentEditIndexByKey;
         bool keyboardActive = false;
         std::string keyboardEditKey;
         vr::VROverlayHandle_t keyboardEventHandle = vr::k_ulOverlayHandleInvalid;
@@ -1098,8 +1099,11 @@ namespace
             return 0;
         if (s.componentEditKey != spec.key)
         {
+            auto it = s.componentEditIndexByKey.find(spec.key);
+            const int index = (it == s.componentEditIndexByKey.end()) ? 0 : it->second;
+            
             s.componentEditKey = spec.key;
-            s.componentEditIndex = 0;
+            s.componentEditIndex = index;
         }
         s.componentEditIndex = (std::clamp)(s.componentEditIndex, 0, count - 1);
         return s.componentEditIndex;
@@ -1110,8 +1114,7 @@ namespace
         const int count = CfgComponentCount(spec);
         if (count <= 0)
             return;
-        s.componentEditKey = spec.key;
-        s.componentEditIndex = (std::clamp)(index, 0, count - 1);
+        s.componentEditIndexByKey[spec.key] = (std::clamp)(index, 0, count - 1);
         s.dirty = true;
     }
 
@@ -1146,6 +1149,7 @@ namespace
             next = CfgClampFloatToSpec(spec, next);
 
         values[(size_t)index] = next;
+        s.componentEditIndexByKey[spec.key] = index;
         const std::string value = CfgFormatComponentValues(spec, values);
         const float formatStep = CfgComponentFormatStep(spec, index, next);
         s.values[spec.key] = value;
@@ -4956,7 +4960,7 @@ namespace
                 if (CfgIsComponentEditable(spec))
                 {
                     const int count = CfgComponentCount(spec);
-                    const int activeIndex = selected ? CfgSelectedComponentIndex(s, spec) : (s.componentEditKey == spec.key ? (std::clamp)(s.componentEditIndex, 0, (std::max)(0, count - 1)) : 0);
+                    const int activeIndex = CfgSelectedComponentIndex(s, spec);
                     for (int i = 0; i < count; ++i)
                     {
                         const int bx = kCfgComponentX + i * (kCfgComponentButtonW + kCfgComponentGap);

--- a/L4D2VR/vr_config_overlay_embedded.inl
+++ b/L4D2VR/vr_config_overlay_embedded.inl
@@ -1106,6 +1106,7 @@ namespace
             s.componentEditIndex = index;
         }
         s.componentEditIndex = (std::clamp)(s.componentEditIndex, 0, count - 1);
+        s.componentEditIndexByKey[spec.key] = s.componentEditIndex;
         return s.componentEditIndex;
     }
 
@@ -1114,7 +1115,9 @@ namespace
         const int count = CfgComponentCount(spec);
         if (count <= 0)
             return;
-        s.componentEditIndexByKey[spec.key] = (std::clamp)(index, 0, count - 1);
+        s.componentEditKey = spec.key;
+        s.componentEditIndex = (std::clamp)(index, 0, count - 1);
+        s.componentEditIndexByKey[s.componentEditKey] = s.componentEditIndex;
         s.dirty = true;
     }
 


### PR DESCRIPTION
Fix #347 
- X Y Z selector resets when the selected column changes.

### Preview

https://github.com/user-attachments/assets/3fe27e71-4dba-4552-b85c-a9446b3ee25a