### PR TITLE
Fixed: config menu can't scroll to last page

### DIFF
--- a/L4D2VR/vr_config_overlay_embedded.inl
+++ b/L4D2VR/vr_config_overlay_embedded.inl
@@ -1641,7 +1641,7 @@ namespace
             return;
         }
 
-        const int nextScroll = (std::clamp)(s.scroll + delta, 0, (std::max)(0, total - kCfgOverlayRowsVisible));
+        const int nextScroll = (std::clamp)(s.scroll + delta, 0, (std::max)(0, total - 1));
         if (nextScroll == s.scroll)
             return;
 


### PR DESCRIPTION
- The last page contains one row, which is Bright Threshold, and is unable to scroll to: requires pressing the next page.