### PR TITLE
Fix Bandicam Vulkan swapchain teardown crash

### DIFF
--- a/dxvk_new/src/vulkan/vulkan_loader.cpp
+++ b/dxvk_new/src/vulkan/vulkan_loader.cpp
@@ -1,4 +1,6 @@
+#include <mutex>
 #include <tuple>
+#include <unordered_map>
 
 #include "vulkan_loader.h"
 
@@ -8,6 +10,46 @@
 #include "../util/util_win32_compat.h"
 
 namespace dxvk::vk {
+
+#ifdef _WIN32
+  namespace {
+
+    struct BandicamDeviceFunctions {
+      PFN_vkDeviceWaitIdle          waitIdle         = nullptr;
+      PFN_vkDestroySwapchainKHR     destroySwapchain = nullptr;
+    };
+
+    std::mutex g_bandicamMutex;
+    std::unordered_map<VkDevice, BandicamDeviceFunctions> g_bandicamDevices;
+
+    bool isBandicamVulkanHookLoaded() {
+      return ::GetModuleHandleW(L"bdcamvk32.dll") != nullptr
+          || ::GetModuleHandleW(L"bdcamvk64.dll") != nullptr;
+    }
+
+    VKAPI_ATTR void VKAPI_CALL destroySwapchainBandicamCompat(
+            VkDevice                    device,
+            VkSwapchainKHR              swapchain,
+      const VkAllocationCallbacks*      allocator) {
+      BandicamDeviceFunctions functions;
+
+      {
+        std::lock_guard lock(g_bandicamMutex);
+        auto entry = g_bandicamDevices.find(device);
+
+        if (entry != g_bandicamDevices.end())
+          functions = entry->second;
+      }
+
+      if (functions.waitIdle)
+        functions.waitIdle(device);
+
+      if (functions.destroySwapchain)
+        functions.destroySwapchain(device, swapchain, allocator);
+    }
+
+  }
+#endif
 
   static std::pair<HMODULE, PFN_vkGetInstanceProcAddr> loadVulkanLibrary() {
     static const std::array<const char*, 2> dllNames = {{
@@ -103,10 +145,35 @@ namespace dxvk::vk {
   
   
   DeviceFn::DeviceFn(const Rc<InstanceLoader>& library, bool owned, VkDevice device)
-  : DeviceLoader(library, owned, device) { }
+  : DeviceLoader(library, owned, device) {
+#ifdef _WIN32
+#ifdef VK_KHR_swapchain
+    if (isBandicamVulkanHookLoaded()
+     && this->vkDeviceWaitIdle
+     && this->vkDestroySwapchainKHR) {
+      {
+        std::lock_guard lock(g_bandicamMutex);
+        g_bandicamDevices[device] = {
+          this->vkDeviceWaitIdle,
+          this->vkDestroySwapchainKHR,
+        };
+      }
+
+      this->vkDestroySwapchainKHR = &destroySwapchainBandicamCompat;
+      Logger::warn("Vulkan: Bandicam hook detected; synchronizing the device before swapchain destruction.");
+    }
+#endif
+#endif
+  }
+
   DeviceFn::~DeviceFn() {
     if (m_owned)
       this->vkDestroyDevice(m_device, nullptr);
+
+#ifdef _WIN32
+    std::lock_guard lock(g_bandicamMutex);
+    g_bandicamDevices.erase(m_device);
+#endif
   }
   
 }

--- a/dxvk_new/src/vulkan/vulkan_loader.cpp
+++ b/dxvk_new/src/vulkan/vulkan_loader.cpp
@@ -1,6 +1,8 @@
+#ifdef _WIN32
 #include <mutex>
-#include <tuple>
 #include <unordered_map>
+#endif
+#include <tuple>
 
 #include "vulkan_loader.h"
 
@@ -11,7 +13,7 @@
 
 namespace dxvk::vk {
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(VK_KHR_swapchain)
   namespace {
 
     struct BandicamDeviceFunctions {
@@ -146,8 +148,7 @@ namespace dxvk::vk {
   
   DeviceFn::DeviceFn(const Rc<InstanceLoader>& library, bool owned, VkDevice device)
   : DeviceLoader(library, owned, device) {
-#ifdef _WIN32
-#ifdef VK_KHR_swapchain
+#if defined(_WIN32) && defined(VK_KHR_swapchain)
     if (isBandicamVulkanHookLoaded()
      && this->vkDeviceWaitIdle
      && this->vkDestroySwapchainKHR) {
@@ -163,14 +164,13 @@ namespace dxvk::vk {
       Logger::warn("Vulkan: Bandicam hook detected; synchronizing the device before swapchain destruction.");
     }
 #endif
-#endif
   }
 
   DeviceFn::~DeviceFn() {
     if (m_owned)
       this->vkDestroyDevice(m_device, nullptr);
 
-#ifdef _WIN32
+#if defined(_WIN32) && defined(VK_KHR_swapchain)
     std::lock_guard lock(g_bandicamMutex);
     g_bandicamDevices.erase(m_device);
 #endif


### PR DESCRIPTION
## Root cause

Bandicam injects `bdcamvk32.dll` into the Vulkan device dispatch path. The supplied crash stack and the current 32-bit `DeviceFn` layout resolve `d3d9+0x1125bb` to the return from `vkDestroySwapchainKHR`, with the fault occurring inside Bandicam's Vulkan hook.

DXVK normally skips a full device-idle wait during swapchain teardown when `VK_EXT_swapchain_maintenance1` is available. Bandicam's hook can still access capture-side swapchain state during that teardown and crash.

## Changes

- Detect `bdcamvk32.dll` / `bdcamvk64.dll` when the Vulkan device function table is created.
- Preserve the original Bandicam-hooked `vkDestroySwapchainKHR` and `vkDeviceWaitIdle` pointers per `VkDevice`.
- Route swapchain destruction through a small compatibility wrapper that waits for the device to become idle before calling Bandicam's original destruction hook.
- Leave the normal DXVK dispatch path unchanged when Bandicam is not loaded.
- Keep the source file in CRLF format.

## Validation

- Verified the crash call-site against the uploaded 32-bit `d3d9.dll` and the current `dxvk_new` `DeviceFn` member order.
- Confirmed the branch is based on current `master` (`9dd40c8`).
- Performed standalone C++17 syntax and calling-convention validation of the wrapper/map structure with warnings treated as errors.
- Full Windows build and runtime Bandicam capture validation remain required on an affected machine.