### PR TITLE
Fixed shotgun unable to two-handed

### DIFF
--- a/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
+++ b/L4D2VR/vr_hands/vr_hand_vr_bridge.cpp
@@ -5564,7 +5564,7 @@ bool VR::UpdateMagazineInteraction(
 
         if (leftGripJustPressed &&
             twoHandedGripRuntimeAllowed &&
-            !IsMagazineInteractionManualActive() &&
+            (!IsMagazineInteractionManualActive() || activeWeaponUsesShotgunShells) &&
             !m_MagazineInteractionLeftHandHolding &&
             !leftHandTouchesMagazineForGripExclusion())
         {


### PR DESCRIPTION
Allow the shotgun to be able to grab in two hands.