### PR TITLE
When pulling the magazine out, keep one bullet in the chamber

### DIFF
--- a/L4D2VR/hooks/hooks_combat_network.inl
+++ b/L4D2VR/hooks/hooks_combat_network.inl
@@ -1996,6 +1996,8 @@ void __fastcall Hooks::dWriteUsercmdDeltaToBuffer(void* ecx, void* edx, int a1, 
 
 int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 {
+	static int s_lastButtons = 0;
+
 	const bool localUsingMountedWeapon = m_VR &&
 		m_VR->m_IsVREnabled &&
 		!m_VR->m_ForceNonVRServerMovement &&
@@ -2011,7 +2013,7 @@ int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 		const bool magazineInteractionBlocksFire = m_VR->IsMagazineInteractionBlockingFire();
 		if (magazineInteractionBlocksFire)
 		{
-			if ((to->buttons & kMagazineInteractionInAttack) != 0)
+			if ((to->buttons & kMagazineInteractionInAttack) != 0 && (s_lastButtons & kMagazineInteractionInAttack) == 0)
 				m_VR->PlayMagazineInteractionBlockedFireEmptySound();
 			to->buttons &= ~kMagazineInteractionInAttack; // IN_ATTACK
 		}
@@ -2029,7 +2031,7 @@ int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 			m_VR->ShouldSuppressMagazineInteractionEmptyClipAutoReload(nullptr);
 		if (suppressMagazineEmptyClipAutoReload)
 		{
-			if ((to->buttons & kMagazineInteractionInAttack) != 0)
+			if ((to->buttons & kMagazineInteractionInAttack) != 0 && (s_lastButtons & kMagazineInteractionInAttack) == 0)
 				m_VR->PlayMagazineInteractionBlockedFireEmptySound();
 			to->buttons &= ~(kMagazineInteractionInAttack | kMagazineInteractionInReload);
 		}
@@ -2048,6 +2050,8 @@ int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 		// 保持标准 CUserCmd，让 dCreateMove 写入的 forwardmove/sidemove 正常生效
 		return hkWriteUsercmd.fOriginal(buf, to, from);
 	}
+
+	s_lastButtons = to->buttons;
 
 	// ======== 以下为原有“编码”逻辑，保持不变，仅包在 canEncode 分支内 ========
 	CInput* m_Input = **(CInput***)(m_Game->m_Offsets->g_pppInput.address);

--- a/L4D2VR/hooks/hooks_createmove.inl
+++ b/L4D2VR/hooks/hooks_createmove.inl
@@ -1,5 +1,6 @@
 bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime, CUserCmd* cmd)
 {
+	static int s_lastButtons = 0;
 	// When returning from spectator/observer back to a live player entity ("rescued"),
 	// VR origin can be desynced. Force a recenter/reset once on that transition.
 	// Netvars (client):
@@ -1435,7 +1436,7 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 	const bool magazineInteractionBlocksFire = m_VR->IsMagazineInteractionBlockingFire();
 	if (!localUsingMountedWeapon && magazineInteractionBlocksFire)
 	{
-		if ((cmd->buttons & kMagazineInteractionInAttack) != 0)
+		if ((cmd->buttons & kMagazineInteractionInAttack) != 0 && (s_lastButtons & kMagazineInteractionInAttack) == 0)
 			m_VR->PlayMagazineInteractionBlockedFireEmptySound();
 		cmd->buttons &= ~kMagazineInteractionInAttack; // IN_ATTACK
 	}
@@ -1455,7 +1456,7 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 		m_VR->ShouldSuppressMagazineInteractionEmptyClipAutoReload(nullptr);
 	if (!localUsingMountedWeapon && suppressMagazineEmptyClipAutoReload)
 	{
-		if ((cmd->buttons & kMagazineInteractionInAttack) != 0)
+		if ((cmd->buttons & kMagazineInteractionInAttack) != 0 && (s_lastButtons & kMagazineInteractionInAttack) == 0)
 			m_VR->PlayMagazineInteractionBlockedFireEmptySound();
 		cmd->buttons &= ~(kMagazineInteractionInAttack | kMagazineInteractionInReload);
 	}
@@ -1552,6 +1553,8 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 		m_VR->ApplyRoomscale1To1Move(cmd, flInputSampleTime, controlLocomotionActive);
 		m_VR->ApplyMovementLedgeGuard(cmd, m_VR->m_ScopeFovAdjustSuppressWalk || m_VR->m_TeleportTargetingActive);
 	}
+
+	s_lastButtons = cmd->buttons;
 	return result;
 }
 

--- a/L4D2VR/vr/vr_process_input.inl
+++ b/L4D2VR/vr/vr_process_input.inl
@@ -1303,7 +1303,7 @@ void VR::ProcessInput()
     const bool usingMountedWeaponForPrimary = vrAwareServerSupportPath && localPlayer && IsUsingMountedGun(localPlayer);
     if (!usingMountedWeaponForPrimary &&
         (magazineInteractionBlocksFire || suppressMagazineEmptyClipAutoReload) &&
-        primaryAttackDown)
+        primaryAttackJustPressed)
     {
         PlayMagazineInteractionBlockedFireEmptySound();
     }

