### PR TITLE
Suppress m_ReloadCmdOwned when m_MagazineInteractionEnabled

### DIFF
--- a/L4D2VR/vr/vr_process_input.inl
+++ b/L4D2VR/vr/vr_process_input.inl
@@ -1480,7 +1480,7 @@ void VR::ProcessInput()
     const bool wantReload =
         magazineInteractionReloadPulse ||
         (!crouchButtonDown && reloadButtonDown && !adjustViewmodelActive && !scopeAdjustActive);
-    if (wantReload && !m_ReloadCmdOwned)
+    if (wantReload && !m_ReloadCmdOwned && !m_MagazineInteractionEnabled)
     {
         m_Game->ClientCmd_Unrestricted("+reload");
         m_ReloadCmdOwned = true;


### PR DESCRIPTION
Using the **Reload** button to grab a magazine will no longer trigger +reload command