### PR TITLE
Separate reload from handguard input and holding button for two-handed

### DIFF
--- a/L4D2VR/vr.h
+++ b/L4D2VR/vr.h
@@ -3179,6 +3179,8 @@ public:
 		C_BasePlayer* localPlayer,
 		bool leftGripDown,
 		bool leftGripJustPressed,
+		bool leftHandguardGripDown,
+    	bool leftHandguardGripJustPressed,
 		bool allowGameplayInputOnTwoHandedGripRelease);
 	void MarkMagazineInteractionReloadCommandIssued();
 	bool IsMagazineInteractionReloadCommandActive() const;

--- a/L4D2VR/vr/vr_process_input.inl
+++ b/L4D2VR/vr/vr_process_input.inl
@@ -73,7 +73,7 @@ void VR::ProcessInput()
         m_PrimaryAttackDown = false;
         m_MagazineInteractionThumbIndexCurlDownPrev = false;
         m_MagazineInteractionThreeFingerCurlDownPrev = false;
-        (void)UpdateMagazineInteraction(nullptr, false, false, false);
+        (void)UpdateMagazineInteraction(nullptr, false, false, false, false, false);
         CancelMagazineInteractionManual();
         CancelTeleportTargeting();
         return;
@@ -474,14 +474,11 @@ void VR::ProcessInput()
     const bool magazineButtonGripInput =
         vrHandsGripInputEnabled &&
         (!magazineInteractionInputEnabled || m_MagazineInteractionUseButtonGripInput);
-    const bool magazineFingerCurlInput =
-        magazineInteractionInputEnabled &&
-        !m_MagazineInteractionUseButtonGripInput;
     std::array<float, 5> magazineInteractionFingerCurls{};
     const bool magazineInteractionFingerCurlsValid =
-        magazineFingerCurlInput &&
+        magazineInteractionInputEnabled &&
         ReadMagazineInteractionFingerCurls(magazineInteractionFingerCurls);
-    if (!magazineFingerCurlInput)
+    if (!magazineInteractionInputEnabled)
     {
         m_MagazineInteractionThumbIndexCurlDownPrev = false;
         m_MagazineInteractionThreeFingerCurlDownPrev = false;
@@ -518,7 +515,7 @@ void VR::ProcessInput()
 
     bool thumbIndexGripDown = false;
     bool threeFingerGripDown = false;
-    if (magazineFingerCurlInput && magazineInteractionFingerCurlsValid)
+    if (magazineInteractionInputEnabled && magazineInteractionFingerCurlsValid)
     {
         const float thumbIndexThreshold = thumbIndexWasDown ? thumbIndexCurlRelease : thumbIndexCurlStart;
         const float threeFingerThreshold = threeFingerWasDown ? threeFingerCurlRelease : threeFingerCurlStart;
@@ -538,6 +535,10 @@ void VR::ProcessInput()
         ? magazineButtonGripJustPressed
         : ((thumbIndexGripDown && !thumbIndexWasDown) ||
             (threeFingerGripDown && !threeFingerWasDown));
+
+    const bool handguardGripDown =  (thumbIndexGripDown || threeFingerGripDown);
+    const bool handguardGripJustPressed =  (thumbIndexGripDown && !thumbIndexWasDown) || (threeFingerGripDown && !threeFingerWasDown);
+
     m_MagazineInteractionThumbIndexCurlDownPrev = thumbIndexGripDown;
     m_MagazineInteractionThreeFingerCurlDownPrev = threeFingerGripDown;
 
@@ -545,6 +546,8 @@ void VR::ProcessInput()
         localPlayer,
         magazineGripDown,
         magazineGripJustPressed,
+        handguardGripDown,
+        handguardGripJustPressed,
         allowGameplayInputOnTwoHandedGripRelease);
     if (IsMagazineInteractionLeftHandActive())
     {

--- a/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
+++ b/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
@@ -4374,6 +4374,10 @@ bool VR::UpdateMagazineInteraction(
     C_BasePlayer* localPlayer,
     bool leftGripDown,
     bool leftGripJustPressed,
+
+    bool leftHandguardGripDown,
+    bool leftHandguardGripJustPressed,
+
     bool allowGameplayInputOnTwoHandedGripRelease)
 {
     const auto now = std::chrono::steady_clock::now();
@@ -5516,7 +5520,7 @@ bool VR::UpdateMagazineInteraction(
     {
         clearMountFriendlyGripContact();
 
-        if (leftGripJustPressed && twoHandedGripRuntimeAllowed && m_VrHandsTwoHandedGripActive)
+        if (!leftHandguardGripDown && twoHandedGripRuntimeAllowed && m_VrHandsTwoHandedGripActive)
         {
             m_VrHandsTwoHandedGripActive = false;
             m_VrHandsTwoHandedGripWeaponId = 0;
@@ -5531,12 +5535,7 @@ bool VR::UpdateMagazineInteraction(
             }
             return false;
         }
-
-        if (leftGripJustPressed &&
-            twoHandedGripRuntimeAllowed &&
-            !IsMagazineInteractionManualActive() &&
-            !m_MagazineInteractionLeftHandHolding &&
-            !leftHandTouchesMagazineForGripExclusion())
+        else if (leftHandguardGripDown && twoHandedGripRuntimeAllowed && !m_VrHandsTwoHandedGripActive)
         {
             float twoHandTargetDistance = FLT_MAX;
             if (leftHandTouchesTwoHandedGripTarget(twoHandTargetDistance))


### PR DESCRIPTION
#346 Hands / Reload

- When MagazineInteractionUseButtonGripInput is enabled, the off-hand stay using grip button for two-handed mode, while the magazine grab button changes to whatever it is
- Off-hand handguard grip mode changes to holding for two-handed mode, release the button to stop two-handed mode