--- a/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
+++ b/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
@@ -6250,7 +6250,9 @@ bool VR::UpdateMagazineInteraction(
                 false);
         else // One in the chamber
         {
-            if (activeClip == 0 || m_MagazineInteractionServerClipReserveHoldReserve == 0) // Chamber was loaded, but the clip just went empty.
+            const int heldAmmoType = m_MagazineInteractionServerClipReserveHoldAmmoType;
+            const int heldReserve = m_MagazineInteractionServerClipReserveHoldReserve;
+            if (activeClip == 0 || (heldAmmoType > 2 && heldReserve == 0)) // Chamber was loaded, but the clip just went empty.
                 m_MagazineInteractionChamberEmpty = true;
             else if (activeClip != 1) // Anti-spam call to block +attack when there is still ammo
                 applyServerHookClipSettlement(
@@ -7126,8 +7128,11 @@ bool VR::UpdateMagazineInteraction(
                 m_MagazineInteractionReloadCommandIssued = false;
                 m_MagazineInteractionReloadCommandHoldUntil = {};
                 m_MagazineInteractionChamberEmpty = activeClip == 0;
+
+                const int heldAmmoType = m_MagazineInteractionServerClipReserveHoldAmmoType;
+                const int heldReserve = m_MagazineInteractionServerClipReserveHoldReserve;
                 applyServerHookClipSettlement(
-                    (m_MagazineInteractionChamberEmpty || m_MagazineInteractionServerClipReserveHoldReserve == 0) ? 0 : 1,
+                    (m_MagazineInteractionChamberEmpty || (heldAmmoType > 2 && heldReserve == 0)) ? 0 : 1,
                     -1,
                     -1,
                     -1,

--- a/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
+++ b/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
@@ -3411,6 +3411,7 @@ bool VR::ShouldSuppressMagazineInteractionEmptyClipAutoReload(C_BasePlayer* loca
 {
     if (!m_MagazineInteractionEnabled ||
         !m_IsVREnabled ||
+        !m_MagazineInteractionChamberEmpty ||
         (!m_VrHandsEnabled && !m_NativeViewmodelHandsOnly))
     {
         return false;
@@ -3472,7 +3473,7 @@ bool VR::IsMagazineInteractionBlockingFire() const
             m_MagazineInteractionState == MagazineInteractionManualState::AutoBolting;
     }
 
-    return IsMagazineInteractionManualActive();
+    return IsMagazineInteractionManualActive() && m_MagazineInteractionChamberEmpty;
 }
 
 void VR::PlayMagazineInteractionBlockedFireEmptySound()
@@ -6238,14 +6239,31 @@ bool VR::UpdateMagazineInteraction(
             m_MagazineInteractionState == MagazineInteractionManualState::WaitingForFreshMagazine ||
             m_MagazineInteractionState == MagazineInteractionManualState::HoldingFreshMagazine))
     {
-        applyServerHookClipSettlement(
-            0,
-            -1,
-            -1,
-            -1,
-            "magazine-out-maintain-empty",
-            0.35f,
-            false);
+        if (m_MagazineInteractionChamberEmpty) // Chamber is empty lock it to 0
+            applyServerHookClipSettlement(
+                0,
+                -1,
+                -1,
+                -1,
+                "magazine-out-maintain-empty",
+                0.35f,
+                false);
+        else // One in the chamber
+        {
+            if (activeClip == 0) // Chamber was loaded, but the clip just went empty.
+            {
+                m_MagazineInteractionChamberEmpty = true;
+            }
+            else if (activeClip != 1) // Anti-spam call to block +attack when there is still ammo
+                applyServerHookClipSettlement(
+                    1,
+                    -1,
+                    -1,
+                    -1,
+                    "magazine-out-maintain-empty",
+                    0.35f,
+                    false);
+        }
     }
 
     if (m_MagazineInteractionState == MagazineInteractionManualState::WaitingForBackendReload)
@@ -7109,8 +7127,9 @@ bool VR::UpdateMagazineInteraction(
                 m_MagazineInteractionReloadCommandPending = false;
                 m_MagazineInteractionReloadCommandIssued = false;
                 m_MagazineInteractionReloadCommandHoldUntil = {};
+                m_MagazineInteractionChamberEmpty = activeClip == 0;
                 applyServerHookClipSettlement(
-                    0,
+                    m_MagazineInteractionChamberEmpty ? 0 : 1,
                     -1,
                     -1,
                     -1,

--- a/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
+++ b/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
@@ -6250,10 +6250,8 @@ bool VR::UpdateMagazineInteraction(
                 false);
         else // One in the chamber
         {
-            if (activeClip == 0) // Chamber was loaded, but the clip just went empty.
-            {
+            if (activeClip == 0 || m_MagazineInteractionServerClipReserveHoldReserve == 0) // Chamber was loaded, but the clip just went empty.
                 m_MagazineInteractionChamberEmpty = true;
-            }
             else if (activeClip != 1) // Anti-spam call to block +attack when there is still ammo
                 applyServerHookClipSettlement(
                     1,
@@ -7129,7 +7127,7 @@ bool VR::UpdateMagazineInteraction(
                 m_MagazineInteractionReloadCommandHoldUntil = {};
                 m_MagazineInteractionChamberEmpty = activeClip == 0;
                 applyServerHookClipSettlement(
-                    m_MagazineInteractionChamberEmpty ? 0 : 1,
+                    (m_MagazineInteractionChamberEmpty || m_MagazineInteractionServerClipReserveHoldReserve == 0) ? 0 : 1,
                     -1,
                     -1,
                     -1,


### PR DESCRIPTION
- Allow one bullet to be left in the chamber when pulling the magazine out.
- Allow shooting the last bullet to make `m_MagazineInteractionChamberEmpty`

https://github.com/user-attachments/assets/c75c8dd1-1a37-409d-b28b-c6e8e79d02ba