### PR TITLE
Fixed holding attack spam fire empty sound

### DIFF
--- a/L4D2VR/hooks/hooks_combat_network.inl
+++ b/L4D2VR/hooks/hooks_combat_network.inl
@@ -1996,6 +1996,8 @@ void __fastcall Hooks::dWriteUsercmdDeltaToBuffer(void* ecx, void* edx, int a1, 
 
 int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 {
+	static int s_lastButtons = 0;
+
 	const bool localUsingMountedWeapon = m_VR &&
 		m_VR->m_IsVREnabled &&
 		!m_VR->m_ForceNonVRServerMovement &&
@@ -2011,7 +2013,7 @@ int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 		const bool magazineInteractionBlocksFire = m_VR->IsMagazineInteractionBlockingFire();
 		if (magazineInteractionBlocksFire)
 		{
-			if ((to->buttons & kMagazineInteractionInAttack) != 0)
+			if ((to->buttons & kMagazineInteractionInAttack) != 0 && (s_lastButtons & kMagazineInteractionInAttack) == 0)
 				m_VR->PlayMagazineInteractionBlockedFireEmptySound();
 			to->buttons &= ~kMagazineInteractionInAttack; // IN_ATTACK
 		}
@@ -2029,7 +2031,7 @@ int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 			m_VR->ShouldSuppressMagazineInteractionEmptyClipAutoReload(nullptr);
 		if (suppressMagazineEmptyClipAutoReload)
 		{
-			if ((to->buttons & kMagazineInteractionInAttack) != 0)
+			if ((to->buttons & kMagazineInteractionInAttack) != 0 && (s_lastButtons & kMagazineInteractionInAttack) == 0)
 				m_VR->PlayMagazineInteractionBlockedFireEmptySound();
 			to->buttons &= ~(kMagazineInteractionInAttack | kMagazineInteractionInReload);
 		}
@@ -2119,6 +2121,9 @@ int Hooks::dWriteUsercmd(void* buf, CUserCmd* to, CUserCmd* from)
 	// 重算校验，否则多人下枪声会异常
 	pVerified->m_cmd = *to;
 	pVerified->m_crc = to->GetChecksum();
+
+	s_lastButtons = to->buttons;
+
 	return 1;
 }
 

--- a/L4D2VR/hooks/hooks_createmove.inl
+++ b/L4D2VR/hooks/hooks_createmove.inl
@@ -53,6 +53,8 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 	static int s_effectiveRangeMeleeSwitchBackCmd = -1;
 	static int s_effectiveRangeMeleeCycleEndCmd = -1;
 
+	static int s_lastButtons = 0;
+
 	if (!cmd)
 		return hkCreateMove.fOriginal(ecx, flInputSampleTime, cmd);
 
@@ -1435,7 +1437,7 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 	const bool magazineInteractionBlocksFire = m_VR->IsMagazineInteractionBlockingFire();
 	if (!localUsingMountedWeapon && magazineInteractionBlocksFire)
 	{
-		if ((cmd->buttons & kMagazineInteractionInAttack) != 0)
+		if ((cmd->buttons & kMagazineInteractionInAttack) != 0 && (s_lastButtons & kMagazineInteractionInAttack) == 0)
 			m_VR->PlayMagazineInteractionBlockedFireEmptySound();
 		cmd->buttons &= ~kMagazineInteractionInAttack; // IN_ATTACK
 	}
@@ -1455,7 +1457,7 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 		m_VR->ShouldSuppressMagazineInteractionEmptyClipAutoReload(nullptr);
 	if (!localUsingMountedWeapon && suppressMagazineEmptyClipAutoReload)
 	{
-		if ((cmd->buttons & kMagazineInteractionInAttack) != 0)
+		if ((cmd->buttons & kMagazineInteractionInAttack) != 0 && (s_lastButtons & kMagazineInteractionInAttack) == 0)
 			m_VR->PlayMagazineInteractionBlockedFireEmptySound();
 		cmd->buttons &= ~(kMagazineInteractionInAttack | kMagazineInteractionInReload);
 	}
@@ -1552,6 +1554,9 @@ bool __fastcall Hooks::dCreateMove(void* ecx, void* edx, float flInputSampleTime
 		m_VR->ApplyRoomscale1To1Move(cmd, flInputSampleTime, controlLocomotionActive);
 		m_VR->ApplyMovementLedgeGuard(cmd, m_VR->m_ScopeFovAdjustSuppressWalk || m_VR->m_TeleportTargetingActive);
 	}
+
+	s_lastButtons = cmd->buttons;
+
 	return result;
 }
 

--- a/L4D2VR/vr/vr_process_input.inl
+++ b/L4D2VR/vr/vr_process_input.inl
@@ -1300,7 +1300,7 @@ void VR::ProcessInput()
     const bool usingMountedWeaponForPrimary = vrAwareServerSupportPath && localPlayer && IsUsingMountedGun(localPlayer);
     if (!usingMountedWeaponForPrimary &&
         (magazineInteractionBlocksFire || suppressMagazineEmptyClipAutoReload) &&
-        primaryAttackDown)
+        primaryAttackJustPressed)
     {
         PlayMagazineInteractionBlockedFireEmptySound();
     }


### PR DESCRIPTION
When the ammo is out and holding the primary attack will no longer loop `PlayMagazineInteractionBlockedFireEmptySound()`