### PR TITLE
Disable Bandicam Vulkan layer before DXVK initialization

### DIFF
--- a/dxvk_new/src/vulkan/vulkan_loader.cpp
+++ b/dxvk_new/src/vulkan/vulkan_loader.cpp
@@ -1,7 +1,3 @@
-#ifdef _WIN32
-#include <mutex>
-#include <unordered_map>
-#endif
 #include <tuple>
 
 #include "vulkan_loader.h"
@@ -13,47 +9,15 @@
 
 namespace dxvk::vk {
 
-#if defined(_WIN32) && defined(VK_KHR_swapchain)
-  namespace {
-
-    struct BandicamDeviceFunctions {
-      PFN_vkDeviceWaitIdle          waitIdle         = nullptr;
-      PFN_vkDestroySwapchainKHR     destroySwapchain = nullptr;
-    };
-
-    std::mutex g_bandicamMutex;
-    std::unordered_map<VkDevice, BandicamDeviceFunctions> g_bandicamDevices;
-
-    bool isBandicamVulkanHookLoaded() {
-      return ::GetModuleHandleW(L"bdcamvk32.dll") != nullptr
-          || ::GetModuleHandleW(L"bdcamvk64.dll") != nullptr;
-    }
-
-    VKAPI_ATTR void VKAPI_CALL destroySwapchainBandicamCompat(
-            VkDevice                    device,
-            VkSwapchainKHR              swapchain,
-      const VkAllocationCallbacks*      allocator) {
-      BandicamDeviceFunctions functions;
-
-      {
-        std::lock_guard lock(g_bandicamMutex);
-        auto entry = g_bandicamDevices.find(device);
-
-        if (entry != g_bandicamDevices.end())
-          functions = entry->second;
-      }
-
-      if (functions.waitIdle)
-        functions.waitIdle(device);
-
-      if (functions.destroySwapchain)
-        functions.destroySwapchain(device, swapchain, allocator);
-    }
-
-  }
+  static std::pair<HMODULE, PFN_vkGetInstanceProcAddr> loadVulkanLibrary() {
+#ifdef _WIN32
+    // Bandicam installs VK_LAYER_bandicam_helper as a global Vulkan layer.
+    // Disable it before loading the Vulkan loader so bdcamvk32.dll never
+    // enters this process's Vulkan instance and device dispatch chains.
+    ::SetEnvironmentVariableW(L"DISABLE_VK_LAYER_bandicam_helper_1", L"1");
+    Logger::info("Vulkan: Disabled Bandicam Vulkan capture layer.");
 #endif
 
-  static std::pair<HMODULE, PFN_vkGetInstanceProcAddr> loadVulkanLibrary() {
     static const std::array<const char*, 2> dllNames = {{
 #ifdef _WIN32
       "winevulkan.dll",
@@ -147,33 +111,12 @@ namespace dxvk::vk {
   
   
   DeviceFn::DeviceFn(const Rc<InstanceLoader>& library, bool owned, VkDevice device)
-  : DeviceLoader(library, owned, device) {
-#if defined(_WIN32) && defined(VK_KHR_swapchain)
-    if (isBandicamVulkanHookLoaded()
-     && this->vkDeviceWaitIdle
-     && this->vkDestroySwapchainKHR) {
-      {
-        std::lock_guard lock(g_bandicamMutex);
-        g_bandicamDevices[device] = {
-          this->vkDeviceWaitIdle,
-          this->vkDestroySwapchainKHR,
-        };
-      }
-
-      this->vkDestroySwapchainKHR = &destroySwapchainBandicamCompat;
-      Logger::warn("Vulkan: Bandicam hook detected; synchronizing the device before swapchain destruction.");
-    }
-#endif
-  }
-
+  : DeviceLoader(library, owned, device) { }
+  
+  
   DeviceFn::~DeviceFn() {
     if (m_owned)
       this->vkDestroyDevice(m_device, nullptr);
-
-#if defined(_WIN32) && defined(VK_KHR_swapchain)
-    std::lock_guard lock(g_bandicamMutex);
-    g_bandicamDevices.erase(m_device);
-#endif
   }
   
 }


### PR DESCRIPTION
## Root cause

The follow-up minidump shows that the previous compatibility wrapper successfully reached `vkDeviceWaitIdle`, but the subsequent call into Bandicam's original `vkDestroySwapchainKHR` hook still crashed at `bdcamvk32+0x14c35`. This confirms the fault is inside Bandicam's Vulkan layer state rather than missing DXVK teardown synchronization.

Bandicam registers a global Vulkan layer named `VK_LAYER_bandicam_helper`. Its manifest provides the dedicated disable variable `DISABLE_VK_LAYER_bandicam_helper_1=1`.

## Changes

- Remove the previously merged per-device `vkDestroySwapchainKHR` wrapper and function-pointer map.
- Set `DISABLE_VK_LAYER_bandicam_helper_1=1` before loading `vulkan-1.dll`.
- Prevent `bdcamvk32.dll` / `bdcamvk64.dll` from entering DXVK's Vulkan instance and device dispatch chains.
- Keep the source file in CRLF format.

## Effect

Bandicam's Vulkan game-capture layer is disabled for L4D2VR. It will no longer receive DXVK Vulkan create, present, or destroy calls. Other Bandicam capture modes that do not depend on this Vulkan layer are outside this change.

## Validation

- Based on current `master` after PR #399 (`e58f551`).
- The supplied second dump directly shows the previous wrapper and Bandicam hook still crashing.
- Confirmed the exact layer name and disable variable from the Bandicam Vulkan layer manifest.
- The same disable variable is used by Godot to block the Bandicam Vulkan layer.
- Full Windows runtime validation with Bandicam remains required.